### PR TITLE
drift sweep — drift-defenses gate report 2026-05-11

### DIFF
--- a/.drift-sweeps/2026-05-11.json
+++ b/.drift-sweeps/2026-05-11.json
@@ -1,0 +1,5 @@
+{
+  "sweep": "2026-05-11",
+  "scheduled": "2026-04-27",
+  "anchor": "see PR body for gate findings"
+}


### PR DESCRIPTION
## Drift sweep — 2026-05-11

Scheduled: 2026-04-27. Run: 2026-05-11.

Gates run: `check-gates-effective`, `check-doc-counts`, `check-docs-cli-claims`, `check-docs-slash-claims`, `check-docs-default-models`.

**Result: 1 gate exited non-zero (`check-gates-effective`); 2 probe failures inside it.**

Gates #2–5 are fully green:
- `check-doc-counts` ✓ — 37 count claims across 8 doc surfaces match the filesystem.
- `check-docs-cli-claims` ✓ — 83 docs scanned; all `motebit <subcommand>` invocations resolve to real dispatch arms.
- `check-docs-slash-claims` ✓ — 81 docs scanned; all `/<slash-command>` invocations resolve to real COMMANDS entries.
- `check-docs-default-models` ✓ — 83 docs scanned; every default-context Claude literal matches `claude-sonnet-4-6`.

---

## Fired gates

### 1. `check-gates-effective` → probe for `check-dist-smoke`

**Failure excerpt:**
```
✗ check-dist-smoke   error: ENOENT: no such file or directory,
                     open '/home/user/motebit/apps/cli/dist/index.js'
```

The probe (in `scripts/check-gates-effective.ts` around line 368–381) attempts to overwrite `apps/cli/dist/index.js` with a crashing stub to verify the gate would catch a broken binary. `dist/` is gitignored and only exists after `pnpm build`. When the build has not run, `mutateFile` throws ENOENT before the gate is ever invoked — the probe errors out rather than proving or disproving gate effectiveness.

`git log --since=2026-04-27 -- apps/cli/dist/`: no results (gitignored, never tracked).
`git log --since=2026-04-27 -- scripts/check-gates-effective.ts`: multiple commits; the `check-dist-smoke` probe entry shipped in `3987d03` (2026-05-10) without a `skipWhen` guard.

**Source moved** — add a `skipWhen: () => !existsSync("apps/cli/dist/index.js")` guard to the `check-dist-smoke` probe entry in `scripts/check-gates-effective.ts` (around line 368). The gate itself is sound; only the effectiveness probe needs the guard so it degrades gracefully when run before a build rather than erroring.

---

### 2. `check-gates-effective` → probe for `check-api-surface`

**Failure excerpt:**
```
✗ check-api-surface  gate exited 0 — did NOT catch the perturbation
```

The probe mutates `packages/protocol/etc/protocol.api.md` (adds a drift-marker line to the baseline), then runs the gate. The gate should exit 1 (divergence detected) but exits 0.

Root cause: `scripts/check-api-surface.ts:114` — `runExtractorAndDiff` checks only `!existsSync(tempPath)` to determine "no divergence". When `dist/` is absent, `api-extractor` crashes (non-zero exit) and produces no temp file, so `existsSync(tempPath)` is false and the function returns `{ ok: true }` — silently passing even with a drifted baseline. The gate's escape-hatch comment (`skipWhen`) guards against a pending `major` changeset but does not guard against an api-extractor infrastructure failure.

`git log --since=2026-04-27 -- scripts/check-api-surface.ts`: `3987d03` (2026-05-10, initial creation). The latent bug was present at creation.

**Source moved** — update `scripts/check-api-surface.ts:114` to distinguish api-extractor crash from api-extractor "no divergence". When `result.status !== 0` AND no temp file was produced, return `{ ok: false }` (infra failure, not a clean pass) rather than `{ ok: true }`. This closes the hole where any api-extractor crash becomes a silent green.

---

## Recommended next step

Land the source-update commit and the prose follows automatically — both failures are in the gate scripts themselves (`scripts/check-gates-effective.ts` probe entry, `scripts/check-api-surface.ts:114`); no doc changes are needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Agy7yi26CFx5CPBi3QZBTa)_