### PR TITLE
fix(scripts): make check-retention-coverage see template-literal SQL + guard the blindness class

### DIFF
--- a/scripts/check-gates-effective.ts
+++ b/scripts/check-gates-effective.ts
@@ -1399,6 +1399,24 @@ export function __probeRunScriptDirectly(record: ProbeRecord, scriptName: string
       ),
   },
   {
+    script: "check-retention-coverage",
+    proves:
+      "fires on a sensitivity-bearing CREATE TABLE written as a SEMICOLON-LESS template-literal statement — the input shape the prior `)\\s*;` body terminator was structurally blind to (the persistence/mobile migration registries write SQL as `\\`CREATE TABLE … )\\`` template literals with no statement-terminating semicolon, so the blind parser matched NOTHING in them). The sibling probe above injects a `;`-terminated CREATE, which the blind parser still caught — so it alone could not detect this regression. Guards the blindness class: a drift-gate parser that assumes a statement terminator a sibling input shape doesn't carry.",
+    perturb: () =>
+      // Inject a `;`-LESS template-literal CREATE TABLE (the shape the
+      // migration registries actually use) for an unregistered
+      // sensitivity-bearing table into a scanned migration file. A `)\s*;`
+      // parser never matches it — the SQL `)` is followed by a backtick, not
+      // a semicolon — so the gate would NOT fire; the balanced-paren parser
+      // does. mutateFile restores byte-identical on cleanup.
+      mutateFile("packages/persistence/src/migrations-registry.ts", (src) =>
+        src.replace(
+          "export const PERSISTENCE_MIGRATIONS",
+          "const __GATE_PROBE_TEMPLATE_SQL = `CREATE TABLE IF NOT EXISTS __probe_unregistered_template (\n  id TEXT PRIMARY KEY,\n  sensitivity TEXT\n)`;\nvoid __GATE_PROBE_TEMPLATE_SQL;\nexport const PERSISTENCE_MIGRATIONS",
+        ),
+      ),
+  },
+  {
     script: "check-relay-retention-coverage",
     proves:
       "flags a `RETENTION_MANIFEST_CONTENT.stores[]` entry whose `store_id` has no matching alias in `RELAY_STORE_TABLE_ALIASES` — the missing-alias drift class (a manifest declaration of an enforcement that doesn't exist, the operator's transparency claim silently rotting). Sibling to check-retention-coverage's probe but scoped to the relay-side manifest projection rather than the runtime-side registry.",

--- a/scripts/check-retention-coverage.ts
+++ b/scripts/check-retention-coverage.ts
@@ -135,23 +135,47 @@ interface AlteredColumn {
 }
 
 function extractCreateTables(content: string, surface: string): CreateTableStmt[] {
-  // Match: CREATE TABLE [IF NOT EXISTS] <name> ( <body> )
-  // Body may contain newlines and nested parens (e.g. CHECK constraints
-  // or DEFAULT expressions), but the matched body terminates at the
-  // last `)` before the next CREATE/INSERT/--/ALTER on a fresh line.
-  // This is heuristic — exhaustive SQL parsing is over-scoped — but
-  // motebit's at-rest schemas are simple flat-column DDL and the
-  // pattern fires reliably on them.
-  const pattern =
-    /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([a-z_][a-z0-9_]*)\s*\(([\s\S]*?)\)\s*;/gi;
+  // Match the CREATE TABLE header + opening paren, then capture the body by
+  // BALANCED-PAREN scanning to the matching close paren.
+  //
+  // The prior implementation terminated the body at `)\s*;` — a closing paren
+  // followed by a semicolon. That silently matched NOTHING in the
+  // template-literal SQL migration files (`packages/persistence/...-registry.ts`,
+  // `apps/mobile/...-migrations.ts`), because those write each statement as a
+  // `\`CREATE TABLE x ( ... )\`` template literal with NO trailing semicolon —
+  // so the regex's lazy body ran past the table's own `)` hunting for a `);`
+  // that never came (or, once any `)` `;` appeared anywhere in the file — e.g.
+  // inside a comment — it over-captured everything up to it). The gate was thus
+  // structurally BLIND to those surfaces. Balanced-paren scanning terminates at
+  // the table's actual closing paren regardless of any trailing `;`, and handles
+  // nested parens (CHECK / DEFAULT(...)) via the depth counter. The effectiveness
+  // probe in check-gates-effective plants a `;`-less fixture so this
+  // blindness class cannot recur silently.
+  const header = /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([a-z_][a-z0-9_]*)\s*\(/gi;
   const stmts: CreateTableStmt[] = [];
   let m: RegExpExecArray | null;
-  while ((m = pattern.exec(content)) !== null) {
+  while ((m = header.exec(content)) !== null) {
+    const openIdx = header.lastIndex - 1; // index of the opening '('
+    let depth = 0;
+    let close = -1;
+    for (let i = openIdx; i < content.length; i++) {
+      const ch = content[i];
+      if (ch === "(") depth++;
+      else if (ch === ")") {
+        depth--;
+        if (depth === 0) {
+          close = i;
+          break;
+        }
+      }
+    }
+    if (close === -1) continue; // unbalanced — skip rather than over-capture
     stmts.push({
       surface,
       tableName: m[1]!.toLowerCase(),
-      body: m[2]!,
+      body: content.slice(openIdx + 1, close),
     });
+    header.lastIndex = close + 1; // resume scanning after this table
   }
   return stmts;
 }


### PR DESCRIPTION
## The bug: a drift-gate that was structurally blind

`check-retention-coverage` extracted CREATE TABLE bodies with a `)\s*;` terminator — a closing paren followed by a **semicolon**. The persistence/mobile migration registries write SQL as `` `CREATE TABLE x ( … )` `` **template literals with no trailing semicolon**, so the regex matched **nothing** in those files. The gate was **false-green by under-detection**, not by coverage: a sensitivity-classified store added to a migration registry would never have been caught. A drift-defense that wasn't defending those surfaces.

**How it surfaced:** PR #123's migration comment introduced the file's first `);` substring (`"…validation); new writes…"`), handing the lazy body a false terminator and flipping the gate into catastrophic over-capture — an 8019-char `service_listings` body that swallowed unrelated `sensitivity` columns into a false-positive "unregistered-table." That false positive is what exposed the latent blindness.

## The fix

Balanced-paren scanning: terminate the body at the table's actual closing paren regardless of any trailing `;`, handling nested parens (CHECK / `DEFAULT(...)`) via a depth counter. The gate now correctly scans **71** CREATE TABLEs (was blind to ~23 in the template-literal files).

## Nothing needed registering — and that's the honest result

The fixed parser surfaces **zero** unregistered sensitivity stores. The one sensitivity-in-CREATE-body table it now sees (`skill_audit`) is already registered (`append_only_horizon`); the ALTER-added `sensitivity` columns (`conversation_messages`, `tool_audit_log`) are on registered stores and were already detected (the ALTER regex was never broken). So the registry was **already complete** — the gate simply couldn't *prove* it. This converts "blind green" to "verified green," not "register missing stores."

## The blindness-class guard (the meta-point)

A parser fix alone would let the next gate author write the same `)\s*;` and re-discover this under a different file's comment. So a **second `check-gates-effective` probe** plants a **semicolon-less template-literal** CREATE TABLE — the exact shape the old parser missed. Proven directly: the old `)\s*;` parser does **not** detect it (gate stays green — blind); the balanced parser does. If anyone reverts to a terminator-assuming regex, this probe fails.

The pre-existing retention probe injected a `;`-**terminated** CREATE, which the blind parser still caught — which is precisely why the blindness survived undetected. Sibling-boundary rule applied to drift gates: when a gate turns out blind to a whole input shape, the fix is the parser **and** the probe that catches the blindness class structurally.

`110/110` gates proven effective. `scripts/` only — no published-package change, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)