### PR TITLE
docs: correct stale "P2P = zero fees" claim on public surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ motebit migrate cancel                                     # abort migration
 
 `motebit run` is the operator daemon — REPL plus task-acceptance in one process. `motebit serve` (used by the scaffold's `npm run dev`) exposes your agent as an MCP server with no REPL. Both accept paid tasks; pick the one that matches whether you want a console or a pure service.
 
-Every task settles through the relay or directly peer-to-peer. Relay-mediated: budget locked → execution → signed receipt → worker paid (5% fee). P2P: delegator sends USDC directly to worker's wallet when trust is high enough — zero fees, relay records the audit trail. Settlement mode selected per-task by policy. All amounts stored as integer micro-units (1 USD = 1,000,000 units) — zero floating-point arithmetic.
+Every task settles through the relay or directly peer-to-peer. Relay-mediated: budget locked → execution → signed receipt → worker paid (5% fee). P2P: delegator sends USDC directly to the worker's wallet when trust is high enough — the same 5% fee rides along as a direct delegator→treasury leg in one atomic Solana transaction, so the relay records the audit but never custodies the funds. Settlement mode selected per-task by policy. All amounts stored as integer micro-units (1 USD = 1,000,000 units) — zero floating-point arithmetic.
 
 ## Federation
 

--- a/apps/docs/content/docs/operator/architecture.mdx
+++ b/apps/docs/content/docs/operator/architecture.mdx
@@ -230,7 +230,7 @@ Eight services in four roles. All are reference implementations of the protocol 
 | **Atoms**     | `web-search` ($0.05/request), `read-url`, `summarize`, `embed` | Stateless capability providers. Single-hop reference implementations of the delegation spec.                                                                       |
 | **Glue**      | `proxy`                                                        | Vercel edge CORS proxy for the web app (Anthropic API, fetch, embed).                                                                                              |
 
-Every task settles through the relay or directly peer-to-peer. Relay-mediated: budget locked → execution → signed receipt → worker paid (5% fee). P2P: delegator sends USDC directly to the worker's wallet when trust is high enough — zero fees, relay records audit only.
+Every task settles through the relay or directly peer-to-peer. Relay-mediated: budget locked → execution → signed receipt → worker paid (5% fee). P2P: delegator sends USDC directly to the worker's wallet when trust is high enough — the same 5% fee rides along as a direct delegator→treasury leg in one atomic Solana transaction, so the relay records the audit but never custodies the funds.
 
 ## Specifications
 

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -5720,7 +5720,7 @@ Eight services in four roles. All are reference implementations of the protocol 
 | **Atoms**     | `web-search` ($0.05/request), `read-url`, `summarize`, `embed` | Stateless capability providers. Single-hop reference implementations of the delegation spec.                                                                       |
 | **Glue**      | `proxy`                                                        | Vercel edge CORS proxy for the web app (Anthropic API, fetch, embed).                                                                                              |
 
-Every task settles through the relay or directly peer-to-peer. Relay-mediated: budget locked → execution → signed receipt → worker paid (5% fee). P2P: delegator sends USDC directly to the worker's wallet when trust is high enough — zero fees, relay records audit only.
+Every task settles through the relay or directly peer-to-peer. Relay-mediated: budget locked → execution → signed receipt → worker paid (5% fee). P2P: delegator sends USDC directly to the worker's wallet when trust is high enough — the same 5% fee rides along as a direct delegator→treasury leg in one atomic Solana transaction, so the relay records the audit but never custodies the funds.
 
 ## Specifications
 


### PR DESCRIPTION
README, the operator architecture doc, and the generated `llms.txt`/`llms-full.txt` all claimed P2P settlement charges **"zero fees."** Arc 2 (off-ramp) shipped a **5% fee on P2P**, composed as a `delegator→relay_treasury` leg in the same atomic Solana multi-output transaction (recorded as `platform_fee`) — `services/relay/CLAUDE.md` rule 8 already notes the pre-Arc-2 zero-fee wording is *"now closed"* in code. The public surfaces just never got updated.

A stale claim on the **money path** is the worst place for one. Corrected all three to state the 5% fee rides as a direct `delegator→treasury` leg — preserving the real P2P value prop (non-custodial / sovereign; the relay records the audit but never custodies the funds) without the false fee claim. `llms.txt`/`llms-full.txt` regenerated from source; `check-llms-txt-fresh` green.

Surfaced by the self-attesting-thesis audit (the "prose ahead of proof" class). Docs-only, single-concern — no published-package change, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)