### PR TITLE
fix(sandbox): bind navigation_triggered to a real document navigation, not a URL string diff

### DIFF
--- a/services/browser-sandbox/src/__tests__/action-executor.test.ts
+++ b/services/browser-sandbox/src/__tests__/action-executor.test.ts
@@ -40,6 +40,15 @@ interface MockSession {
   setEvaluateImpl(fn: () => Promise<unknown>): void;
   setPageUrlImpl(fn: () => string): void;
   setLocatorCountImpl(fn: (selector: string) => number): void;
+  /**
+   * Arm (or disarm) a main-frame document navigation for the next
+   * submit-shaped action. When armed, `waitForRequest` resolves with a
+   * synthetic navigation request → `navigation_triggered: true`. When
+   * disarmed (default), the wait times out → false. Models the real
+   * distinction the dispatcher reads: a real navigation issues a
+   * document request; a same-document URL mutation does not.
+   */
+  setNavigatesOnAction(navigates: boolean): void;
   mockPage: {
     goto: ReturnType<typeof vi.fn>;
     waitForLoadState: ReturnType<typeof vi.fn>;
@@ -50,6 +59,8 @@ interface MockSession {
     mouse: BrowserSession["page"]["mouse"];
     keyboard: BrowserSession["page"]["keyboard"];
     locator: ReturnType<typeof vi.fn>;
+    mainFrame: ReturnType<typeof vi.fn>;
+    waitForRequest: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -98,8 +109,30 @@ function makeMockSession(): MockSession {
     botDetection: false,
   });
   let pageUrlImpl: () => string = () => currentUrl;
+  // Navigation-truth arming — see `setNavigatesOnAction`. A stable
+  // main-frame identity lets the dispatcher's predicate
+  // (`req.frame() === page.mainFrame()`) match the synthetic request.
+  let navArmed = false;
+  const mockMainFrame = {};
 
   const mockPage = {
+    mainFrame: vi.fn(() => mockMainFrame),
+    // Canonical Playwright "did this action navigate" wait. Resolves
+    // with a synthetic main-frame document request when armed; rejects
+    // (the timeout branch) otherwise. The dispatcher maps resolve→true,
+    // reject→false. Rejecting promptly keeps non-navigating tests fast —
+    // the unit test asserts the branch outcome, not the real settle
+    // duration.
+    waitForRequest: vi.fn((predicate: (req: unknown) => boolean, opts?: { timeout?: number }) => {
+      if (navArmed) {
+        const req = {
+          isNavigationRequest: () => true,
+          frame: () => mockMainFrame,
+        };
+        if (predicate(req)) return Promise.resolve(req);
+      }
+      return Promise.reject(new Error(`waitForRequest timeout after ${opts?.timeout ?? 0}ms`));
+    }),
     goto: vi.fn(async (url: string, opts: unknown) => gotoImpl(url, opts)),
     waitForLoadState: vi.fn(async (state: string, opts?: unknown) =>
       waitForLoadStateImpl(state, opts),
@@ -199,6 +232,9 @@ function makeMockSession(): MockSession {
     setLocatorCountImpl(fn: (selector: string) => number): void {
       locatorCountImpl = fn;
     },
+    setNavigatesOnAction(navigates: boolean): void {
+      navArmed = navigates;
+    },
     mockPage,
   } as unknown as MockSession;
 }
@@ -275,11 +311,7 @@ describe("executeAction", () => {
 
     it("navigation_triggered: true when click triggers a navigation (link / form submit)", async () => {
       const mock = makeMockSession();
-      let urlReadCount = 0;
-      mock.setPageUrlImpl(() => {
-        urlReadCount++;
-        return urlReadCount === 1 ? "https://example.com/" : "https://example.com/landing";
-      });
+      mock.setNavigatesOnAction(true);
       const result = (await executeAction(
         mock.session,
         { kind: "click", target: { x: 100, y: 200 } },
@@ -312,11 +344,7 @@ describe("executeAction", () => {
 
     it("navigation_triggered: true when double_click triggers a navigation", async () => {
       const mock = makeMockSession();
-      let urlReadCount = 0;
-      mock.setPageUrlImpl(() => {
-        urlReadCount++;
-        return urlReadCount === 1 ? "https://example.com/" : "https://example.com/result";
-      });
+      mock.setNavigatesOnAction(true);
       const result = (await executeAction(
         mock.session,
         { kind: "double_click", target: { x: 100, y: 200 } },
@@ -576,11 +604,10 @@ describe("executeAction", () => {
     describe("navigation_triggered typed-truth field", () => {
       it("navigation_triggered: false when Enter does NOT trigger navigation (witnessed bug)", async () => {
         const mock = makeMockSession();
-        // Default mock: page.url() returns "about:blank" both before
-        // and after the key press — no navigation fired. Mirrors the
-        // 2026-05-12 witnessed bug where the AI pressed Enter on the
-        // Google search input, Google's promo overlay intercepted,
-        // and the page stayed on the homepage.
+        // Default mock: no navigation request fires — the wait times
+        // out. Mirrors the 2026-05-12 witnessed bug where the AI
+        // pressed Enter on the Google search input, the keystroke went
+        // nowhere, and the page stayed on the homepage.
         const result = (await executeAction(
           mock.session,
           { kind: "key", key: "Enter" },
@@ -592,15 +619,61 @@ describe("executeAction", () => {
 
       it("navigation_triggered: true when Enter triggers a form submission", async () => {
         const mock = makeMockSession();
-        // Simulate Playwright's url() returning different values
-        // before and after the keypress — form submission navigated
-        // the page.
+        // A real form submission issues a main-frame document request.
+        mock.setNavigatesOnAction(true);
+        const result = (await executeAction(
+          mock.session,
+          { kind: "key", key: "Enter" },
+          deps,
+        )) as Record<string, unknown>;
+        expect(result.ok).toBe(true);
+        expect(result.navigation_triggered).toBe(true);
+      });
+
+      // Prod regression 2026-05-26 — the load-bearing guard. Google's
+      // homepage rewrites its own URL to `?zx=<ts>` via history
+      // replaceState on interaction, WITHOUT navigating. The earlier
+      // `beforeUrl !== afterUrl` check read that string change as a
+      // navigation → `navigation_triggered: true` → the dishonest-
+      // closing intercept stayed silent → the model's "Done." stood on
+      // a search that never ran. A same-document mutation issues NO
+      // document request, so the request-keyed signal correctly reports
+      // false even though the URL string changed.
+      it("navigation_triggered: false when the URL mutates same-document (Google ?zx=)", async () => {
+        const mock = makeMockSession();
+        // No navigation request armed (replaceState issues none)…
+        mock.setNavigatesOnAction(false);
+        // …but the URL string DOES change, exactly as Google's ?zx=
+        // rewrite does. The old URL-diff signal would flip to true here.
         let urlReadCount = 0;
         mock.setPageUrlImpl(() => {
           urlReadCount++;
           return urlReadCount === 1
-            ? "https://example.com/form"
-            : "https://example.com/submit-result";
+            ? "https://www.google.com/"
+            : "https://www.google.com/?zx=1779853601769";
+        });
+        const result = (await executeAction(
+          mock.session,
+          { kind: "key", key: "Enter" },
+          deps,
+        )) as Record<string, unknown>;
+        expect(result.ok).toBe(true);
+        expect(result.navigation_triggered).toBe(false);
+      });
+
+      // SPA route move via pushState — a real navigation that issues no
+      // document request. The PATH changes (/ → /results), so it counts;
+      // this is the case a request-only signal would have mis-reported
+      // as "didn't move," over-firing the dishonest-closing intercept.
+      it("navigation_triggered: true when a same-document push changes the path (SPA route)", async () => {
+        const mock = makeMockSession();
+        mock.setNavigatesOnAction(false); // no document request
+        let urlReadCount = 0;
+        mock.setPageUrlImpl(() => {
+          urlReadCount++;
+          return urlReadCount === 1
+            ? "https://app.example.com/"
+            : "https://app.example.com/results";
         });
         const result = (await executeAction(
           mock.session,
@@ -980,13 +1053,9 @@ describe("executeAction", () => {
       expect(clickActions.length).toBe(1);
     });
 
-    it("returns navigation_triggered: true when URL changes during click", async () => {
+    it("returns navigation_triggered: true when the click triggers a navigation", async () => {
       const m = makeMockSession();
-      let urlCallCount = 0;
-      m.setPageUrlImpl(() => {
-        urlCallCount++;
-        return urlCallCount === 1 ? "https://example.com/" : "https://example.com/landing";
-      });
+      m.setNavigatesOnAction(true);
       m.setEvaluateImpl(async () => ({ clicked_tag: "a", focused_typeable: false }));
       const result = (await executeAction(
         m.session,

--- a/services/browser-sandbox/src/action-executor.ts
+++ b/services/browser-sandbox/src/action-executor.ts
@@ -50,7 +50,7 @@ import type {
   TypeIntoAction,
   UserInputEvent,
 } from "@motebit/protocol";
-import type { Page } from "playwright-core";
+import type { Page, Request } from "playwright-core";
 
 import type { BrowserSession } from "./chromium-pool.js";
 import { ServiceError } from "./errors.js";
@@ -260,39 +260,134 @@ async function dispatchAction(
 
 // ── Per-kind implementations ─────────────────────────────────────────
 
+/**
+ * Settle window for observing whether a submit-shaped action triggered
+ * a real document navigation. Cross-document navigations are async — the
+ * top-level request is issued after the page's event handler runs, after
+ * `click()` / `keyboard.press()` has already resolved — so we register a
+ * wait and give it a brief window to fire. Resolves early the instant a
+ * navigation request appears; only non-navigating submit actions pay the
+ * full window, and each pays it at most once.
+ */
+const NAVIGATION_SETTLE_MS = 600;
+
+/**
+ * Run a submit-shaped action and report `navigation_triggered` — whether
+ * it caused a real document navigation. This is the proposition the AI's
+ * "Done." / "submitted" / "search ran" claim asserts, and the input the
+ * dishonest-closing intercept (`@motebit/ai-core`) reads to catch a
+ * success claim the wire contradicts.
+ *
+ * Why this replaces the `beforeUrl !== afterUrl` string diff. That
+ * synchronous URL comparison was wrong in BOTH directions:
+ *
+ *   - False positive (the prod regression). A same-document history
+ *     mutation — `pushState` / `replaceState` / hash change — rewrites
+ *     `page.url()` synchronously WITHOUT the page moving. Google's
+ *     homepage appends a `?zx=<timestamp>` anti-cache token to its own
+ *     URL on interaction (the same pattern already documented on
+ *     `frameStaleRetryDelayMs` above). Enter went nowhere, the search
+ *     never ran, yet the URL string changed → the diff reported
+ *     `navigation_triggered: true` → the intercept saw a successful
+ *     submit and stayed silent → the model's "Done." stood on a search
+ *     that never happened. This is the exact case `navigation_triggered`
+ *     was introduced to catch (witnessed 2026-05-12), defeated by the
+ *     very site it was built for (regressed in prod 2026-05-26,
+ *     URL `www.google.com/?zx=…`, page still the homepage).
+ *   - False negative. A real cross-document navigation is async; the
+ *     request commits AFTER `press()` / `click()` resolves, so the
+ *     immediate `url()` read still showed the old URL.
+ *
+ * Two signals, OR'd:
+ *
+ *   1. A cross-document navigation issues a top-level document request
+ *      on the main frame. We wait for it — the canonical Playwright
+ *      "did this action navigate" pattern (register the wait, then act,
+ *      so a request issued synchronously by the action is not missed).
+ *   2. A same-document navigation that changes the PATH (an SPA route
+ *      move via pushState — real, but issues no request) counts too. A
+ *      same-PATH query/hash mutation (the `?zx=` cache-buster, a hash
+ *      anchor) does NOT — that's the page editing its own URL in place,
+ *      not moving. Comparing origin+path only is what separates the two.
+ *
+ * Signal 2 keeps the intercept from over-firing on legitimate SPA
+ * submits (the doctrine's stated bias: miss before over-fire), which a
+ * request-only signal would have mis-reported as "didn't move."
+ *
+ * Same defense-in-depth shape as the rest of the typed-truth-perception
+ * family: the wire field carries the truth, the prompt teaches reading
+ * it. Doctrine: docs/doctrine/typed-truth-perception.md,
+ * runtime-invariants-over-prompt-rules.md.
+ */
+async function runWithNavigationTruth(page: Page, act: () => Promise<void>): Promise<boolean> {
+  const isMainFrameNav = (req: Request): boolean =>
+    req.isNavigationRequest() && req.frame() === page.mainFrame();
+  // Register BEFORE acting so a navigation request the action issues
+  // synchronously is observed. Resolves true on the first main-frame
+  // document request; resolves false when the window elapses with none.
+  const documentRequest = page
+    .waitForRequest(isMainFrameNav, { timeout: NAVIGATION_SETTLE_MS })
+    .then(() => true)
+    .catch(() => false);
+  const beforePath = navigationPathKey(page.url());
+  await act();
+  // Same-document path change (SPA route) commits synchronously during
+  // the action — check it immediately rather than paying the request
+  // settle window for the common pushState case.
+  const afterPath = navigationPathKey(page.url());
+  if (beforePath !== null && beforePath !== afterPath) return true;
+  return documentRequest;
+}
+
+/**
+ * Origin + path of a URL, ignoring query and fragment, for navigation
+ * comparison. A change here is a real move; a change confined to query
+ * or fragment (Google's `?zx=` cache-buster, a hash anchor) is the page
+ * rewriting its own URL in place. Returns null for unparseable input —
+ * a null never compares equal to a path, and the caller treats "couldn't
+ * read the path" as "no path-change signal," deferring to the request
+ * signal (fail-safe, not fail-open).
+ */
+function navigationPathKey(rawUrl: string): string | null {
+  try {
+    const u = new URL(rawUrl);
+    const path = u.pathname === "" ? "/" : u.pathname;
+    return `${u.origin}${path}`;
+  } catch {
+    return null;
+  }
+}
+
 async function doClick(session: BrowserSession, action: ClickAction): Promise<ActionResult> {
-  // Typed-truth `navigation_triggered`: capture URL before + after so
-  // coordinate clicks on submit buttons report whether the page
-  // actually moved. Same shape `doClickElement` + `doKey` ship for
-  // their respective paths — closes the parallel confabulation gap
-  // where coordinate-based click on a submit element returned ok:true
-  // but the form didn't submit (overlay intercept, bot detection
-  // silently dropping). The AI reads false and surfaces the truth
-  // instead of claiming "Done."
-  const beforeUrl = session.page.url();
-  await session.page.mouse.click(action.target.x, action.target.y, {
-    button: parseButton(action.button),
+  // Typed-truth `navigation_triggered`: report whether a coordinate click
+  // on a submit button actually moved the page. The AI reads false and
+  // surfaces the truth instead of claiming "Done." — see
+  // `runWithNavigationTruth` for why a navigation request, not a URL
+  // diff, is the load-bearing signal.
+  const navigation_triggered = await runWithNavigationTruth(session.page, async () => {
+    await session.page.mouse.click(action.target.x, action.target.y, {
+      button: parseButton(action.button),
+    });
+    session.lastCursorX = action.target.x;
+    session.lastCursorY = action.target.y;
   });
-  session.lastCursorX = action.target.x;
-  session.lastCursorY = action.target.y;
-  const afterUrl = session.page.url();
-  return { kind: "click", ok: true, navigation_triggered: beforeUrl !== afterUrl };
+  return { kind: "click", ok: true, navigation_triggered };
 }
 
 async function doDoubleClick(
   session: BrowserSession,
   action: DoubleClickAction,
 ): Promise<ActionResult> {
-  // Sibling of doClick — same `navigation_triggered` capture so
-  // double-clicks on submit / link elements report navigation truth.
-  const beforeUrl = session.page.url();
-  await session.page.mouse.dblclick(action.target.x, action.target.y, {
-    button: parseButton(action.button),
+  // Sibling of doClick — same `navigation_triggered` truth so
+  // double-clicks on submit / link elements report navigation honestly.
+  const navigation_triggered = await runWithNavigationTruth(session.page, async () => {
+    await session.page.mouse.dblclick(action.target.x, action.target.y, {
+      button: parseButton(action.button),
+    });
+    session.lastCursorX = action.target.x;
+    session.lastCursorY = action.target.y;
   });
-  session.lastCursorX = action.target.x;
-  session.lastCursorY = action.target.y;
-  const afterUrl = session.page.url();
-  return { kind: "double_click", ok: true, navigation_triggered: beforeUrl !== afterUrl };
+  return { kind: "double_click", ok: true, navigation_triggered };
 }
 
 async function doMouseMove(
@@ -420,20 +515,19 @@ async function doKey(session: BrowserSession, action: KeyAction): Promise<Action
   // (e.g. `"cmd+c"`, `"ctrl+shift+t"`, `"Escape"`). No separate
   // modifier list — the translator splits + renames + rejoins.
   //
-  // Typed-truth `navigation_triggered`: capture URL before + after so
-  // form-submission via key("Enter") reports whether the page
-  // actually moved. Same shape `doClickElement` ships for the click
-  // path. When false, the keystroke fired but no navigation happened
-  // — the AI shouldn't claim "submitted" / "done" until it reads the
-  // post-state. Witnessed bug 2026-05-12: AI pressed Enter on the
-  // Google search input, got `ok: true`, said "Done" — but the form
-  // didn't submit (Google's promo overlay intercepted) and the page
-  // stayed on the homepage. The wire field carries the truth; the
-  // prompt teaches reading it.
-  const beforeUrl = session.page.url();
-  await pressKeyCombo(session.page, action.key);
-  const afterUrl = session.page.url();
-  return { kind: "key", ok: true, navigation_triggered: beforeUrl !== afterUrl };
+  // Typed-truth `navigation_triggered`: report whether form submission
+  // via key("Enter") actually moved the page. When false, the keystroke
+  // fired but no navigation happened — the AI shouldn't claim
+  // "submitted" / "done" until it reads the post-state. This is the
+  // witnessed case (2026-05-12: Enter on the Google search input,
+  // `ok: true`, "Done" — but the search never ran). The earlier fix
+  // diffed the URL string, which Google's `?zx=` same-document rewrite
+  // defeated; `runWithNavigationTruth` keys on the navigation request
+  // instead. See its comment for the full regression story.
+  const navigation_triggered = await runWithNavigationTruth(session.page, () =>
+    pressKeyCombo(session.page, action.key),
+  );
+  return { kind: "key", ok: true, navigation_triggered };
 }
 
 async function doScroll(session: BrowserSession, action: ScrollAction): Promise<ActionResult> {
@@ -1335,16 +1429,20 @@ async function doClickElement(
     };
   }
   await locator.first().scrollIntoViewIfNeeded({ timeout: 5_000 });
-  const beforeUrl = session.page.url();
-  await locator.first().click({ timeout: 10_000 });
-  const truth = await session.page.evaluate(clickElementTruth, { selector });
-  const afterUrl = session.page.url();
+  let truth: { clicked_tag: string | null; focused_typeable: boolean } | undefined;
+  const navigation_triggered = await runWithNavigationTruth(session.page, async () => {
+    await locator.first().click({ timeout: 10_000 });
+    // Snapshot the clicked element's truth immediately — before any
+    // navigation the click triggers tears the element (and its frame)
+    // down underneath the evaluate.
+    truth = await session.page.evaluate(clickElementTruth, { selector });
+  });
   return {
     kind: "click_element",
     ok: true,
-    clicked_tag: truth.clicked_tag,
-    focused_typeable: truth.focused_typeable,
-    navigation_triggered: beforeUrl !== afterUrl,
+    clicked_tag: truth?.clicked_tag ?? null,
+    focused_typeable: truth?.focused_typeable ?? false,
+    navigation_triggered,
   };
 }
 


### PR DESCRIPTION
## What

`navigation_triggered` was computed as `beforeUrl !== afterUrl` at four call sites in `services/browser-sandbox/src/action-executor.ts`. A URL-string diff is the wrong signal for "did a document navigation happen":

- **False positive** — SPA `history.replaceState` / `pushState` changes `page.url()` without any document navigation. The action reports `navigation_triggered: true` when nothing navigated.
- **False negative** — an async cross-document navigation that lands on the same URL (or hasn't updated `page.url()` by the time we read it) reports `navigation_triggered: false` when a real nav occurred.

This signal feeds the dishonest-closing perception intercept in `@motebit/ai-core` — a typed-truth field per `docs/doctrine/typed-truth-perception.md`. A wrong producer silently lies to the interpreter.

## Change

All four sites (the action kinds that can trigger navigation) now use `runWithNavigationTruth(page, act)`, which waits on Playwright's real navigation lifecycle rather than diffing the URL string before/after.

## Verification

- 66 tests pass in `@motebit/browser-sandbox`.
- Typecheck clean.
- Complete across all four navigation-capable action kinds — the lone remaining `beforeUrl !== afterUrl` is in a JSDoc comment describing the old (now-fixed) behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)