### PR TITLE
fix(proxy): capture cloud→Anthropic input + cache tokens (billing leak + cache observability)

### DIFF
--- a/services/proxy/src/app/v1/messages/__tests__/usage.test.ts
+++ b/services/proxy/src/app/v1/messages/__tests__/usage.test.ts
@@ -12,21 +12,39 @@ const fresh = (): UsageAccumulator => ({ input: 0, output: 0, cacheRead: 0, cach
 const sse = (obj: unknown) => `data: ${JSON.stringify(obj)}`;
 
 describe("extractUsage — anthropic", () => {
-  it("passes input/output/cache fields through (input already excludes cached)", () => {
+  it("reads input/cache from message_start.message.usage and output from message_delta.usage", () => {
     const u = fresh();
+    // Real Anthropic wire: input + cache fields are NESTED under message.usage on
+    // message_start; the final output_tokens arrives top-level on message_delta.
     extractUsage(
       "anthropic",
       sse({
-        usage: {
-          input_tokens: 100,
-          output_tokens: 40,
-          cache_read_input_tokens: 3000,
-          cache_creation_input_tokens: 50,
+        type: "message_start",
+        message: {
+          usage: {
+            input_tokens: 100,
+            cache_read_input_tokens: 3000,
+            cache_creation_input_tokens: 50,
+          },
         },
       }),
       u,
     );
+    extractUsage("anthropic", sse({ type: "message_delta", usage: { output_tokens: 40 } }), u);
+    // input EXCLUDES cached → additive with the cache fields.
     expect(u).toEqual({ input: 100, output: 40, cacheRead: 3000, cacheCreation: 50 });
+  });
+
+  it("does NOT read top-level usage on message_start (the wrong shape captures nothing)", () => {
+    const u = fresh();
+    // A flat top-level usage on a message_start-like event is a shape Anthropic
+    // never emits — it must NOT populate input/cache (this guards the prior bug).
+    extractUsage(
+      "anthropic",
+      sse({ usage: { input_tokens: 100, cache_read_input_tokens: 3000 } }),
+      u,
+    );
+    expect(u).toEqual({ input: 0, output: 0, cacheRead: 0, cacheCreation: 0 });
   });
 });
 

--- a/services/proxy/src/app/v1/messages/usage.ts
+++ b/services/proxy/src/app/v1/messages/usage.ts
@@ -34,22 +34,28 @@ export function extractUsage(provider: InferenceHost, line: string, usage: Usage
     const evt = JSON.parse(json) as Record<string, unknown>;
 
     if (provider === "anthropic") {
-      // Anthropic: initial message has usage.input_tokens, message_delta has
-      // usage.output_tokens. input_tokens EXCLUDES cached — additive with the
-      // cache fields, so pass through unchanged.
-      const u = evt.usage as
-        | {
-            input_tokens?: number;
-            output_tokens?: number;
-            cache_read_input_tokens?: number;
-            cache_creation_input_tokens?: number;
-          }
-        | undefined;
-      if (u?.input_tokens != null) usage.input = u.input_tokens;
-      if (u?.output_tokens != null) usage.output = u.output_tokens;
-      if (u?.cache_read_input_tokens != null) usage.cacheRead = u.cache_read_input_tokens;
-      if (u?.cache_creation_input_tokens != null)
-        usage.cacheCreation = u.cache_creation_input_tokens;
+      // Anthropic nests input + cache usage on `message_start` under
+      // `message.usage` (NOT top-level), and reports the final output_tokens on
+      // `message_delta` under top-level `usage`. Reading top-level `usage` for
+      // everything silently drops input + cache (billing the bulk of the request
+      // at 0 and making cacheRead unobservable). Mirror the wire shape — and the
+      // BYOK parser in @motebit/ai-core (core.ts) — exactly.
+      // input_tokens EXCLUDES cached, so the cache fields stay additive.
+      type AnthropicUsage = {
+        input_tokens?: number;
+        output_tokens?: number;
+        cache_read_input_tokens?: number;
+        cache_creation_input_tokens?: number;
+      };
+      const start = (evt.message as { usage?: AnthropicUsage } | undefined)?.usage;
+      if (start) {
+        if (start.input_tokens != null) usage.input = start.input_tokens;
+        if (start.cache_read_input_tokens != null) usage.cacheRead = start.cache_read_input_tokens;
+        if (start.cache_creation_input_tokens != null)
+          usage.cacheCreation = start.cache_creation_input_tokens;
+      }
+      const delta = evt.usage as AnthropicUsage | undefined;
+      if (delta?.output_tokens != null) usage.output = delta.output_tokens;
       return;
     }
 


### PR DESCRIPTION
## What

The Anthropic branch of `extractUsage` (`services/proxy/src/app/v1/messages/usage.ts`) read **top-level** `evt.usage`. But Anthropic's streaming wire nests input + cache usage under `message_start`'s `message.usage`, and reports the final `output_tokens` top-level on `message_delta`. Reading top-level for everything silently dropped `input`, `cacheRead`, and `cacheCreation` on **every cloud→Anthropic request**.

### Impact
- **Billing leak:** the cloud Anthropic path (the default `auto`/Claude family) billed *only output tokens*. Input — the bulk of the cost — was billed at 0, systematically under-charging the most-used cloud model family.
- **Caching arc defeated:** `cacheRead` was always 0, so the caching arc's headline proof (`cache_read_input_tokens > 0`) could never fire on Anthropic. The OpenAI cache-fairness work in `cb78922d` sat on top of an Anthropic base that didn't read its own usage at all.

## Fix
Read `message.usage` on `message_start` (mirroring `@motebit/ai-core`'s BYOK parser at `core.ts:1033-1034`) and keep the `message_delta` top-level `output_tokens` read. `input_tokens` excludes cached, so the cache fields stay additive into `calculateCostMicro`.

## Why the old test passed
The prior unit test fed a **flat top-level `usage`** — a shape Anthropic never emits on `message_start` — so it passed against the broken read (the classic "test asserting a shape the producer never emits"). Replaced with a real `message_start` + `message_delta` pair, plus a guard test asserting a top-level usage on a start event captures nothing (fails against the old code). `usage.ts` now at 100% statement coverage.

## Follow-up (not in this PR)
Historical reconciliation: because the bug meant `input` was *never captured*, our own records (`proxy.usage` logs + `relay_transactions` debits) logged 0 too — so the exact dollar magnitude isn't reconstructable from our DB. Sizing requires comparing recorded cloud debits vs Anthropic's invoiced cost for the affected window (treasury-reconciliation pattern). Queries drafted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)