### PR TITLE
feat(runtime,ai-core)!: delegation policy refusal path — agent-signed denied receipts

### DIFF
--- a/.changeset/delegation-policy-refusal-path.md
+++ b/.changeset/delegation-policy-refusal-path.md
@@ -1,0 +1,13 @@
+---
+"@motebit/ai-core": minor
+"@motebit/runtime": minor
+---
+
+Delegation policy refusal path: a delegated task that governance forbids now emits an agent-signed `status:"denied"` ExecutionReceipt instead of a misleading `completed`.
+
+The denial _decision_ already existed (`PolicyGate.validate` hard-denies on the `deny_above` risk band, denylist, delegated scope, budget, and blocked callers), and the relay was already denial-aware end to end (`settleOnReceipt` refunds a denied receipt with zero fee, the task state machine maps `denied → AgentTaskStatus.Denied`, and the archive persists it byte-verbatim). The one missing piece was a producer: nothing ever set `status = "denied"`, so a refusal silently finished as a completion.
+
+- `@motebit/ai-core`: `TurnResult` gains an additive optional `toolCallsDenied` — hard governance refusals counted distinctly from the existing `toolCallsBlocked` superset (which also covers approval-gates, injection-quarantine, and tool-not-found). Incremented only at the `PolicyGate` `!decision.allowed` site.
+- `@motebit/runtime`: `handleAgentTask` downgrades `completed → denied` when a task did zero successful work and was hard-denied at least once (`toolCallsSucceeded === 0 && toolCallsDenied > 0`). The agent signs its own refusal with its own key — the relay cannot, so "the agent refuses itself" is a verifiable fact rather than the relay's word for it. A thrown provider error stays `failed`; a crash and a policy block are never conflated on the signed record.
+
+The denied receipt persists, is retrievable through the owner-scoped receipts endpoint, and re-verifies offline — a refusal is as auditable as a completion.

--- a/packages/ai-core/src/__tests__/loop.test.ts
+++ b/packages/ai-core/src/__tests__/loop.test.ts
@@ -392,6 +392,95 @@ describe("runTurn", () => {
     expect(result.stateAfter).toBeDefined();
   });
 
+  it("counts a hard policy denial into TurnResult.toolCallsDenied (not just toolCallsBlocked)", async () => {
+    // A minimal duck-typed PolicyGate that hard-denies one tool — mirrors the
+    // real gate's `deny_above` band (allowed:false, requiresApproval:false)
+    // without dragging @motebit/policy into ai-core (the gate is injected). The
+    // real band logic is covered by packages/policy tests; this locks that the
+    // LOOP routes a `!decision.allowed` into the denial counter so the
+    // delegated-task handler can mint a signed `denied` receipt.
+    const denyingGate = {
+      filterTools: (t: ToolDefinition[]) => t,
+      createTurnContext: () => ({
+        turnId: "t",
+        toolCallCount: 0,
+        turnStartMs: 0,
+        costAccumulated: 0,
+      }),
+      validate: (tool: ToolDefinition) =>
+        tool.name === "send_money"
+          ? { allowed: false, requiresApproval: false, reason: "risk R4_MONEY exceeds deny_above" }
+          : { allowed: true, requiresApproval: false },
+      classify: () => ({
+        risk: 4,
+        dataClass: "private",
+        sideEffect: "irreversible",
+        requiresApproval: true,
+      }),
+      recordToolCall: (ctx: unknown) => ctx,
+      sanitizeAndCheck: (result: ToolResult) => ({
+        result,
+        injectionDetected: false,
+        injectionPatterns: [],
+      }),
+      sanitizeResult: (result: ToolResult) => result,
+      logInjection: () => undefined,
+    };
+
+    const toolRegistry = makeMockToolRegistry(
+      new Map([
+        [
+          "send_money",
+          {
+            def: {
+              name: "send_money",
+              description: "Send money",
+              inputSchema: { type: "object", properties: { to: { type: "string" } } },
+            },
+            result: { ok: true },
+          },
+        ],
+      ]),
+    );
+
+    const provider = makeMockProvider([
+      {
+        text: "I'll send that.",
+        confidence: 0.8,
+        memory_candidates: [],
+        state_updates: {},
+        tool_calls: [{ id: "tc_deny", name: "send_money", args: { to: "x" } }],
+      },
+    ]);
+
+    const deps = {
+      ...makeDepsWithProvider(provider, toolRegistry),
+      policyGate: denyingGate,
+    } as unknown as SensitivityCleared<MotebitLoopDependencies>;
+
+    let resultChunk:
+      | {
+          type: "result";
+          result: {
+            toolCallsDenied?: number;
+            toolCallsSucceeded: number;
+            toolCallsBlocked: number;
+          };
+        }
+      | undefined;
+    for await (const chunk of runTurnStreaming(deps, "send money to x")) {
+      if (chunk.type === "result") {
+        resultChunk = chunk as typeof resultChunk;
+      }
+    }
+
+    expect(resultChunk).toBeDefined();
+    // The hard deny is counted distinctly AND remains a subset of blocked.
+    expect(resultChunk!.result.toolCallsDenied).toBe(1);
+    expect(resultChunk!.result.toolCallsSucceeded).toBe(0);
+    expect(resultChunk!.result.toolCallsBlocked).toBeGreaterThanOrEqual(1);
+  });
+
   it("version clocks increment across turns", async () => {
     const deps = makeDeps();
 

--- a/packages/ai-core/src/loop.ts
+++ b/packages/ai-core/src/loop.ts
@@ -481,6 +481,16 @@ export interface TurnResult {
   toolCallsSucceeded: number;
   /** Number of tool calls blocked by policy or requiring approval. */
   toolCallsBlocked: number;
+  /**
+   * Number of tool calls HARD-DENIED by governance — a strict subset of
+   * `toolCallsBlocked` that excludes approval-gates, injection-quarantine, and
+   * tool-not-found. Optional + additive: absent on legacy `TurnResult` literals
+   * (read as 0), always emitted by the loop. The delegated-task handler keys an
+   * agent-signed `status:"denied"` receipt on `toolCallsSucceeded === 0 &&
+   * toolCallsDenied > 0` — a task that accomplished nothing because policy
+   * forbade every action it attempted.
+   */
+  toolCallsDenied?: number;
   /** Number of tool calls that failed during execution. */
   toolCallsFailed: number;
 }
@@ -838,6 +848,16 @@ export async function* runTurnStreaming(
   let iteration = 0;
   let toolCallsSucceeded = 0;
   let toolCallsBlocked = 0;
+  // Hard governance refusals only — a strict subset of `toolCallsBlocked`.
+  // Incremented solely at the PolicyGate `!decision.allowed` site (deny_above
+  // risk band, denylist, delegated-scope, budget ceiling, blocked caller), NOT
+  // for approval-gates (a pause, not a refusal), injection-quarantine (the tool
+  // ran; its result was withheld), or tool-not-found. The delegated-task path
+  // reads this to mint an agent-signed `status:"denied"` ExecutionReceipt when a
+  // task accomplished nothing because governance forbade every action it tried —
+  // the difference between "I refused" and "I finished." See
+  // docs/doctrine/delegation.md + agent-task-handler.ts.
+  let toolCallsDenied = 0;
   let toolCallsFailed = 0;
   // Typed-truth log for the dishonest-closing intercept. Captures
   // structured tool result data PRE-sanitization so the typed-truth
@@ -991,6 +1011,12 @@ export async function* runTurnStreaming(
 
         if (!decision.allowed) {
           toolCallsBlocked++;
+          // Hard governance refusal (deny_above / denylist / scope / budget /
+          // blocked caller) — the one block category that is a true "no," not a
+          // pause. Counted distinctly so a delegated task that does nothing but
+          // get refused mints a signed `denied` receipt rather than a misleading
+          // `completed` one.
+          toolCallsDenied++;
           yield {
             type: "tool_status",
             name: toolCall.name,
@@ -1652,6 +1678,7 @@ export async function* runTurnStreaming(
       iterations: iteration,
       toolCallsSucceeded,
       toolCallsBlocked,
+      toolCallsDenied,
       toolCallsFailed,
       ...(turnCtx && turnCtx.costAccumulated > 0 ? { totalTokens: turnCtx.costAccumulated } : {}),
     },

--- a/packages/runtime/src/__tests__/agent-task-handler.test.ts
+++ b/packages/runtime/src/__tests__/agent-task-handler.test.ts
@@ -48,6 +48,35 @@ async function* mockStreamWithTools(text: string, tools: string[]): AsyncGenerat
   };
 }
 
+/**
+ * A stream that attempts work but is hard-denied by governance: the loop made
+ * `succeeded` successful tool calls and `denied` policy-refused ones. Mirrors
+ * what `runTurnStreaming` emits when PolicyGate.validate returns
+ * `allowed: false` (deny_above / denylist / scope / budget).
+ */
+async function* mockStreamGoverned(
+  text: string,
+  succeeded: number,
+  denied: number,
+): AsyncGenerator<StreamChunk> {
+  yield { type: "text", text };
+  yield {
+    type: "result",
+    result: {
+      response: text,
+      memoriesFormed: [],
+      memoriesRetrieved: [],
+      stateAfter: {} as any,
+      cues: {} as any,
+      iterations: 1,
+      toolCallsSucceeded: succeeded,
+      toolCallsBlocked: denied,
+      toolCallsDenied: denied,
+      toolCallsFailed: 0,
+    },
+  };
+}
+
 async function collectChunks(gen: AsyncGenerator<StreamChunk>): Promise<StreamChunk[]> {
   const chunks: StreamChunk[] = [];
   for await (const chunk of gen) {
@@ -238,6 +267,87 @@ describe("handleAgentTask (direct)", () => {
     expect(receipt.result_hash).toBeDefined();
     expect(receipt.prompt_hash).toMatch(/^[0-9a-f]{64}$/);
     expect(receipt.result_hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  // === Delegation policy refusal path ===
+
+  it("mints an agent-signed status:'denied' receipt when governance refused every action", async () => {
+    const deps = createMockDeps({
+      sendMessageStreaming: vi
+        .fn()
+        .mockReturnValue(mockStreamGoverned("I'm not permitted to do that.", 0, 1)),
+    });
+    const task = createMockTask();
+
+    const result = await getTaskResult(
+      handleAgentTask(deps, task, keypair.privateKey, "device-001", keypair.publicKey),
+    );
+
+    // The agent refuses itself — signed by its OWN key, verifiable offline.
+    expect(result.receipt.status).toBe("denied");
+    expect(result.receipt.result).toContain("refused by governance");
+    expect(await verifyExecutionReceipt(result.receipt, keypair.publicKey)).toBe(true);
+  });
+
+  it("logs the denial as AgentTaskDenied", async () => {
+    const deps = createMockDeps({
+      sendMessageStreaming: vi.fn().mockReturnValue(mockStreamGoverned("nope", 0, 2)),
+    });
+    const task = createMockTask();
+
+    await collectChunks(
+      handleAgentTask(deps, task, keypair.privateKey, "device-001", keypair.publicKey),
+    );
+
+    const calls = (deps.events.appendWithClock as any).mock.calls as Array<
+      [{ event_type: string }]
+    >;
+    expect(calls.some(([e]) => e.event_type === "agent_task_denied")).toBe(true);
+  });
+
+  it("does NOT deny when at least one action succeeded (partial work is completion, not refusal)", async () => {
+    const deps = createMockDeps({
+      sendMessageStreaming: vi.fn().mockReturnValue(mockStreamGoverned("Did part of it.", 1, 1)),
+    });
+    const task = createMockTask();
+
+    const result = await getTaskResult(
+      handleAgentTask(deps, task, keypair.privateKey, "device-001", keypair.publicKey),
+    );
+
+    expect(result.receipt.status).toBe("completed");
+  });
+
+  it("does NOT deny a zero-action task (nothing was refused)", async () => {
+    const deps = createMockDeps({
+      sendMessageStreaming: vi.fn().mockReturnValue(mockStreamGoverned("Here's the answer.", 0, 0)),
+    });
+    const task = createMockTask();
+
+    const result = await getTaskResult(
+      handleAgentTask(deps, task, keypair.privateKey, "device-001", keypair.publicKey),
+    );
+
+    expect(result.receipt.status).toBe("completed");
+  });
+
+  it("a thrown provider error stays 'failed', never reclassified as 'denied'", async () => {
+    // A crash is a failure; a policy block is a denial. The two must not be
+    // confused on the signed record — the downgrade only fires from 'completed'.
+    const deps = createMockDeps({
+      sendMessageStreaming: vi.fn().mockImplementation(function () {
+        return (async function* (): AsyncGenerator<StreamChunk> {
+          throw new Error("Provider unavailable");
+        })();
+      }),
+    });
+    const task = createMockTask();
+
+    const result = await getTaskResult(
+      handleAgentTask(deps, task, keypair.privateKey, "device-001", keypair.publicKey),
+    );
+
+    expect(result.receipt.status).toBe("failed");
   });
 
   it("restores conversation context even when streaming fails", async () => {

--- a/packages/runtime/src/agent-task-handler.ts
+++ b/packages/runtime/src/agent-task-handler.ts
@@ -96,6 +96,13 @@ export async function* handleAgentTask(
   const toolsUsed: string[] = [];
   let memoriesFormed = 0;
   let status: "completed" | "failed" | "denied" = "completed";
+  // Governance-refusal signal from the loop's terminal result. A delegated task
+  // that completed zero successful tool calls but was hard-denied by policy at
+  // least once is a refusal, not a completion — we mint an agent-signed
+  // `status:"denied"` receipt for it below. Approval-gates / injection /
+  // tool-not-found are NOT counted here (see TurnResult.toolCallsDenied).
+  let toolCallsSucceeded = 0;
+  let toolCallsDenied = 0;
 
   try {
     const stream = deps.sendMessageStreaming(task.prompt, undefined, {
@@ -118,6 +125,10 @@ export async function* handleAgentTask(
       } else if (chunk.type === "result") {
         responseText = chunk.result.response;
         memoriesFormed = chunk.result.memoriesFormed.length;
+        toolCallsSucceeded = chunk.result.toolCallsSucceeded;
+        // Optional + additive on TurnResult — absent on legacy producers ⇒ 0 ⇒
+        // never spuriously denies.
+        toolCallsDenied = chunk.result.toolCallsDenied ?? 0;
       }
 
       yield chunk;
@@ -130,6 +141,23 @@ export async function* handleAgentTask(
 
     // Restore user conversation context
     deps.restoreConversationContext(savedCtx);
+  }
+
+  // Delegation policy refusal path. A task that did NO successful work and was
+  // hard-denied by governance at least once is a refusal — surface it as an
+  // agent-signed `status:"denied"` receipt instead of a misleading `completed`.
+  // Only downgrades from `completed` (never overrides a `failed` from a thrown
+  // provider error / timeout): a crash is a failure, a policy block is a denial,
+  // and the two must not be confused on the signed record. The agent signs its
+  // OWN refusal here (the relay cannot — it holds no agent key), which is what
+  // makes "the agent refuses itself" a verifiable fact rather than the relay's
+  // word for it. See docs/doctrine/delegation.md.
+  if (status === "completed" && toolCallsSucceeded === 0 && toolCallsDenied > 0) {
+    status = "denied";
+    responseText =
+      `Task refused by governance: ${toolCallsDenied} action(s) exceeded this motebit's policy ` +
+      `(deny_above / denylist / delegated scope) and no permitted action completed.` +
+      (responseText ? ` Model note: ${responseText}` : "");
   }
 
   // Drain delegation receipts from motebit MCP adapters + interactive delegation tool

--- a/services/relay/src/__tests__/agent-receipts.test.ts
+++ b/services/relay/src/__tests__/agent-receipts.test.ts
@@ -27,7 +27,10 @@ interface SeededAgent {
 }
 
 /** Register an identity + device and persist one signed receipt for it. */
-async function seedAgentWithReceipt(relay: SyncRelay): Promise<SeededAgent> {
+async function seedAgentWithReceipt(
+  relay: SyncRelay,
+  status: "completed" | "denied" = "completed",
+): Promise<SeededAgent> {
   const kp = await generateKeypair();
   const pubKeyHex = bytesToHex(kp.publicKey);
   const idRes = await relay.app.request("/identity", {
@@ -50,9 +53,12 @@ async function seedAgentWithReceipt(relay: SyncRelay): Promise<SeededAgent> {
     device_id,
     submitted_at: 1000,
     completed_at: 2000,
-    status: "completed",
-    result: "audited the ledger and paused for approval",
-    tools_used: ["web_search"],
+    status,
+    result:
+      status === "denied"
+        ? "Task refused by governance: 1 action(s) exceeded this motebit's policy."
+        : "audited the ledger and paused for approval",
+    tools_used: status === "denied" ? [] : ["web_search"],
     memories_formed: 0,
     prompt_hash: "0".repeat(64),
     result_hash: "1".repeat(64),
@@ -114,6 +120,23 @@ describe("user-owned receipt retrieval", () => {
     expect(getRes.status).toBe(200);
     const one = (await getRes.json()) as Parameters<typeof verifyReceipt>[0];
     expect((await verifyReceipt(one)).valid).toBe(true);
+  });
+
+  it("a status:'denied' refusal receipt is retrievable + offline-verifiable (delegation refusal path)", async () => {
+    // The agent refuses itself (deny_above / scope / budget); the runtime signs
+    // the refusal with its OWN key. This closes the user-facing leg: the signed
+    // denial is pulled back through the same owner-scoped endpoint and re-verified
+    // offline, byte-verbatim — a refusal is as auditable as a completion.
+    const a = await seedAgentWithReceipt(relay, "denied");
+    const token = await mintToken(a.motebitId, a.deviceId, a.privateKey);
+
+    const getRes = await relay.app.request(`/api/v1/agents/${a.motebitId}/receipts/${a.taskId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(getRes.status).toBe(200);
+    const receipt = (await getRes.json()) as Parameters<typeof verifyReceipt>[0];
+    expect((receipt as { status: string }).status).toBe("denied");
+    expect((await verifyReceipt(receipt)).valid).toBe(true);
   });
 
   it("the operator master token can read any motebit's receipts", async () => {


### PR DESCRIPTION
## Delegation policy refusal path

A delegated task that governance forbids now emits an **agent-signed `status:"denied"` ExecutionReceipt** instead of a misleading `completed`. This makes "the agent refuses itself" a verifiable cryptographic fact, not the relay's word for it.

### The finding

The denial *decision* already existed, and the relay was already denial-aware **end to end** — the whole path was scaffolded across protocol + relay, and **the only missing piece was a producer**:

- `PolicyGate.validate` already hard-denies on the `deny_above` risk band, denylist, delegated scope, budget, and blocked callers (`loop.ts:992`).
- `settleOnReceipt` already refunds a `denied` receipt at **zero fee** — no charge for a refusal (`packages/market/src/settlement.ts:148`).
- `tasks.ts` already maps `denied → AgentTaskStatus.Denied`; the archive persists it byte-verbatim; trust treats it neutrally; credentials skip it.

Nothing ever *set* `status = "denied"`, so a governance refusal silently finished as a completion. This PR is that producer.

### Changes

- **`@motebit/ai-core`** — `TurnResult` gains an additive optional `toolCallsDenied`: hard governance refusals counted distinctly from the `toolCallsBlocked` superset (which also covers approval-gates, injection-quarantine, tool-not-found — categorically *not* refusals). Incremented only at the `PolicyGate` `!decision.allowed` site. Additive/optional → the 41 existing `TurnResult` literals are untouched.
- **`@motebit/runtime`** — `handleAgentTask` downgrades `completed → denied` iff `toolCallsSucceeded === 0 && toolCallsDenied > 0` (zero work + ≥1 hard deny = refusal, not partial completion). The agent signs its own refusal with its own key — the relay structurally cannot. A thrown provider error stays `failed`: a crash and a policy block are never conflated on the signed record.

The denied receipt persists, is retrievable through the owner-scoped receipts endpoint, and re-verifies offline — **a refusal is as auditable as a completion.**

### Tests

- `agent-task-handler`: denied / partial-work-is-completion / zero-action / failed-stays-failed + offline-verify + `AgentTaskDenied` event.
- `ai-core` loop: a real `!decision.allowed` (injected duck-typed gate) → `toolCallsDenied === 1`, `toolCallsSucceeded === 0`.
- relay `agent-receipts`: a `denied` receipt retrievable + offline-verifiable through the shipped endpoint.

ai-core **506** · runtime **1087** · relay agent-receipts **6** · all **110** drift gates pass · typecheck clean · 0 lint errors.

### Scope note

This is the deterministic *delegation policy refusal path*. Interactive approval (the `requiresApproval` band — pause/resume + human consent, product-surface-coupled) is a separate later arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
