### PR TITLE
feat(protocol,crypto,runtime): signed approval/consent decisions

### DIFF
--- a/.changeset/signed-approval-consent-decision-ignored.md
+++ b/.changeset/signed-approval-consent-decision-ignored.md
@@ -1,0 +1,5 @@
+---
+"@motebit/runtime": minor
+---
+
+Runtime side of the signed approval/consent decision arc. `streaming.ts`'s `resumeAfterApproval` now produces and signs an `ApprovalDecision` with the approver's device key at every final verdict (single-approver, deny, quorum-met), delivers it via a new `onApprovalDecision` sink, and buffers it in `getRecentApprovalDecisions()` — the same buffer + forward shape as `onToolInvocation` (no new StreamChunk variant; no runtime event-log append, which would double-emit against the daemon's existing goal-audit event). See the published `@motebit/protocol` + `@motebit/crypto` changeset for the artifact + verifier.

--- a/.changeset/signed-approval-consent-decision.md
+++ b/.changeset/signed-approval-consent-decision.md
@@ -1,0 +1,14 @@
+---
+"@motebit/protocol": minor
+"@motebit/crypto": minor
+---
+
+Signed approval/consent decisions: the "approve" governance band is now a verifiable artifact, not a plaintext row.
+
+Interactive approval pause/resume already existed (`streaming.ts` `resumeAfterApproval`/`resolveApprovalVote` across all surfaces, with quorum + timeout + a durable daemon path). The gap was that the consent _decision_ itself was unsigned — a plaintext `approval_queue` row + event, with mid-turn denial injected as the literal string `"User denied this tool call."` This left the governance triad asymmetric: the auto band proves itself with a `ToolInvocationReceipt` and the deny band with an agent-signed `ExecutionReceipt{status:"denied"}`, but the approve band's verdict was unverifiable.
+
+- `@motebit/protocol`: new `ApprovalDecision` interface — a JCS + Ed25519 signed-artifact-family member committing to `approval_id` (the gated `tool_call_id`, bound so a verdict is non-portable), `args_hash` (never raw args), `risk_level`, `verdict`, and requested/resolved timestamps.
+- `@motebit/crypto`: `signApprovalDecision` / `verifyApprovalDecision` (+ `APPROVAL_DECISION_SUITE`), mirroring `signAdjudicatorVote` and embedding the approver's `public_key` for offline verification. Registered in `check-signed-artifact-verifiers`.
+- `@motebit/runtime`: `resumeAfterApproval` produces and signs the decision with the **approver's** device key (consent is the approver's own assertion, the way the worker signs its own refusal), for every final verdict — single-approver, deny, and quorum-met. Delivered via a new `onApprovalDecision` sink and buffered in `getRecentApprovalDecisions()` — the exact buffer + forward shape as `onToolInvocation` (a sink, not a new StreamChunk variant, so no surface switch changes; and no runtime event-log append, which would double-emit against the daemon's existing goal-audit event).
+
+The decision verifies offline with the approver's public key, no relay contact. Deferred (consumer-forced shape, mirroring how the refusal path shipped retrieval separately): durable cross-restart archival + a dedicated retrieval surface, per-quorum-vote signing, and signing the timeout-expiry auto-deny.

--- a/docs/doctrine/receipts-unified.md
+++ b/docs/doctrine/receipts-unified.md
@@ -72,6 +72,18 @@ The trigger for shipping `@motebit/receipts` as a facade package: a third-party 
 
 Until then, this doctrine memo IS the unification surface. Future contributors searching for "receipts" find this memo via `grep` in `docs/doctrine/`, follow the table to the canonical owners, and read the verification path. That's the lightweight fix the audit identified.
 
+## Sibling: the verifiable governance triad
+
+The three receipts are the family's core, but the same JCS + Ed25519 + suite-dispatch shape extends to governance _decisions_ — so each of the three governance bands a motebit can apply to an act is a self-verifiable fact, not the system's plaintext word for it:
+
+| Band        | Trigger                                      | Verifiable artifact                                                  | Signed by                     |
+| ----------- | -------------------------------------------- | -------------------------------------------------------------------- | ----------------------------- |
+| **auto**    | risk ≤ `require_approval_above`              | `ToolInvocationReceipt`                                              | agent                         |
+| **approve** | `require_approval_above < risk ≤ deny_above` | `ApprovalDecision`                                                   | **approver (human's device)** |
+| **deny**    | risk > `deny_above`                          | `ExecutionReceipt{status:"denied"}` (delegation policy refusal path) | agent                         |
+
+`ApprovalDecision` (`@motebit/protocol`; `signApprovalDecision`/`verifyApprovalDecision` in `@motebit/crypto`) closes the band that was previously a plaintext DB row + event. It commits to `args_hash` (never raw args — same privacy discipline as `ToolInvocationReceipt`), binds the gated `approval_id` so a verdict is non-portable across calls, and is signed by the **approver's** key — consent is the approver's own assertion, mirroring how the worker signs its own refusal. Produced at the verdict locus in `streaming.ts`'s `resumeAfterApproval` (covering single-approver, deny, and quorum-met paths), delivered via the `onApprovalDecision` sink and buffered in `getRecentApprovalDecisions()` — the exact buffer + forward shape as `onToolInvocation` (no runtime event-log append: the daemon already records its own goal-audit event, and durable archival is a separate consumer-shaped concern). Prior art for the shape: the key-rotation guardian quorum (`relay_approval_votes.signature`). Structurally locked by `check-signed-artifact-verifiers`. Deferred (consumer-forced shape): durable cross-restart archival + a dedicated retrieval surface, per-quorum-vote signing, and signing the timeout-expiry auto-deny.
+
 ## Cross-cuts
 
 - [`self-attesting-system.md`](self-attesting-system.md) — every claim is user-verifiable; receipts are the structural implementation of that principle.

--- a/packages/crypto/etc/crypto.api.md
+++ b/packages/crypto/etc/crypto.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import type { AdjudicatorVote } from '@motebit/protocol';
+import type { ApprovalDecision } from '@motebit/protocol';
 import type { BalanceWaiver } from '@motebit/protocol';
 import type { ComputerSessionActionRecord } from '@motebit/protocol';
 import type { ConsolidationReceipt } from '@motebit/protocol';
@@ -94,6 +95,11 @@ export interface AgentSettlementAnchorVerifyResult {
     };
     valid: boolean;
 }
+
+// @public
+export const APPROVAL_DECISION_SUITE: "motebit-jcs-ed25519-b64-v1";
+
+export { ApprovalDecision }
 
 // @public (undocumented)
 export type ArtifactType = VerifyResult["type"];
@@ -1070,6 +1076,12 @@ export interface SignableToolInvocationReceipt {
 export function signAdjudicatorVote(vote: Omit<AdjudicatorVote, "signature" | "suite">, peerPrivateKey: Uint8Array): Promise<AdjudicatorVote>;
 
 // @public
+export function signApprovalDecision<T extends Omit<ApprovalDecision, "signature" | "suite">>(decision: T, approverPrivateKey: Uint8Array, publicKey?: Uint8Array): Promise<T & {
+    suite: typeof APPROVAL_DECISION_SUITE;
+    signature: string;
+}>;
+
+// @public
 export function signBalanceWaiver(waiver: Omit<BalanceWaiver, "signature" | "suite">, agentPrivateKey: Uint8Array): Promise<BalanceWaiver>;
 
 // @public
@@ -1431,6 +1443,9 @@ export function verifyAdjudicatorVote(vote: AdjudicatorVote, peerPublicKey: Uint
 
 // @public
 export function verifyAgentSettlementAnchor(settlement: Record<string, unknown>, proof: AgentSettlementAnchorProofFields, chainVerifier?: ChainAnchorVerifier): Promise<AgentSettlementAnchorVerifyResult>;
+
+// @public
+export function verifyApprovalDecision(decision: ApprovalDecision, approverPublicKey: Uint8Array): Promise<boolean>;
 
 // @public
 export function verifyBalanceWaiver(waiver: BalanceWaiver, agentPublicKey: Uint8Array): Promise<boolean>;

--- a/packages/crypto/src/__tests__/verify-artifacts.test.ts
+++ b/packages/crypto/src/__tests__/verify-artifacts.test.ts
@@ -49,6 +49,8 @@ import {
   verifyConsolidationReceipt,
   signAdjudicatorVote,
   verifyAdjudicatorVote,
+  signApprovalDecision,
+  verifyApprovalDecision,
   signDisputeResolution,
   verifyDisputeResolution,
   signDisputeRequest,
@@ -908,6 +910,85 @@ describe("signAdjudicatorVote / verifyAdjudicatorVote", () => {
     const signed = await signAdjudicatorVote(makeVote(), kp.privateKey);
     const wrongSuite = { ...signed, suite: "motebit-future-pqc-v7" as never };
     expect(await verifyAdjudicatorVote(wrongSuite, kp.publicKey)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// signApprovalDecision / verifyApprovalDecision  (the "approve" governance band)
+// ---------------------------------------------------------------------------
+
+describe("signApprovalDecision / verifyApprovalDecision", () => {
+  function makeDecision(overrides?: {
+    approval_id?: string;
+    args_hash?: string;
+    verdict?: "approved" | "denied";
+  }) {
+    return {
+      approval_id: overrides?.approval_id ?? "tc-alpha",
+      motebit_id: "motebit-executor",
+      device_id: "device-approver",
+      tool_name: "send_money",
+      args_hash: overrides?.args_hash ?? "a".repeat(64),
+      risk_level: 4,
+      verdict: overrides?.verdict ?? ("approved" as const),
+      requested_at: 1000,
+      resolved_at: 2000,
+    };
+  }
+
+  it("round-trips and stamps suite; embeds public_key for offline verify", async () => {
+    const kp = await generateKeypair();
+    const signed = await signApprovalDecision(makeDecision(), kp.privateKey, kp.publicKey);
+    expect(signed.suite).toBe("motebit-jcs-ed25519-b64-v1");
+    expect(signed.signature).toBeTruthy();
+    expect(signed.public_key).toBeTruthy();
+    expect(await verifyApprovalDecision(signed, kp.publicKey)).toBe(true);
+  });
+
+  it("verifies without an embedded public_key (caller supplies the key)", async () => {
+    const kp = await generateKeypair();
+    const signed = await signApprovalDecision(makeDecision(), kp.privateKey);
+    expect(signed.public_key).toBeUndefined();
+    expect(await verifyApprovalDecision(signed, kp.publicKey)).toBe(true);
+  });
+
+  // The non-portability invariant: the signature covers approval_id, so a
+  // verdict rendered for one gated call cannot be replayed onto another.
+  it("signature binds to approval_id — a verdict for call A fails on call B's bytes", async () => {
+    const kp = await generateKeypair();
+    const forA = await signApprovalDecision(makeDecision({ approval_id: "tc-A" }), kp.privateKey);
+    const replayedToB = { ...forA, approval_id: "tc-B" };
+    expect(await verifyApprovalDecision(replayedToB, kp.publicKey)).toBe(false);
+  });
+
+  // Consent binds to the exact call shape: tampering args_hash (a different
+  // call than the human saw) breaks the signature.
+  it("signature binds to args_hash — swapped args break verification", async () => {
+    const kp = await generateKeypair();
+    const signed = await signApprovalDecision(makeDecision(), kp.privateKey);
+    const swapped = { ...signed, args_hash: "b".repeat(64) };
+    expect(await verifyApprovalDecision(swapped, kp.publicKey)).toBe(false);
+  });
+
+  it("detects verdict tampering — approved flipped to denied fails", async () => {
+    const kp = await generateKeypair();
+    const signed = await signApprovalDecision(makeDecision({ verdict: "approved" }), kp.privateKey);
+    const flipped = { ...signed, verdict: "denied" as const };
+    expect(await verifyApprovalDecision(flipped, kp.publicKey)).toBe(false);
+  });
+
+  it("rejects the wrong key", async () => {
+    const kpA = await generateKeypair();
+    const kpB = await generateKeypair();
+    const signed = await signApprovalDecision(makeDecision(), kpA.privateKey);
+    expect(await verifyApprovalDecision(signed, kpB.publicKey)).toBe(false);
+  });
+
+  it("rejects unknown suite (no legacy-no-suite path)", async () => {
+    const kp = await generateKeypair();
+    const signed = await signApprovalDecision(makeDecision(), kp.privateKey);
+    const wrongSuite = { ...signed, suite: "motebit-future-pqc-v7" as never };
+    expect(await verifyApprovalDecision(wrongSuite, kp.publicKey)).toBe(false);
   });
 });
 

--- a/packages/crypto/src/artifacts.ts
+++ b/packages/crypto/src/artifacts.ts
@@ -909,6 +909,69 @@ export async function verifyAdjudicatorVote(
   }
 }
 
+// === Approval Decisions (human-consent over a governance-gated tool call) ===
+
+// prettier-ignore
+import type { ApprovalDecision } from "@motebit/protocol";
+export type { ApprovalDecision };
+
+/** The one suite ApprovalDecisions sign under today. */
+export const APPROVAL_DECISION_SUITE = "motebit-jcs-ed25519-b64-v1" as const;
+
+/**
+ * Sign a human-consent decision over a governance-gated tool call. Signed by
+ * the APPROVER's key — consent is the approver's own assertion, the same way the
+ * worker signs its own refusal. The `approval_id` (the gated call's
+ * `tool_call_id`) and `args_hash` are part of the signed body, so a verdict is
+ * non-portable: it cannot be replayed onto a different call or different args
+ * without breaking the signature.
+ *
+ * Callers pass the body without `signature` or `suite`; the signer owns both.
+ * When `publicKey` is supplied it is embedded as `public_key` (hex) so a third
+ * party can verify offline without a separate key lookup — same portability
+ * contract as `signExecutionReceipt`.
+ */
+export async function signApprovalDecision<T extends Omit<ApprovalDecision, "signature" | "suite">>(
+  decision: T,
+  approverPrivateKey: Uint8Array,
+  publicKey?: Uint8Array,
+): Promise<T & { suite: typeof APPROVAL_DECISION_SUITE; signature: string }> {
+  const withKey = publicKey ? { ...decision, public_key: bytesToHex(publicKey) } : decision;
+  const body = { ...withKey, suite: APPROVAL_DECISION_SUITE };
+  const canonical = canonicalJson(body);
+  const message = new TextEncoder().encode(canonical);
+  const sig = await signBySuite(APPROVAL_DECISION_SUITE, message, approverPrivateKey);
+  const signed = { ...body, signature: toBase64Url(sig) } as T & {
+    suite: typeof APPROVAL_DECISION_SUITE;
+    signature: string;
+  };
+  // Immutable evidence by contract — freeze so any post-sign mutation throws at
+  // the producer rather than surfacing as wire corruption downstream.
+  return Object.freeze(signed);
+}
+
+/**
+ * Verify an approval decision against the approver's public key. Reconstructs
+ * the canonical JSON from every field except `signature` (the suite IS part of
+ * the signed body, so tampering with it breaks verification). Fail-closed on
+ * unknown suite, base64url decode error, and primitive verification failure.
+ */
+export async function verifyApprovalDecision(
+  decision: ApprovalDecision,
+  approverPublicKey: Uint8Array,
+): Promise<boolean> {
+  if (decision.suite !== APPROVAL_DECISION_SUITE) return false;
+  const { signature, ...body } = decision;
+  const canonical = canonicalJson(body);
+  const message = new TextEncoder().encode(canonical);
+  try {
+    const sig = fromBase64Url(signature);
+    return await verifyBySuite(decision.suite, message, sig, approverPublicKey);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Sign a dispute resolution. For single-relay adjudication
  * (`adjudicator_votes: []`) the relay signs with its own identity key.

--- a/packages/protocol/etc/protocol.api.md
+++ b/packages/protocol/etc/protocol.api.md
@@ -317,6 +317,25 @@ export const ALL_TOKEN_AUDIENCES: readonly TokenAudience[];
 export type AllocationId = Brand<string, "AllocationId">;
 
 // @public
+export interface ApprovalDecision {
+    approval_id: string;
+    args_hash: string;
+    denied_reason?: string;
+    device_id: DeviceId;
+    motebit_id: MotebitId;
+    public_key?: string;
+    requested_at: number;
+    resolved_at: number;
+    risk_level: number;
+    run_id?: string;
+    // (undocumented)
+    signature: string;
+    suite: "motebit-jcs-ed25519-b64-v1";
+    tool_name: string;
+    verdict: "approved" | "denied";
+}
+
+// @public
 export interface ApprovalQuorum {
     approvers: string[];
     risk_floor?: string;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1002,6 +1002,75 @@ export interface ToolInvocationReceipt {
 }
 
 /**
+ * Signed human-consent decision over a tool call that governance gated for
+ * approval (the middle band: `require_approval_above < risk <= deny_above`).
+ *
+ * The third governance band made verifiable. The auto band proves itself with
+ * a `ToolInvocationReceipt`; the deny band proves itself with an agent-signed
+ * `ExecutionReceipt{status:"denied"}` (the delegation policy refusal path). The
+ * approve band was the only one whose decision was unsigned — a plaintext DB
+ * row + event. This artifact closes that asymmetry: when a human approves (or
+ * denies) a gated act, the verdict becomes a self-verifiable fact — "this
+ * approver consented to THIS tool call with THESE args at THIS time" — that any
+ * third party can check offline with the approver's public key, no relay
+ * contact required.
+ *
+ * Signed by the APPROVER's device key (the human consenting), mirroring how the
+ * worker signs its own refusal: consent is the approver's assertion, not the
+ * system's word for it. Prior art for signed approval votes: the key-rotation
+ * guardian quorum (`relay_approval_votes.signature`) — this lifts that shape
+ * from the narrow key-rotation case to the general agentic tool-consent path.
+ *
+ * Privacy: commits to `args_hash` (SHA-256 of the canonical args), never the
+ * raw args — same discipline as `ToolInvocationReceipt`. A verifier holding the
+ * raw args recomputes and matches; one holding only the decision still proves a
+ * verdict was rendered over *some* call at *some* time.
+ *
+ * Member of the JCS + Ed25519 + suite-dispatch signed-artifact family
+ * (`docs/doctrine/receipts-unified.md`). Verify with `verifyApprovalDecision`.
+ */
+export interface ApprovalDecision {
+  /**
+   * Binds the decision to the specific gated call — the `tool_call_id` from the
+   * `approval_request`. Part of the signed body, so a verdict cannot be
+   * replayed onto a different call (the binding breaks the signature).
+   */
+  approval_id: string;
+  /** The motebit whose governance gated the call (the executor being approved). */
+  motebit_id: MotebitId;
+  /** Signer's (approver's) Ed25519 public key (hex). Enables offline verification without a key lookup. */
+  public_key?: string;
+  /** The approver's device that rendered the verdict and holds the signing key. */
+  device_id: DeviceId;
+  /** Tool the verdict authorizes (or refuses). */
+  tool_name: string;
+  /**
+   * SHA-256 hex of the canonical JSON of the tool's arguments — never the raw
+   * args. Binds consent to the exact call shape the approver saw.
+   */
+  args_hash: string;
+  /** The `RiskLevel` numeric that triggered the approval gate. */
+  risk_level: number;
+  /** The human's verdict. `denied` carries an optional `denied_reason`. */
+  verdict: "approved" | "denied";
+  /** Unix ms when the approval was requested (the gate fired). */
+  requested_at: number;
+  /** Unix ms when the human rendered the verdict. */
+  resolved_at: number;
+  /** Free-text reason, present only on `denied`. */
+  denied_reason?: string;
+  /** The turn/run the gated call belongs to, when known. */
+  run_id?: string;
+  /**
+   * Cryptosuite discriminator. Always `"motebit-jcs-ed25519-b64-v1"` today.
+   * Widening requires a `SuiteId` registry change + a new dispatch arm in
+   * `@motebit/crypto`, not a wire-format break.
+   */
+  suite: "motebit-jcs-ed25519-b64-v1";
+  signature: string;
+}
+
+/**
  * Signed proof that the motebit performed a consolidation cycle. The
  * receipt commits to structural facts only — counts of memories merged,
  * promoted, pruned, and the cycle's identity / timestamps — never to

--- a/packages/runtime/src/__tests__/streaming.test.ts
+++ b/packages/runtime/src/__tests__/streaming.test.ts
@@ -4,6 +4,8 @@ import type { PlatformAdapters, StreamChunk, ConversationStoreAdapter } from "..
 import type { StreamingProvider, AgenticChunk, TurnResult } from "@motebit/ai-core";
 import type { AIResponse, ContextPack, ToolHandler } from "@motebit/sdk";
 import { TrustMode, BatteryMode, EventType, SensitivityLevel } from "@motebit/sdk";
+// eslint-disable-next-line no-restricted-imports -- test verifies the signed consent artifact directly
+import { generateKeypair, verifyApprovalDecision, type ApprovalDecision } from "@motebit/crypto";
 
 // === Mock ai-core: override runTurnStreaming and reflect, keep everything else real ===
 
@@ -963,6 +965,88 @@ describe("processStream side effects", () => {
 
     // Should extract *smiles* action and convert to state delta without error
     await collectChunks(runtime.sendMessageStreaming("hello"));
+  });
+});
+
+// === signed approval/consent decision (the "approve" governance band) ===
+
+describe("resumeAfterApproval — signed consent decision", () => {
+  let runtime: MotebitRuntime;
+  let keypair: { publicKey: Uint8Array; privateKey: Uint8Array };
+  let decisions: ApprovalDecision[];
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    keypair = await generateKeypair();
+    decisions = [];
+    runtime = new MotebitRuntime(
+      {
+        motebitId: "consent-test",
+        tickRateHz: 0,
+        deviceId: "device-approver",
+        signingKeys: { privateKey: keypair.privateKey, publicKey: keypair.publicKey },
+        onApprovalDecision: (d) => decisions.push(d),
+      },
+      createAdapters(createMockProvider()),
+    );
+  });
+
+  async function enterPendingApproval(
+    toolCallId: string,
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<void> {
+    mockRunTurnStreaming.mockReturnValueOnce(
+      yieldChunks(
+        { type: "approval_request", tool_call_id: toolCallId, name, args, risk_level: 4 },
+        { type: "result", result: makeTurnResult() },
+      ),
+    );
+    await collectChunks(runtime.sendMessageStreaming("do the thing"));
+    expect(runtime.hasPendingApproval).toBe(true);
+    mockRunTurnStreaming.mockReturnValueOnce(
+      yieldChunks({ type: "result", result: makeTurnResult() }),
+    );
+  }
+
+  it("an APPROVED verdict emits a signed consent decision that verifies offline", async () => {
+    await enterPendingApproval("tc-approve", "send_money", { to: "x", amount: 5 });
+    await collectChunks(runtime.resumeAfterApproval(true));
+
+    expect(decisions).toHaveLength(1);
+    const d = decisions[0]!;
+    expect(d.verdict).toBe("approved");
+    expect(d.approval_id).toBe("tc-approve");
+    expect(d.tool_name).toBe("send_money");
+    expect(d.risk_level).toBe(4);
+    expect(d.device_id).toBe("device-approver");
+    // args_hash commits to the call — never the raw args.
+    expect(d.args_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(d).not.toHaveProperty("args");
+    // The approver's own signature verifies with no relay contact.
+    expect(await verifyApprovalDecision(d, keypair.publicKey)).toBe(true);
+  });
+
+  it("a DENIED verdict also emits a signed decision (consent refusal is provable too)", async () => {
+    await enterPendingApproval("tc-deny", "delete_account", {});
+    await collectChunks(runtime.resumeAfterApproval(false));
+
+    expect(decisions).toHaveLength(1);
+    const d = decisions[0]!;
+    expect(d.verdict).toBe("denied");
+    expect(d.denied_reason).toBeTruthy();
+    expect(await verifyApprovalDecision(d, keypair.publicKey)).toBe(true);
+  });
+
+  it("buffers the decision in getRecentApprovalDecisions(), verifiable, same contract as getRecentReceipts()", async () => {
+    await enterPendingApproval("tc-buffer", "transfer", { amt: 1 });
+    await collectChunks(runtime.resumeAfterApproval(true));
+
+    const buffered = runtime.getRecentApprovalDecisions();
+    expect(buffered).toHaveLength(1);
+    expect(buffered[0]!.approval_id).toBe("tc-buffer");
+    // The buffered artifact reverifies offline — self-attesting consent.
+    expect(await verifyApprovalDecision(buffered[0]!, keypair.publicKey)).toBe(true);
   });
 });
 

--- a/packages/runtime/src/motebit-runtime.ts
+++ b/packages/runtime/src/motebit-runtime.ts
@@ -543,6 +543,10 @@ export class MotebitRuntime {
    * persist the payload beyond the call.
    */
   private _onToolActivity: ((event: import("./streaming.js").ToolActivityEvent) => void) | null;
+  /** Surface sink for signed human-consent decisions (the "approve" band artifact). */
+  private _onApprovalDecision:
+    | ((decision: import("@motebit/crypto").ApprovalDecision) => void)
+    | null;
   /**
    * receipts-1 — in-memory buffer of recent signed
    * `ToolInvocationReceipt`s, capped at `RECEIPTS_BUFFER_CAP`.
@@ -566,6 +570,8 @@ export class MotebitRuntime {
    */
   private _recentReceipts: import("@motebit/crypto").SignableToolInvocationReceipt[] = [];
   private static readonly RECEIPTS_BUFFER_CAP = 50;
+  /** In-session buffer of signed human-consent decisions (newest last), same cap + contract as `_recentReceipts`. */
+  private _recentApprovalDecisions: import("@motebit/crypto").ApprovalDecision[] = [];
 
   constructor(config: RuntimeConfig, adapters: PlatformAdapters) {
     // Defense-in-depth: trip the species-constraint tamper detection as
@@ -607,6 +613,7 @@ export class MotebitRuntime {
       }
     };
     this._onToolActivity = config.onToolActivity ?? null;
+    this._onApprovalDecision = config.onApprovalDecision ?? null;
     this.compactionThreshold = config.compactionThreshold ?? 1000;
     this.mcpConfigs = config.mcpServers ?? [];
     this.taskRouter = config.taskRouter ? new TaskRouter(config.taskRouter) : null;
@@ -1069,9 +1076,38 @@ export class MotebitRuntime {
         ? (receipt) => this._onToolInvocation?.(receipt)
         : undefined,
       onToolActivity: this._onToolActivity ? (event) => this._onToolActivity?.(event) : undefined,
+      onApprovalDecision: (decision) => this.recordApprovalDecision(decision),
     });
 
     this.wireLoopDeps();
+  }
+
+  /**
+   * Buffer a signed human-consent decision and forward it to the surface sink —
+   * the exact shape as `_onToolInvocation`: push to the in-session buffer FIRST
+   * (so `getRecentApprovalDecisions()` is correct regardless of whether a
+   * surface listener throws), then fan out. Deliberately does NOT append an
+   * event-log entry: the daemon/goal path already records its own
+   * `ApprovalApproved`/`ApprovalDenied` goal-audit event (`apps/cli` scheduler),
+   * so a runtime append would double-emit; and durable cross-restart archival of
+   * the signed artifact is a separate, consumer-shaped concern (a dedicated
+   * retrieval surface), deferred until a consumer forces its shape — the same
+   * sequencing the delegation refusal path used for receipt retrieval.
+   */
+  private recordApprovalDecision(decision: import("@motebit/crypto").ApprovalDecision): void {
+    this._recentApprovalDecisions.push(decision);
+    if (this._recentApprovalDecisions.length > MotebitRuntime.RECEIPTS_BUFFER_CAP) {
+      this._recentApprovalDecisions.shift();
+    }
+    if (this._onApprovalDecision) {
+      try {
+        this._onApprovalDecision(decision);
+      } catch (err: unknown) {
+        this._logger.warn(
+          `[runtime] surface onApprovalDecision threw: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
   }
 
   // === Lifecycle ===
@@ -3571,6 +3607,19 @@ export class MotebitRuntime {
    */
   getRecentReceipts(): ReadonlyArray<import("@motebit/crypto").SignableToolInvocationReceipt> {
     return this._recentReceipts;
+  }
+
+  /**
+   * Recent signed human-consent decisions (`ApprovalDecision`), newest last,
+   * capped at `RECEIPTS_BUFFER_CAP`. The "approve" governance band's
+   * counterpart to `getRecentReceipts()`: each entry is the approver's signed,
+   * offline-verifiable verdict over a gated tool call. Empty when no decisions
+   * were rendered this session, or when no signing key was wired (fail-closed —
+   * the runtime emits nothing rather than an unsigned decision). Durable
+   * cross-restart archival is a deferred, consumer-shaped concern.
+   */
+  getRecentApprovalDecisions(): ReadonlyArray<import("@motebit/crypto").ApprovalDecision> {
+    return this._recentApprovalDecisions;
   }
 
   /**

--- a/packages/runtime/src/runtime-config.ts
+++ b/packages/runtime/src/runtime-config.ts
@@ -112,6 +112,17 @@ export interface RuntimeConfig {
    */
   onToolInvocation?: (receipt: import("@motebit/crypto").SignableToolInvocationReceipt) => void;
   /**
+   * Optional sink for a signed human-consent decision over a
+   * governance-gated tool call (the "approve" governance band made
+   * verifiable). Fires once per final approval verdict with the
+   * `ApprovalDecision` already signed by the approver's device key. The
+   * runtime ALSO appends a durable `ApprovalApproved`/`ApprovalDenied`
+   * audit event carrying the signed decision regardless of this sink;
+   * this callback is for surfaces that want the artifact live (e.g. to
+   * render or anchor it). See `docs/doctrine/receipts-unified.md`.
+   */
+  onApprovalDecision?: (decision: import("@motebit/crypto").ApprovalDecision) => void;
+  /**
    * Optional live-activity sink for tool calls — delivers the raw args
    * + result bytes alongside the structured event at the same moment
    * the receipt is signed. Intended for surfaces that render *what the

--- a/packages/runtime/src/streaming.ts
+++ b/packages/runtime/src/streaming.ts
@@ -18,7 +18,8 @@ import type { AgenticChunk, TurnResult } from "@motebit/ai-core";
 import { extractStateTags, runTurnStreaming } from "@motebit/ai-core";
 import type { MotebitLoopDependencies } from "@motebit/ai-core";
 import type { SignableToolInvocationReceipt } from "@motebit/crypto";
-import { signToolInvocationReceipt, hashToolPayload } from "@motebit/crypto";
+import { signToolInvocationReceipt, hashToolPayload, signApprovalDecision } from "@motebit/crypto";
+import type { ApprovalDecision } from "@motebit/crypto";
 import type { StreamChunk } from "./runtime-config.js";
 
 // Re-import the helper — it's file-local in index.ts, so we duplicate it here.
@@ -150,6 +151,18 @@ export interface StreamingDeps {
    */
   onToolInvocation?: (receipt: SignableToolInvocationReceipt) => void;
   /**
+   * Sink for a signed human-consent decision over a governance-gated tool call.
+   * Fires once per FINAL approval verdict (single-approver, deny, or quorum-met)
+   * at the resolution point in `resumeAfterApproval`, with the
+   * `ApprovalDecision` already signed by the approver's device key via
+   * `signApprovalDecision`. This is the "approve" governance band made
+   * verifiable — the sibling of the `ToolInvocationReceipt` (auto band) and the
+   * agent-signed denied `ExecutionReceipt` (deny band). The runtime wires this
+   * to a durable audit record; subscribers MUST NOT mutate the decision (frozen
+   * by the signer) or block the generator — fire-and-forget, exceptions logged.
+   */
+  onApprovalDecision?: (decision: ApprovalDecision) => void;
+  /**
    * Sink for live tool-invocation activity — the raw args + result
    * bytes the receipt's `args_hash` / `result_hash` commit to. Fires
    * at the same point as `onToolInvocation`, with a payload shaped
@@ -199,6 +212,10 @@ interface PendingApproval {
   userMessage: string;
   runId?: string;
   quorum?: { required: number; approvers: string[]; collected: string[] };
+  /** RiskLevel numeric that triggered the gate — bound into the signed consent decision. */
+  riskLevel?: number;
+  /** Unix ms when the gate fired (the approval was requested). */
+  requestedAt: number;
 }
 
 export class StreamingManager {
@@ -418,6 +435,8 @@ export class StreamingManager {
           userMessage,
           runId,
           quorum: chunk.quorum,
+          riskLevel: chunk.risk_level,
+          requestedAt: Date.now(),
         };
 
         // Persist quorum metadata to the approval store (source of truth)
@@ -507,6 +526,12 @@ export class StreamingManager {
     this.deps.setSpeaking(true);
 
     try {
+      // Record the human's consent as a signed, offline-verifiable decision
+      // BEFORE acting on it — the "approve" governance band made provable, the
+      // sibling of the agent-signed refusal receipt. Best-effort: a signing
+      // failure must never block the actual resume.
+      await this.signAndEmitApprovalDecision(pending, approved);
+
       if (approved) {
         // Execute the tool directly
         yield { type: "tool_status" as const, name: pending.toolName, status: "calling" as const };
@@ -565,6 +590,60 @@ export class StreamingManager {
       this.deps.setSpeaking(false);
       this.deps.pushStateUpdate({ processing: 0.1, attention: 0.3 });
       this._isProcessing = false;
+    }
+  }
+
+  /**
+   * Build, sign, and emit the human-consent decision for a resolved approval.
+   * Signed by the APPROVER's device key — consent is the approver's own
+   * assertion, mirroring how the worker signs its own refusal. Commits to
+   * `args_hash` (never raw args), the gated `approval_id` (= tool_call_id), the
+   * verdict, and the requested/resolved timestamps, so a third party can verify
+   * offline that this approver consented to THIS call at THIS time.
+   *
+   * Best-effort and fail-open on the AUDIT side only: if the signing material
+   * is absent (no device key wired) or signing throws, the resume still
+   * proceeds — the decision artifact is an audit record layered on top of the
+   * already-enforced gate, not the gate itself. Mirrors `onToolInvocation`.
+   */
+  private async signAndEmitApprovalDecision(
+    pending: PendingApproval,
+    approved: boolean,
+  ): Promise<void> {
+    const sink = this.deps.onApprovalDecision;
+    if (!sink) return;
+    const deviceId = this.deps.getDeviceId?.() ?? null;
+    const privateKey = this.deps.getSigningPrivateKey?.() ?? null;
+    const publicKey = this.deps.getSigningPublicKey?.() ?? null;
+    if (!deviceId || !privateKey || !this.deps.motebitId) return;
+
+    try {
+      const argsHash = await hashToolPayload(pending.args);
+      const unsigned: Omit<ApprovalDecision, "signature" | "suite"> = {
+        approval_id: pending.toolCallId,
+        motebit_id: this.deps.motebitId,
+        device_id: deviceId,
+        tool_name: pending.toolName,
+        args_hash: argsHash,
+        risk_level: pending.riskLevel ?? 0,
+        verdict: approved ? "approved" : "denied",
+        requested_at: pending.requestedAt,
+        resolved_at: Date.now(),
+        ...(approved ? {} : { denied_reason: "User denied this tool call." }),
+        ...(pending.runId != null ? { run_id: pending.runId } : {}),
+      };
+      const signed = await signApprovalDecision(unsigned, privateKey, publicKey ?? undefined);
+      try {
+        sink(signed);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        // eslint-disable-next-line no-console -- diagnostic on consumer fault
+        console.warn(`[streaming] onApprovalDecision sink threw: ${msg}`);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // eslint-disable-next-line no-console -- diagnostic on signing fault
+      console.warn(`[streaming] failed to sign approval decision: ${msg}`);
     }
   }
 

--- a/scripts/check-signed-artifact-verifiers.ts
+++ b/scripts/check-signed-artifact-verifiers.ts
@@ -106,6 +106,7 @@ export const REGISTRY: Record<string, Classification> = {
   ComputerSessionReceipt: { kind: "verifier", verifier: "verifyComputerSessionReceipt" },
   CredentialAnchorProof: { kind: "verifier", verifier: "verifyCredentialAnchor" },
   AdjudicatorVote: { kind: "verifier", verifier: "verifyAdjudicatorVote" },
+  ApprovalDecision: { kind: "verifier", verifier: "verifyApprovalDecision" },
   DisputeAppeal: { kind: "verifier", verifier: "verifyDisputeAppeal" },
   DisputeEvidence: { kind: "verifier", verifier: "verifyDisputeEvidence" },
   DisputeRequest: { kind: "verifier", verifier: "verifyDisputeRequest" },


### PR DESCRIPTION
## Signed approval/consent decisions — the "approve" governance band made verifiable

Interactive approval pause/resume already existed (`streaming.ts` `resumeAfterApproval`/`resolveApprovalVote` across web/desktop/mobile/spatial, with quorum + timeout + a durable daemon path). The gap was that the consent **decision itself** was unsigned — a plaintext `approval_queue` row + event, with mid-turn denial injected as the literal string `"User denied this tool call."` This left the governance triad asymmetric.

### The governance triad, now symmetric

| Band | Trigger | Verifiable artifact | Signer |
|---|---|---|---|
| **auto** | risk ≤ `require_approval_above` | `ToolInvocationReceipt` | agent |
| **approve** | `require_approval_above < risk ≤ deny_above` | **`ApprovalDecision` (new)** | **approver's device** |
| **deny** | risk > `deny_above` | `ExecutionReceipt{status:"denied"}` (refusal path, #139) | agent |

Proof of permission before action — the approve band was the only one whose decision wasn't cryptographically provable.

### Changes

- **`@motebit/protocol`** — new `ApprovalDecision` interface (JCS + Ed25519 signed-artifact family). Commits to `approval_id` (the gated `tool_call_id`, bound so a verdict is non-portable), `args_hash` (never raw args — same privacy discipline as `ToolInvocationReceipt`), `risk_level`, `verdict`, and requested/resolved timestamps.
- **`@motebit/crypto`** — `signApprovalDecision` / `verifyApprovalDecision` (+ `APPROVAL_DECISION_SUITE`), mirroring `signAdjudicatorVote` and embedding the approver's `public_key` for offline verification. Registered in `check-signed-artifact-verifiers`.
- **`@motebit/runtime`** — `resumeAfterApproval` produces and signs the decision with the **approver's** device key (consent is the approver's own assertion, the way the worker signs its own refusal) for every final verdict — single-approver, deny, and quorum-met. Delivered via a new `onApprovalDecision` sink and buffered in `getRecentApprovalDecisions()` — the exact buffer + forward shape as `onToolInvocation`.

### Principal-engineer review (pre-commit)

Caught and fixed one real issue: the first cut had the runtime append an `ApprovalApproved`/`ApprovalDenied` event-log entry, which deviated from the `onToolInvocation` sink contract **and double-emitted** against the CLI daemon's existing goal-audit event (`scheduler.ts:891`). No consumer counts those events (grep clean), so not a live bug — but a coherence smell. Reworked to mirror `onToolInvocation` exactly (sink + buffer, no event append). Durable cross-restart archival is a deferred consumer-forced surface, the same sequencing the refusal path used for retrieval.

### Tests

- 7 crypto: roundtrip / offline-verify / non-portability (`approval_id` + `args_hash`) / verdict-tamper / wrong-key / unknown-suite.
- 3 runtime streaming: approved + denied emit a signed decision verifying offline; buffered in `getRecentApprovalDecisions()`.

All 110 drift gates pass · pre-push coverage suite green · API baselines regenerated · changesets split published/ignored · doctrine (`receipts-unified.md`) updated.

### Deferred (consumer-forced shape)

Durable cross-restart archival + dedicated retrieval surface; per-quorum-vote signing; signing the timeout-expiry auto-deny. Minor known gap: legacy approval path (no policy gate) signs `risk_level: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
