### PR TITLE
feat(verifier,docs): surface ApprovalDecision for cold consumers — close governance-triad discoverability gaps

### DIFF
--- a/.changeset/governance-triad-consumer-surfacing.md
+++ b/.changeset/governance-triad-consumer-surfacing.md
@@ -1,0 +1,13 @@
+---
+"@motebit/verifier": minor
+"@motebit/verify": patch
+---
+
+Surface `ApprovalDecision` verification for browser/library consumers — close the cold-consume gaps an external integrator hit.
+
+A cold consume of the just-shipped governance triad (an outside developer using only public docs + npm) found the approve-band artifact was real but undiscoverable: the docs pointed browser users to `@motebit/verifier`, which didn't expose approval verification, and the `@motebit/verify` README never mentioned it — so the capability looked absent when it was only unsurfaced.
+
+- `@motebit/verifier`: re-export `verifyApprovalDecision` (+ the `ApprovalDecision` type) from the browser-safe `@motebit/crypto` primitive, so consumers already depending on this library can verify a human-consent decision client-side without adding a second dependency.
+- `@motebit/verify`: README now documents the `approval-decision` subcommand, the governance triad (approve/deny/auto), the **browser path** (`import { verifyApprovalDecision } from "@motebit/crypto"`), and a `verify` vs `verifier` vs `crypto` disambiguation — plus the honest framing that a verified `ApprovalDecision` is signature-authentic against a _pinned_ approver key, not authority-bound (verifying against the embedded key alone is circular).
+
+Paired with a non-published canonical `ApprovalDecision` fixture (+ published approver key) and a new `developer/governance-triad` doc page covering where a verified decision sits on the binding ladder.

--- a/apps/docs/content/docs/developer/governance-triad.mdx
+++ b/apps/docs/content/docs/developer/governance-triad.mdx
@@ -33,7 +33,18 @@ It reports the signature's validity and binding rung. A `denied` receipt that ve
 
 ## Verify a consent decision (approve band)
 
-An `ApprovalDecision` carries the approver's embedded `public_key`, so it verifies self-contained, offline:
+Two real, signed fixtures to verify — one per verdict (both reproducible from [`mint-approval-decision-fixture.mjs`](https://github.com/motebit/motebit/blob/main/examples/python-receipt-verifier/fixtures/mint-approval-decision-fixture.mjs)):
+
+- [`approval-decision-approved.json`](https://raw.githubusercontent.com/motebit/motebit/main/examples/python-receipt-verifier/fixtures/approval-decision-approved.json)
+- [`approval-decision-denied.json`](https://raw.githubusercontent.com/motebit/motebit/main/examples/python-receipt-verifier/fixtures/approval-decision-denied.json)
+
+**Canonical demo approver public key** (pin this — see [What a verified `ApprovalDecision` proves](#what-a-verified-approvaldecision-proves) for why you must not trust the embedded key alone):
+
+```
+e7f162a10bec559afea195e4dce84b69568d5d2cb0963eb446c0685e2b17f2f0
+```
+
+### Command line
 
 ```bash
 motebit-verify approval-decision decision.json
@@ -63,13 +74,50 @@ motebit-verify approval-decision decision.json --producer-key 6f1c8e2b...
 motebit-verify approval-decision decision.json --expect-verdict approved
 ```
 
+Exit codes match the rest of the CLI: `0` verified, `1` detected-but-invalid, `2` usage/IO.
+
+### In the browser (no server)
+
+`ApprovalDecision` verifies client-side with **`@motebit/crypto`** — zero dependencies, no `node:` imports, browser-safe (the same permissive-floor primitive that backs sovereign-receipt verification). There is no server in this path:
+
+```ts
+import { verifyApprovalDecision, hexToBytes } from "@motebit/crypto";
+
+// Pin the CANONICAL approver key — do NOT verify against decision.public_key
+// alone (that is circular; see below). For the demo fixtures, the canonical key
+// is published above.
+const CANONICAL_APPROVER_KEY =
+  "e7f162a10bec559afea195e4dce84b69568d5d2cb0963eb446c0685e2b17f2f0";
+
+const ok = await verifyApprovalDecision(decision, hexToBytes(CANONICAL_APPROVER_KEY));
+// ok === true  → signature-authentic against the canonical approver key
+```
+
+> `@motebit/verify` (the CLI) and `@motebit/verifier` (the file/format library) are sibling packages; the low-level `verifyApprovalDecision` primitive lives in `@motebit/crypto` and is what both build on. For a browser, import from `@motebit/crypto` directly.
+
 What the signature commits to — and why it can't be replayed:
 
 - **`approval_id`** is the gated call's id, inside the signed body. A verdict can't be lifted onto a different call without breaking the signature.
 - **`args_hash`** is the SHA-256 of the canonical arguments — never the raw args. Consent binds to the exact call the human saw; a verifier who holds the raw args recomputes and matches, and one who holds only the decision still proves a verdict was rendered over *some* call at *some* time. (No sensitive argument data sits in the signed artifact.)
 - **`verdict`** (`approved` / `denied`) is signed; flipping it fails verification.
 
-Exit codes match the rest of the CLI: `0` verified, `1` detected-but-invalid, `2` usage/IO.
+### What a verified `ApprovalDecision` proves
+
+Read this before you render an `ApprovalDecision` as a trust signal — it does **not** carry the same authority a sovereign `ExecutionReceipt` does.
+
+`verifyApprovalDecision(decision, key)` proves the decision was **signed by whoever holds `key`, untampered** — *signature-authentic*. It does **not** prove that `key` has any authority to approve. Unlike a sovereign `ExecutionReceipt` — where `motebit_id` is *derived from* the signing key, so the key's authority is self-proving offline — an `ApprovalDecision` carries **no `motebit_id → key` commitment**. The approver is a separate party (the human/owner's device), and nothing inside the artifact binds that device to a legitimate role.
+
+The consequence, and the rule: **verifying against the decision's own embedded `public_key` is circular** — the decision says "I'm signed by K" and you confirm it's signed by K, which proves nothing about who K is. To get a real signal, **pin an independently-known approver key** (the canonical demo key above; in production, a device key from the motebit's identity file) via `--producer-key` / the `key` argument, and confirm the decision verifies against *that*.
+
+Where a verified `ApprovalDecision` sits on the [binding ladder](/docs/developer/choosing-a-verify-surface):
+
+| Check | Rung | Honest label |
+| --- | --- | --- |
+| verifies against its embedded key only | **integrity-only** | "signature valid" (says nothing about the approver) |
+| verifies against an independently-pinned approver key | **pinned** | "approver-signed ✓ (offline)" |
+| approver device proven a registered device of the motebit | *future rung* | requires the motebit's identity file — not wired today |
+
+So: render a pinned `ApprovalDecision` as **"approver-signed ✓ (offline)"**, never as **"sovereign."** Authority-binding the approver device to the motebit's registered devices is a future rung; today the honest claim is signature-authenticity against a key you pinned.
 
 ## Verify an auto-band proof (auto band)
 

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -3328,7 +3328,18 @@ It reports the signature's validity and binding rung. A `denied` receipt that ve
 
 ## Verify a consent decision (approve band)
 
-An `ApprovalDecision` carries the approver's embedded `public_key`, so it verifies self-contained, offline:
+Two real, signed fixtures to verify — one per verdict (both reproducible from [`mint-approval-decision-fixture.mjs`](https://github.com/motebit/motebit/blob/main/examples/python-receipt-verifier/fixtures/mint-approval-decision-fixture.mjs)):
+
+- [`approval-decision-approved.json`](https://raw.githubusercontent.com/motebit/motebit/main/examples/python-receipt-verifier/fixtures/approval-decision-approved.json)
+- [`approval-decision-denied.json`](https://raw.githubusercontent.com/motebit/motebit/main/examples/python-receipt-verifier/fixtures/approval-decision-denied.json)
+
+**Canonical demo approver public key** (pin this — see [What a verified `ApprovalDecision` proves](#what-a-verified-approvaldecision-proves) for why you must not trust the embedded key alone):
+
+```
+e7f162a10bec559afea195e4dce84b69568d5d2cb0963eb446c0685e2b17f2f0
+```
+
+### Command line
 
 ```bash
 motebit-verify approval-decision decision.json
@@ -3358,13 +3369,50 @@ motebit-verify approval-decision decision.json --producer-key 6f1c8e2b...
 motebit-verify approval-decision decision.json --expect-verdict approved
 ```
 
+Exit codes match the rest of the CLI: `0` verified, `1` detected-but-invalid, `2` usage/IO.
+
+### In the browser (no server)
+
+`ApprovalDecision` verifies client-side with **`@motebit/crypto`** — zero dependencies, no `node:` imports, browser-safe (the same permissive-floor primitive that backs sovereign-receipt verification). There is no server in this path:
+
+```ts
+import { verifyApprovalDecision, hexToBytes } from "@motebit/crypto";
+
+// Pin the CANONICAL approver key — do NOT verify against decision.public_key
+// alone (that is circular; see below). For the demo fixtures, the canonical key
+// is published above.
+const CANONICAL_APPROVER_KEY =
+  "e7f162a10bec559afea195e4dce84b69568d5d2cb0963eb446c0685e2b17f2f0";
+
+const ok = await verifyApprovalDecision(decision, hexToBytes(CANONICAL_APPROVER_KEY));
+// ok === true  → signature-authentic against the canonical approver key
+```
+
+> `@motebit/verify` (the CLI) and `@motebit/verifier` (the file/format library) are sibling packages; the low-level `verifyApprovalDecision` primitive lives in `@motebit/crypto` and is what both build on. For a browser, import from `@motebit/crypto` directly.
+
 What the signature commits to — and why it can't be replayed:
 
 - **`approval_id`** is the gated call's id, inside the signed body. A verdict can't be lifted onto a different call without breaking the signature.
 - **`args_hash`** is the SHA-256 of the canonical arguments — never the raw args. Consent binds to the exact call the human saw; a verifier who holds the raw args recomputes and matches, and one who holds only the decision still proves a verdict was rendered over *some* call at *some* time. (No sensitive argument data sits in the signed artifact.)
 - **`verdict`** (`approved` / `denied`) is signed; flipping it fails verification.
 
-Exit codes match the rest of the CLI: `0` verified, `1` detected-but-invalid, `2` usage/IO.
+### What a verified `ApprovalDecision` proves
+
+Read this before you render an `ApprovalDecision` as a trust signal — it does **not** carry the same authority a sovereign `ExecutionReceipt` does.
+
+`verifyApprovalDecision(decision, key)` proves the decision was **signed by whoever holds `key`, untampered** — *signature-authentic*. It does **not** prove that `key` has any authority to approve. Unlike a sovereign `ExecutionReceipt` — where `motebit_id` is *derived from* the signing key, so the key's authority is self-proving offline — an `ApprovalDecision` carries **no `motebit_id → key` commitment**. The approver is a separate party (the human/owner's device), and nothing inside the artifact binds that device to a legitimate role.
+
+The consequence, and the rule: **verifying against the decision's own embedded `public_key` is circular** — the decision says "I'm signed by K" and you confirm it's signed by K, which proves nothing about who K is. To get a real signal, **pin an independently-known approver key** (the canonical demo key above; in production, a device key from the motebit's identity file) via `--producer-key` / the `key` argument, and confirm the decision verifies against *that*.
+
+Where a verified `ApprovalDecision` sits on the [binding ladder](/docs/developer/choosing-a-verify-surface):
+
+| Check | Rung | Honest label |
+| --- | --- | --- |
+| verifies against its embedded key only | **integrity-only** | "signature valid" (says nothing about the approver) |
+| verifies against an independently-pinned approver key | **pinned** | "approver-signed ✓ (offline)" |
+| approver device proven a registered device of the motebit | *future rung* | requires the motebit's identity file — not wired today |
+
+So: render a pinned `ApprovalDecision` as **"approver-signed ✓ (offline)"**, never as **"sovereign."** Authority-binding the approver device to the motebit's registered devices is a future rung; today the honest claim is signature-authenticity against a key you pinned.
 
 ## Verify an auto-band proof (auto band)
 

--- a/examples/python-receipt-verifier/fixtures/approval-decision-approved.json
+++ b/examples/python-receipt-verifier/fixtures/approval-decision-approved.json
@@ -1,0 +1,15 @@
+{
+  "approval_id": "019dc500-0000-7000-b000-000000000a01",
+  "motebit_id": "65b60673-d6ed-884b-b01c-2c222d82ada0",
+  "device_id": "019dc500-0000-7000-b000-0000000000ap",
+  "tool_name": "send_email",
+  "args_hash": "d991d7790b5494706f5a129e5bd9ba2fdb47b9cb784dfb019e530f5c99b49956",
+  "risk_level": 2,
+  "verdict": "approved",
+  "requested_at": 1777109100000,
+  "resolved_at": 1777109142000,
+  "run_id": "019dc500-0000-7000-b000-000000000r01",
+  "public_key": "e7f162a10bec559afea195e4dce84b69568d5d2cb0963eb446c0685e2b17f2f0",
+  "suite": "motebit-jcs-ed25519-b64-v1",
+  "signature": "XJ-YQ1EpODEp-2urVuZRhdCKBgIQPsuFgMLu5nTO1mmqA4X4zN1ohCkZzYVA44hR9acASw_nA_KaoxmmtMq3BA"
+}

--- a/examples/python-receipt-verifier/fixtures/approval-decision-denied.json
+++ b/examples/python-receipt-verifier/fixtures/approval-decision-denied.json
@@ -1,0 +1,16 @@
+{
+  "approval_id": "019dc500-0000-7000-b000-000000000d01",
+  "motebit_id": "65b60673-d6ed-884b-b01c-2c222d82ada0",
+  "device_id": "019dc500-0000-7000-b000-0000000000ap",
+  "tool_name": "send_payment",
+  "args_hash": "344b06e445ae75ebfa5cf525bbc9a92996776501e26b526663341eff3316d87a",
+  "risk_level": 4,
+  "verdict": "denied",
+  "requested_at": 1777109200000,
+  "resolved_at": 1777109230000,
+  "denied_reason": "Above the owner's approval ceiling — declined.",
+  "run_id": "019dc500-0000-7000-b000-000000000r02",
+  "public_key": "e7f162a10bec559afea195e4dce84b69568d5d2cb0963eb446c0685e2b17f2f0",
+  "suite": "motebit-jcs-ed25519-b64-v1",
+  "signature": "7PacGSFKlpeynqWXvzMxj2KkMQdSFCSE9tekkFMOLb5FO6ibY--7pLk2YinGmlRuntGQM0cXshxCxzI28EQ1Dw"
+}

--- a/examples/python-receipt-verifier/fixtures/mint-approval-decision-fixture.mjs
+++ b/examples/python-receipt-verifier/fixtures/mint-approval-decision-fixture.mjs
@@ -1,0 +1,116 @@
+/**
+ * Regenerates the canonical `approval-decision-*.json` fixtures — real, signed
+ * human-consent decisions (the "approve" governance band) for demos, evals, and
+ * cold-consume tests.
+ *
+ * Provenance over magic (this is a proof brand): the approver key is a FIXED,
+ * PUBLIC seed below — DISTINCT from the agent/executor seed used by
+ * `mint-sovereign-fixture.mjs`, because the approver (the human consenting) is a
+ * different party from the agent whose action is gated. Anyone can re-run this
+ * and reproduce the byte-identical signed decisions. Signed through the
+ * canonical `signApprovalDecision` from @motebit/crypto — never a hand-rolled
+ * signer.
+ *
+ *   node mint-approval-decision-fixture.mjs   # from this dir, after `pnpm build` of crypto
+ *
+ * IMPORTANT — what a verified ApprovalDecision proves (read before rendering it):
+ * unlike a sovereign ExecutionReceipt, `motebit_id` does NOT commit to the
+ * approver's key. So `verifyApprovalDecision(decision, key)` proves the decision
+ * was signed by whoever holds `key` and is untampered (signature-authentic) — it
+ * does NOT prove that key has authority. To verify HONESTLY, pin the CANONICAL
+ * APPROVER PUBLIC KEY printed below (do not trust the embedded `public_key`
+ * alone — that is circular). See docs/developer/governance-triad.mdx
+ * § "What a verified ApprovalDecision proves."
+ */
+import * as ed from "@noble/ed25519";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { bytesToHex } from "@noble/hashes/utils.js";
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+  deriveSovereignMotebitId,
+  signApprovalDecision,
+  verifyApprovalDecision,
+} from "@motebit/crypto";
+
+// PUBLIC demo APPROVER key — committed on purpose, distinct from the agent seed
+// (0x01..0x20 in mint-sovereign-fixture.mjs). This is the human owner's device
+// key that renders consent. Publish its public key so consumers pin against it.
+const APPROVER_SEED = new Uint8Array(32);
+for (let i = 0; i < 32; i++) APPROVER_SEED[i] = i + 33; // 0x21..0x40
+
+const approverPriv = APPROVER_SEED;
+const approverPub = await ed.getPublicKeyAsync(approverPriv);
+const approverPubHex = bytesToHex(approverPub);
+
+// The EXECUTOR (the agent whose gated action is being approved) is the same
+// sovereign demo agent as mint-sovereign-fixture.mjs (seed 0x01..0x20), so the
+// fixtures tell one coherent story: the owner consents to their agent's act.
+const AGENT_SEED = new Uint8Array(32);
+for (let i = 0; i < 32; i++) AGENT_SEED[i] = i + 1; // 0x01..0x20
+const agentPub = await ed.getPublicKeyAsync(AGENT_SEED);
+const motebitId = await deriveSovereignMotebitId(bytesToHex(agentPub));
+
+const sha = (s) => bytesToHex(sha256(new TextEncoder().encode(s)));
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/** One approval decision: approver consents to (or refuses) a gated tool call. */
+const cases = [
+  {
+    file: "approval-decision-approved.json",
+    body: {
+      approval_id: "019dc500-0000-7000-b000-000000000a01",
+      motebit_id: motebitId,
+      device_id: "019dc500-0000-7000-b000-0000000000ap",
+      tool_name: "send_email",
+      // SHA-256 of the canonical args the approver saw — never the raw args.
+      args_hash: sha('{"to":"vendor@example.com","subject":"Q3 contract"}'),
+      risk_level: 2,
+      verdict: "approved",
+      requested_at: 1777109100000,
+      resolved_at: 1777109142000,
+      run_id: "019dc500-0000-7000-b000-000000000r01",
+    },
+  },
+  {
+    file: "approval-decision-denied.json",
+    body: {
+      approval_id: "019dc500-0000-7000-b000-000000000d01",
+      motebit_id: motebitId,
+      device_id: "019dc500-0000-7000-b000-0000000000ap",
+      tool_name: "send_payment",
+      args_hash: sha('{"to":"0xX","amount_usd":4800}'),
+      risk_level: 4,
+      verdict: "denied",
+      requested_at: 1777109200000,
+      resolved_at: 1777109230000,
+      denied_reason: "Above the owner's approval ceiling — declined.",
+      run_id: "019dc500-0000-7000-b000-000000000r02",
+    },
+  },
+];
+
+for (const c of cases) {
+  const signed = await signApprovalDecision(c.body, approverPriv, approverPub);
+  // Self-verify against the canonical approver key before writing — refuse to
+  // emit anything that doesn't verify.
+  const ok = await verifyApprovalDecision(signed, approverPub);
+  if (!ok) {
+    console.error(`REFUSING TO WRITE ${c.file} — does not verify`);
+    process.exit(1);
+  }
+  // Tamper check: flipping the verdict must break the signature.
+  const tampered = { ...signed, verdict: signed.verdict === "approved" ? "denied" : "approved" };
+  if (await verifyApprovalDecision(tampered, approverPub)) {
+    console.error(`REFUSING TO WRITE ${c.file} — tamper did not break verification`);
+    process.exit(1);
+  }
+  writeFileSync(join(here, c.file), JSON.stringify(signed, null, 2) + "\n");
+  console.log(`OK ${c.verdict ?? c.body.verdict} → ${c.file}`);
+}
+
+console.log("");
+console.log("CANONICAL APPROVER PUBLIC KEY (pin this — do not trust the embedded key alone):");
+console.log("  " + approverPubHex);

--- a/packages/verifier/README.md
+++ b/packages/verifier/README.md
@@ -45,6 +45,8 @@ The unified `verify()` dispatcher in [`@motebit/crypto`](https://www.npmjs.com/p
 
 This package wraps the dispatcher with `verifyFile` (path → result), `verifyArtifact` (string → result), `verifySkillDirectory` (path-to-a-skill-directory → result, for skill bundles shipped as a tree rather than a single file), and `formatHuman` (result → printable banner).
 
+It also re-exports **`verifyApprovalDecision`** from `@motebit/crypto` — the "approve" governance band's signed human-consent artifact (`ApprovalDecision`). Unlike the auto-detected artifact types above, an `ApprovalDecision` is verified explicitly against a **pinned approver key** (it carries no `motebit_id → key` binding, so verifying against its own embedded key is circular). See [the governance-triad guide](https://docs.motebit.com/docs/developer/governance-triad) for where a verified decision sits on the binding ladder.
+
 ## Guarantees
 
 - **No network.** Verification runs entirely offline. No relay calls, no DID resolution over the wire.

--- a/packages/verifier/src/index.ts
+++ b/packages/verifier/src/index.ts
@@ -34,9 +34,17 @@
 
 export { verifyFile, verifyArtifact, verifySkillDirectory, formatHuman } from "./lib.js";
 export type { VerifyFileOptions, VerifyResultWithBinding } from "./lib.js";
+// Re-exported from the browser-safe `@motebit/crypto` primitive so consumers
+// already depending on this library can verify a human-consent decision (the
+// "approve" governance band) without adding a second dependency. `ApprovalDecision`
+// is NOT an auto-detected artifact type (it has no `motebit_id → key` binding
+// ladder — see docs/developer/governance-triad.mdx); it is verified explicitly
+// against a pinned approver key, never against its own embedded key alone.
+export { verifyApprovalDecision } from "@motebit/crypto";
 export type {
   VerifyResult,
   ArtifactType,
   SkillVerifyResult,
   SkillFileVerifyResult,
+  ApprovalDecision,
 } from "@motebit/crypto";

--- a/packages/verify/README.md
+++ b/packages/verify/README.md
@@ -52,7 +52,18 @@ motebit-verify <file> \
   --bundle-id com.example.app \
   --android-attestation-application-id ./app-id.bin \
   --rp-id example.com
+
+# Governance triad — verify a human-consent decision (the "approve" band)
+motebit-verify approval-decision decision.json
+motebit-verify approval-decision decision.json --producer-key <hex>   # pin the approver
+motebit-verify approval-decision decision.json --expect-verdict approved
 ```
+
+### The governance triad — approve / deny / auto
+
+`motebit-verify approval-decision <file>` verifies a signed `ApprovalDecision` — **proof of permission before a gated act** (the "approve" band). The deny band (`ExecutionReceipt{status:"denied"}`) and auto band (`ToolInvocationReceipt`) verify through the ordinary receipt path. A verified `ApprovalDecision` is **signature-authentic against a key you pin, not authority-bound** — pin the approver with `--producer-key`; verifying against the embedded key alone is circular. Full model, the binding-ladder placement, and the **browser path** (`import { verifyApprovalDecision } from "@motebit/crypto"` — zero-dep, no server): see [the governance-triad guide](https://docs.motebit.com/docs/developer/governance-triad).
+
+> **`@motebit/verify` vs `@motebit/verifier` vs `@motebit/crypto`.** This package (`verify`) is the **CLI binary** a human installs. [`@motebit/verifier`](https://www.npmjs.com/package/@motebit/verifier) is the **browser-safe library** (file I/O + formatting; also re-exports `verifyApprovalDecision`). [`@motebit/crypto`](https://www.npmjs.com/package/@motebit/crypto) is the **zero-dependency primitive** that carries the actual verify/sign functions — import it directly for browser/client-side verification.
 
 **Verifying `android_keystore` credentials requires `--android-attestation-application-id`.** The flag's value is a path to a binary file containing the raw bytes of the leaf cert's `attestationApplicationId` extension — operators capture this once at build time (deterministic from the registered Android package name + signing-cert SHA-256) and commit the file alongside other pinned config. Without the flag, the Android Keystore arm is intentionally unwired (passing a placeholder would false-reject every real claim); the dispatcher reports `"verifier not wired"`.
 

--- a/scripts/check-receipt-conformance.ts
+++ b/scripts/check-receipt-conformance.ts
@@ -49,12 +49,31 @@ async function main(): Promise<void> {
   const failures: string[] = [];
   const note = (m: string) => console.log(`  ${m}`);
 
-  const fixtures = readdirSync(fixturesDir)
-    .filter((f) => f.endsWith(".json"))
-    .sort();
+  // Scope to ExecutionReceipt fixtures only — this gate checks cross-impl
+  // RECEIPT conformance. The fixtures dir also holds other signed-artifact
+  // vectors (e.g. approval-decision-*.json, the "approve" governance band),
+  // which are a different shape verified by their own primitive
+  // (verifyApprovalDecision against a pinned approver key), not the receipt
+  // verifiers swept here. Shape-detect (task_id + result_hash) rather than
+  // name-match so a future non-receipt fixture can't silently re-break this gate.
+  const isReceiptFixture = (f: string): boolean => {
+    if (!f.endsWith(".json")) return false;
+    try {
+      const o = JSON.parse(readFileSync(join(fixturesDir, f), "utf8")) as Record<string, unknown>;
+      return typeof o.task_id === "string" && typeof o.result_hash === "string";
+    } catch {
+      return false;
+    }
+  };
+  const allJson = readdirSync(fixturesDir).filter((f) => f.endsWith(".json"));
+  const fixtures = allJson.filter(isReceiptFixture).sort();
+  const skipped = allJson.length - fixtures.length;
 
   console.log(
-    `▸ check-receipt-conformance — ${fixtures.length} vectors × {verifier, crypto, state-export-client, python}`,
+    `▸ check-receipt-conformance — ${fixtures.length} receipt vectors × {verifier, crypto, state-export-client, python}` +
+      (skipped > 0
+        ? ` (${skipped} non-receipt fixture(s) excluded — verified by their own primitives)`
+        : ""),
   );
 
   // Python availability (best-effort unless REQUIRE_PYTHON=1).


### PR DESCRIPTION
## Governance triad: close the cold-consume discoverability gaps

A true cold consume of the just-shipped governance triad — an outside developer (the agency.computer PE agent) using **only public docs + npm, no insider help** — found the approve-band artifact (`ApprovalDecision`) was real but undiscoverable. This closes the gaps it surfaced, plus the honesty correction the consume forced.

### What the cold consume found
- Docs pointed browser users to `@motebit/verifier`, which didn't expose approval verification → capability looked absent when it was only unsurfaced.
- `@motebit/verify`'s README never mentioned the `approval-decision` verb.
- No canonical fixture to consume byte-identical (the pattern every other fixture uses).
- **The sharpest catch:** `verifyApprovalDecision(decision, key)` takes a *supplied* key, and `ApprovalDecision` carries no `motebit_id → key` commitment — so a verified decision is **signature-authentic, not authority-bound**. Verifying against its own embedded key is *circular*. The docs didn't say so, so an outsider could render a circular "approver-signed ✓" — theater in a new costume.

### Changes
- **examples:** canonical `approval-decision-approved.json` + `-denied.json` fixtures + `mint-approval-decision-fixture.mjs` (committed PUBLIC approver seed, *distinct* from the agent seed; self-verify + tamper-check before write). **Canonical approver key published** so consumers pin it: `e7f162a1…2b17f2f0`.
- **`@motebit/verifier`:** re-export `verifyApprovalDecision` (+ `ApprovalDecision` type) from the browser-safe `@motebit/crypto` primitive; README documents it.
- **`@motebit/verify`:** README documents the `approval-decision` subcommand, the triad, the browser path (`import { verifyApprovalDecision } from "@motebit/crypto"` — zero-dep, no server), and a `verify`/`verifier`/`crypto` disambiguation.
- **docs (`developer/governance-triad`):** browser path, the canonical key to pin, and a **"What a verified `ApprovalDecision` proves"** section placing it on the binding ladder (integrity-only → pinned; **sovereign unreachable**; device-registration a future rung). Render it "approver-signed ✓ (offline)", never "sovereign."

### Verification
Smoke-tested the non-circular path: pinned-verify ✓, embedded==canonical ✓, tamper-rejected ✓. All 110 drift gates pass; `@motebit/verifier` 40 + `@motebit/verify` 48 tests pass.

Fixtures + doc are non-published → live on `main` at merge, consumable immediately via the already-published `@motebit/crypto@3.1.0`. Verifier re-export + READMEs ship next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
