### PR TITLE
docs(doctrine): promotion playbook reconciles ignore-era changeset pile-up

### DIFF
--- a/docs/doctrine/promoting-private-to-public.md
+++ b/docs/doctrine/promoting-private-to-public.md
@@ -61,7 +61,18 @@ Three doc surfaces drift in step here. All must move:
 
 If wraps in `<ReferenceExample>` referenced this package, unwrap them now. Replace with plain `import` statements naming the now-public package. Run `pnpm check-doc-private-imports` and `pnpm tsx scripts/audit-doc-imports-vs-sdk.ts` to confirm both report clean.
 
-### 7. Land a `major` changeset
+### 7. Reconcile the `ignore`-era changeset pile-up, then land a `major` changeset
+
+**First, clear the accumulated changesets.** While a package sits in `.changeset/config.json`'s `ignore` list, `changeset version` never consumes the changesets that bump it — they accumulate indefinitely (the day this was written, ignored libs carried up to ~9 lingering changesets each; apps far more). The moment you remove the package from `ignore`, the **next** `changeset version` consumes **all** of them at once: a first published changelog polluted with stale entries describing private-era churn, and a bump level derived from changes made before anyone could install it. So before promoting:
+
+```bash
+# Find every pending changeset that bumps the package being promoted.
+grep -l '"@motebit/<pkg>"' .changeset/*.md
+```
+
+Delete or rewrite them deliberately. The honest default is to **delete** the private-era ones (the `## Migration` "you couldn't install it → you can" in the `major` below is the real v1.0.0 changelog entry; the private churn is not a public-version event). Keep one only if it describes a change a v1.0.0 consumer genuinely needs to know. This is the step the playbook is easy to skip — `changeset version` won't warn you; it will just silently fold the pile-up into the first release.
+
+**Then land the `major`:**
 
 ```bash
 pnpm changeset


### PR DESCRIPTION
## Promotion playbook: reconcile the `ignore`-era changeset pile-up

Surfaced while auditing changeset state after the #138 release. A "stuck releases" flag turned out to be a false alarm (the lingering changesets are all for `ignore`-listed packages; `changeset status` confirmed only `verify`/`verifier` release next) — but the audit found a **real gap in the promotion doctrine**.

### The gap

While a package sits in `.changeset/config.json`'s `ignore` list, `changeset version` never consumes the changesets that bump it — they accumulate indefinitely (today: ignored libs carry up to ~9 each; `runtime` 27, `relay` 25). The moment a package is removed from `ignore` to promote it, the **next** `changeset version` folds **all** of them into the first published release: a v1.0.0 changelog polluted with private-era churn, and a bump level derived from changes made before anyone could install it. `changeset version` gives no warning — it just silently folds them in.

The 7-step `promoting-private-to-public` playbook told you to land a `major` changeset but never to clear the pile-up first.

### The fix

Step 7 now leads with reconciliation — `grep -l '"@motebit/<pkg>"' .changeset/*.md`, delete the private-era ones (the `major`'s Migration section is the real v1.0.0 entry), *then* land the major. Kept the playbook at 7 steps (the count is referenced in the root `CLAUDE.md` index) by folding reconciliation into step 7 rather than adding an eighth.

Doc-only; all 110 drift gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
