### PR TITLE
feat(examples,docs): paired full-governance-triad fixture set — the linked triad

### DIFF
--- a/apps/docs/content/docs/developer/governance-triad.mdx
+++ b/apps/docs/content/docs/developer/governance-triad.mdx
@@ -131,6 +131,45 @@ const ok = await verifyToolInvocationReceipt(receipt, signerPublicKeyBytes);
 
 Like the others it commits to `args_hash` / `result_hash` rather than raw bytes, so the proof is independently checkable without exposing tool inputs or outputs.
 
+## The full triad, as one linked story
+
+The individual fixtures above each prove one band. A **paired set** proves the bands *connect* — that the human's consent and the agent's execution are the same act, not two unrelated cards. One sovereign demo agent (`motebit_id` commits to its key) and the canonical approver, with real correlators (reproducible from [`mint-triad-fixture.mjs`](https://github.com/motebit/motebit/blob/main/examples/python-receipt-verifier/fixtures/mint-triad-fixture.mjs)):
+
+| Fixture | Band | Signed by | Links by |
+| --- | --- | --- | --- |
+| [`triad-approval-decision.json`](https://raw.githubusercontent.com/motebit/motebit/main/examples/python-receipt-verifier/fixtures/triad-approval-decision.json) | approve (consent) | approver key | `run_id` = T, `args_hash` = H, `approval_id` = C |
+| [`triad-tool-invocation-receipt.json`](https://raw.githubusercontent.com/motebit/motebit/main/examples/python-receipt-verifier/fixtures/triad-tool-invocation-receipt.json) | approve (executed call) | agent (sovereign) | `task_id` = T, `args_hash` = H, `invocation_id` = C |
+| [`triad-execution-receipt.json`](https://raw.githubusercontent.com/motebit/motebit/main/examples/python-receipt-verifier/fixtures/triad-execution-receipt.json) | approve (task) | agent (sovereign) | `task_id` = T |
+| [`triad-deny-receipt.json`](https://raw.githubusercontent.com/motebit/motebit/main/examples/python-receipt-verifier/fixtures/triad-deny-receipt.json) | deny | agent (sovereign) | distinct `task_id` = D, `status: "denied"` |
+
+The linkage is the point, and it is **cryptographic, not asserted**:
+
+- **`args_hash` (H)** is identical on the `ApprovalDecision` and the `ToolInvocationReceipt` — the human consented to the *exact* call that ran. Different bytes → different hash → no link.
+- **`run_id` (T) on the decision = `task_id` (T)** on both receipts — consent → execution, same task.
+- **`approval_id` (C) = `invocation_id` (C)** — the gated call and the executed call are one.
+
+Verify the whole story offline — pin the approver key for consent (it is not authority-bound; see above), and the receipts are sovereign (the agent's `motebit_id` commits to its key):
+
+```ts
+import { verifyApprovalDecision, verifyExecutionReceipt, verifyToolInvocationReceipt, hexToBytes } from "@motebit/crypto";
+
+const APPROVER = hexToBytes("e7f162a10bec559afea195e4dce84b69568d5d2cb0963eb446c0685e2b17f2f0");
+const AGENT = hexToBytes("79b5562e8fe654f94078b112e8a98ba7901f853ae695bed7e0e3910bad049664");
+
+const consentOk  = await verifyApprovalDecision(approval, APPROVER);       // pinned approver
+const callOk     = await verifyToolInvocationReceipt(toolReceipt, AGENT);  // sovereign agent
+const taskOk     = await verifyExecutionReceipt(execReceipt, AGENT);       // sovereign agent
+
+// The link — assert it; never assume it:
+const linked =
+  approval.run_id === execReceipt.task_id &&
+  approval.run_id === toolReceipt.task_id &&
+  approval.args_hash === toolReceipt.args_hash &&
+  approval.approval_id === toolReceipt.invocation_id;
+```
+
+All four signatures verify, and `linked` is true, with no server and no relay. That is the full governance triad — *the human approved this exact call, the agent ran it, and refused a separate over-policy one* — proven end to end.
+
 ## Why this matters
 
 Generating signed artifacts internally is not the claim. The claim is: **a third party can verify what a motebit was permitted to do, what a human consented to, and what was refused — without trusting the application.** The triad makes all three governance outcomes provable with the same public packages and the signer's public key. Nothing here is gated behind a subscription; it is a baseline property of every motebit identity.

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -3426,6 +3426,45 @@ const ok = await verifyToolInvocationReceipt(receipt, signerPublicKeyBytes);
 
 Like the others it commits to `args_hash` / `result_hash` rather than raw bytes, so the proof is independently checkable without exposing tool inputs or outputs.
 
+## The full triad, as one linked story
+
+The individual fixtures above each prove one band. A **paired set** proves the bands *connect* — that the human's consent and the agent's execution are the same act, not two unrelated cards. One sovereign demo agent (`motebit_id` commits to its key) and the canonical approver, with real correlators (reproducible from [`mint-triad-fixture.mjs`](https://github.com/motebit/motebit/blob/main/examples/python-receipt-verifier/fixtures/mint-triad-fixture.mjs)):
+
+| Fixture | Band | Signed by | Links by |
+| --- | --- | --- | --- |
+| [`triad-approval-decision.json`](https://raw.githubusercontent.com/motebit/motebit/main/examples/python-receipt-verifier/fixtures/triad-approval-decision.json) | approve (consent) | approver key | `run_id` = T, `args_hash` = H, `approval_id` = C |
+| [`triad-tool-invocation-receipt.json`](https://raw.githubusercontent.com/motebit/motebit/main/examples/python-receipt-verifier/fixtures/triad-tool-invocation-receipt.json) | approve (executed call) | agent (sovereign) | `task_id` = T, `args_hash` = H, `invocation_id` = C |
+| [`triad-execution-receipt.json`](https://raw.githubusercontent.com/motebit/motebit/main/examples/python-receipt-verifier/fixtures/triad-execution-receipt.json) | approve (task) | agent (sovereign) | `task_id` = T |
+| [`triad-deny-receipt.json`](https://raw.githubusercontent.com/motebit/motebit/main/examples/python-receipt-verifier/fixtures/triad-deny-receipt.json) | deny | agent (sovereign) | distinct `task_id` = D, `status: "denied"` |
+
+The linkage is the point, and it is **cryptographic, not asserted**:
+
+- **`args_hash` (H)** is identical on the `ApprovalDecision` and the `ToolInvocationReceipt` — the human consented to the *exact* call that ran. Different bytes → different hash → no link.
+- **`run_id` (T) on the decision = `task_id` (T)** on both receipts — consent → execution, same task.
+- **`approval_id` (C) = `invocation_id` (C)** — the gated call and the executed call are one.
+
+Verify the whole story offline — pin the approver key for consent (it is not authority-bound; see above), and the receipts are sovereign (the agent's `motebit_id` commits to its key):
+
+```ts
+import { verifyApprovalDecision, verifyExecutionReceipt, verifyToolInvocationReceipt, hexToBytes } from "@motebit/crypto";
+
+const APPROVER = hexToBytes("e7f162a10bec559afea195e4dce84b69568d5d2cb0963eb446c0685e2b17f2f0");
+const AGENT = hexToBytes("79b5562e8fe654f94078b112e8a98ba7901f853ae695bed7e0e3910bad049664");
+
+const consentOk  = await verifyApprovalDecision(approval, APPROVER);       // pinned approver
+const callOk     = await verifyToolInvocationReceipt(toolReceipt, AGENT);  // sovereign agent
+const taskOk     = await verifyExecutionReceipt(execReceipt, AGENT);       // sovereign agent
+
+// The link — assert it; never assume it:
+const linked =
+  approval.run_id === execReceipt.task_id &&
+  approval.run_id === toolReceipt.task_id &&
+  approval.args_hash === toolReceipt.args_hash &&
+  approval.approval_id === toolReceipt.invocation_id;
+```
+
+All four signatures verify, and `linked` is true, with no server and no relay. That is the full governance triad — *the human approved this exact call, the agent ran it, and refused a separate over-policy one* — proven end to end.
+
 ## Why this matters
 
 Generating signed artifacts internally is not the claim. The claim is: **a third party can verify what a motebit was permitted to do, what a human consented to, and what was refused — without trusting the application.** The triad makes all three governance outcomes provable with the same public packages and the signer's public key. Nothing here is gated behind a subscription; it is a baseline property of every motebit identity.

--- a/examples/python-receipt-verifier/fixtures/mint-triad-fixture.mjs
+++ b/examples/python-receipt-verifier/fixtures/mint-triad-fixture.mjs
@@ -1,0 +1,198 @@
+/**
+ * Regenerates the PAIRED full-governance-triad fixture set — the artifact that
+ * makes the whole triad showable as one *linked* story instead of disconnected
+ * cards. One sovereign agent + the canonical approver, with REAL correlators
+ * (no faked linkage):
+ *
+ *   approve band (3 linked fixtures for ONE gated call):
+ *     triad-approval-decision.json      ApprovalDecision  (approver-signed)
+ *       run_id = T, args_hash = H, approval_id = C
+ *     triad-tool-invocation-receipt.json ToolInvocationReceipt (agent-signed)
+ *       task_id = T, args_hash = H, invocation_id = C   ← same T, H, C
+ *     triad-execution-receipt.json      ExecutionReceipt (agent-signed, sovereign)
+ *       task_id = T, status completed                   ← same T
+ *
+ *   deny band (same agent, distinct task):
+ *     triad-deny-receipt.json           ExecutionReceipt (agent-signed, sovereign)
+ *       task_id = D, status denied
+ *
+ * The linkage is what's new and honest: `args_hash` ties the human's consent to
+ * the EXACT executed call (ApprovalDecision.args_hash === ToolInvocationReceipt
+ * .args_hash); `task_id`/`run_id` ties consent → execution (ApprovalDecision
+ * .run_id === both receipts' task_id). The execution side is SOVEREIGN (the
+ * agent's motebit_id commits to its key); the consent side is approver-signed,
+ * verified against the PINNED canonical approver key (never the embedded one —
+ * see docs/developer/governance-triad.mdx).
+ *
+ *   node mint-triad-fixture.mjs   # from this dir, after `pnpm build` of crypto
+ *
+ * Provenance over magic: both keys are FIXED PUBLIC seeds (agent 0x01..0x20 —
+ * the same sovereign demo agent as mint-sovereign-fixture.mjs; approver
+ * 0x21..0x40 — the same as mint-approval-decision-fixture.mjs). Reproducible
+ * byte-for-byte. Refuses to write unless every signature verifies AND every
+ * cross-fixture correlator matches.
+ */
+import * as ed from "@noble/ed25519";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { bytesToHex } from "@noble/hashes/utils.js";
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+  deriveSovereignMotebitId,
+  hashToolPayload,
+  signApprovalDecision,
+  verifyApprovalDecision,
+  signToolInvocationReceipt,
+  verifyToolInvocationReceipt,
+  signExecutionReceipt,
+  verifyExecutionReceipt,
+} from "@motebit/crypto";
+
+const seed = (start) => {
+  const s = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) s[i] = i + start;
+  return s;
+};
+
+// Agent (executor) — sovereign: motebit_id commits to this key. Seed 0x01..0x20.
+const agentPriv = seed(1);
+const agentPub = await ed.getPublicKeyAsync(agentPriv);
+const agentPubHex = bytesToHex(agentPub);
+const motebitId = await deriveSovereignMotebitId(agentPubHex);
+
+// Approver (the human's device) — seed 0x21..0x40. Published canonical key.
+const approverPriv = seed(33);
+const approverPub = await ed.getPublicKeyAsync(approverPriv);
+const approverPubHex = bytesToHex(approverPub);
+
+const sha = (s) => bytesToHex(sha256(new TextEncoder().encode(s)));
+const here = dirname(fileURLToPath(import.meta.url));
+const write = (name, obj) => writeFileSync(join(here, name), JSON.stringify(obj, null, 2) + "\n");
+
+// === The shared correlators for the APPROVE-band call ===
+const T = "019dc500-0000-7000-c000-000000000a01"; // task / run
+const C = "019dc500-0000-7000-c000-0000000000c1"; // the gated tool call (approval_id === invocation_id)
+const agentDevice = "019dc500-0000-7000-a000-0000000000de";
+const approverDevice = "019dc500-0000-7000-b000-0000000000ab";
+
+// The exact args the human saw and approved — both consent and execution commit
+// to THIS hash, which is what proves the executed call is the one approved.
+const emailArgs = '{"to":"vendor@example.com","subject":"Q3 contract — signed copy"}';
+const H = await hashToolPayload(JSON.parse(emailArgs));
+const emailResult = "Email sent to vendor@example.com after your approval.";
+
+// 1. The human's signed consent (approver-signed; verify against PINNED approver key).
+const approval = await signApprovalDecision(
+  {
+    approval_id: C,
+    motebit_id: motebitId,
+    device_id: approverDevice,
+    tool_name: "send_email",
+    args_hash: H,
+    risk_level: 2,
+    verdict: "approved",
+    requested_at: 1777109300000,
+    resolved_at: 1777109331000,
+    run_id: T,
+  },
+  approverPriv,
+  approverPub,
+);
+
+// 2. The executed approved call (agent-signed; same args_hash H, same call id C, task T).
+const toolReceipt = await signToolInvocationReceipt(
+  {
+    invocation_id: C,
+    task_id: T,
+    motebit_id: motebitId,
+    device_id: agentDevice,
+    tool_name: "send_email",
+    started_at: 1777109332000,
+    completed_at: 1777109333000,
+    status: "completed",
+    args_hash: H,
+    result_hash: sha(emailResult),
+    invocation_origin: "user-tap",
+  },
+  agentPriv,
+  agentPub,
+);
+
+// 3. The task that ran after approval (agent-signed, sovereign; same task T).
+const execReceipt = await signExecutionReceipt(
+  {
+    task_id: T,
+    motebit_id: motebitId,
+    device_id: agentDevice,
+    submitted_at: 1777109299000,
+    completed_at: 1777109334000,
+    status: "completed",
+    result: "Sent the Q3 contract to the vendor after you approved the send.",
+    tools_used: ["send_email"],
+    memories_formed: 0,
+    prompt_hash: sha("Send the signed Q3 contract to the vendor."),
+    result_hash: sha("Sent the Q3 contract to the vendor after you approved the send."),
+    invocation_origin: "user-tap",
+  },
+  agentPriv,
+  agentPub,
+);
+
+// 4. Deny band — same agent refuses an over-policy act (distinct task D).
+const D = "019dc500-0000-7000-c000-000000000d01";
+const denyResult = "Attempted to send $4,800 to a new payee. Denied by policy. No funds moved.";
+const denyReceipt = await signExecutionReceipt(
+  {
+    task_id: D,
+    motebit_id: motebitId,
+    device_id: agentDevice,
+    submitted_at: 1777109400000,
+    completed_at: 1777109401000,
+    status: "denied",
+    result: denyResult,
+    tools_used: [],
+    memories_formed: 0,
+    prompt_hash: sha("Pay the new vendor $4,800."),
+    result_hash: sha(denyResult),
+    invocation_origin: "user-tap",
+  },
+  agentPriv,
+  agentPub,
+);
+
+// === Refuse to write unless every signature verifies AND every correlator matches ===
+const checks = [
+  ["approval verifies (pinned approver key)", await verifyApprovalDecision(approval, approverPub)],
+  ["tool-invocation verifies (agent key)", await verifyToolInvocationReceipt(toolReceipt, agentPub)],
+  ["execution verifies (agent key)", await verifyExecutionReceipt(execReceipt, agentPub)],
+  ["deny verifies (agent key)", await verifyExecutionReceipt(denyReceipt, agentPub)],
+  // Linkage — the whole point.
+  ["run_id ↔ task_id (consent → task)", approval.run_id === execReceipt.task_id && approval.run_id === toolReceipt.task_id],
+  ["args_hash (consent ↔ exact executed call)", approval.args_hash === toolReceipt.args_hash],
+  ["call id (approval_id ↔ invocation_id)", approval.approval_id === toolReceipt.invocation_id],
+  ["one agent across the receipts", execReceipt.motebit_id === toolReceipt.motebit_id && execReceipt.motebit_id === motebitId],
+  // Tamper — flipping the verdict must break the approval signature.
+  ["approval tamper rejected", !(await verifyApprovalDecision({ ...approval, verdict: "denied" }, approverPub))],
+];
+const failed = checks.filter(([, ok]) => !ok);
+if (failed.length > 0) {
+  console.error("REFUSING TO WRITE — checks failed:");
+  for (const [name] of failed) console.error("  ✗ " + name);
+  process.exit(1);
+}
+
+write("triad-approval-decision.json", approval);
+write("triad-tool-invocation-receipt.json", toolReceipt);
+write("triad-execution-receipt.json", execReceipt);
+write("triad-deny-receipt.json", denyReceipt);
+
+for (const [name] of checks) console.log("  ✓ " + name);
+console.log("");
+console.log("Shared correlators:  task/run T =", T, " call C =", C);
+console.log("                     args_hash H =", H.slice(0, 16) + "…");
+console.log("Agent (sovereign) motebit_id:", motebitId);
+console.log("Agent public key (verify receipts against this OR rely on sovereign binding):");
+console.log("  " + agentPubHex);
+console.log("CANONICAL APPROVER PUBLIC KEY (pin this for the ApprovalDecision):");
+console.log("  " + approverPubHex);

--- a/examples/python-receipt-verifier/fixtures/triad-approval-decision.json
+++ b/examples/python-receipt-verifier/fixtures/triad-approval-decision.json
@@ -1,0 +1,15 @@
+{
+  "approval_id": "019dc500-0000-7000-c000-0000000000c1",
+  "motebit_id": "65b60673-d6ed-884b-b01c-2c222d82ada0",
+  "device_id": "019dc500-0000-7000-b000-0000000000ab",
+  "tool_name": "send_email",
+  "args_hash": "02fa90d9e5ac0a4c3d0449fd10dccc24c80031a81376a1b73f3af7cc99e075dd",
+  "risk_level": 2,
+  "verdict": "approved",
+  "requested_at": 1777109300000,
+  "resolved_at": 1777109331000,
+  "run_id": "019dc500-0000-7000-c000-000000000a01",
+  "public_key": "e7f162a10bec559afea195e4dce84b69568d5d2cb0963eb446c0685e2b17f2f0",
+  "suite": "motebit-jcs-ed25519-b64-v1",
+  "signature": "-OQLp4RMqm0pY09AdpH51exQ3xnvrkurfz9YZ2R8ZXRnXCuOCiCu_5OVY9jARY83TeQrtPRNm79OS7onHgrnDw"
+}

--- a/examples/python-receipt-verifier/fixtures/triad-deny-receipt.json
+++ b/examples/python-receipt-verifier/fixtures/triad-deny-receipt.json
@@ -1,0 +1,17 @@
+{
+  "task_id": "019dc500-0000-7000-c000-000000000d01",
+  "motebit_id": "65b60673-d6ed-884b-b01c-2c222d82ada0",
+  "device_id": "019dc500-0000-7000-a000-0000000000de",
+  "submitted_at": 1777109400000,
+  "completed_at": 1777109401000,
+  "status": "denied",
+  "result": "Attempted to send $4,800 to a new payee. Denied by policy. No funds moved.",
+  "tools_used": [],
+  "memories_formed": 0,
+  "prompt_hash": "3d17f307d6b3ea82579c732cb7e928b838a96181699e5248e2467fd4dd5e3362",
+  "result_hash": "25d83c75396ee98c9f66b93cf66bc452cb89c3195fa7c841a4bd2ac50613fe04",
+  "invocation_origin": "user-tap",
+  "public_key": "79b5562e8fe654f94078b112e8a98ba7901f853ae695bed7e0e3910bad049664",
+  "suite": "motebit-jcs-ed25519-b64-v1",
+  "signature": "9iwwMUljjBgkcjh497lDIM8GikYGmSeOPn2Wrh_RHit2pJaiUgx_o0Cv8Bc0Is5bMwyIM6rMraJFy4p4CbyQBA"
+}

--- a/examples/python-receipt-verifier/fixtures/triad-execution-receipt.json
+++ b/examples/python-receipt-verifier/fixtures/triad-execution-receipt.json
@@ -1,0 +1,17 @@
+{
+  "task_id": "019dc500-0000-7000-c000-000000000a01",
+  "motebit_id": "65b60673-d6ed-884b-b01c-2c222d82ada0",
+  "device_id": "019dc500-0000-7000-a000-0000000000de",
+  "submitted_at": 1777109299000,
+  "completed_at": 1777109334000,
+  "status": "completed",
+  "result": "Sent the Q3 contract to the vendor after you approved the send.",
+  "tools_used": ["send_email"],
+  "memories_formed": 0,
+  "prompt_hash": "8d3e902ca01dccd60e052d209b45c4028fc612d3fdd8ca59165a47dbb47c207d",
+  "result_hash": "4824059811d694758753b8db48ea93d60942b70b07e0f059b3eb2cdf77b0c583",
+  "invocation_origin": "user-tap",
+  "public_key": "79b5562e8fe654f94078b112e8a98ba7901f853ae695bed7e0e3910bad049664",
+  "suite": "motebit-jcs-ed25519-b64-v1",
+  "signature": "Ln_qQfVh3sNNizgVAJ859z_8m_LRaFhDGohKmok0g7U7x4iI39pOnxqfabOIjmoWmF5Wt6Dn2B-9MhleMKXqAA"
+}

--- a/examples/python-receipt-verifier/fixtures/triad-tool-invocation-receipt.json
+++ b/examples/python-receipt-verifier/fixtures/triad-tool-invocation-receipt.json
@@ -1,0 +1,16 @@
+{
+  "invocation_id": "019dc500-0000-7000-c000-0000000000c1",
+  "task_id": "019dc500-0000-7000-c000-000000000a01",
+  "motebit_id": "65b60673-d6ed-884b-b01c-2c222d82ada0",
+  "device_id": "019dc500-0000-7000-a000-0000000000de",
+  "tool_name": "send_email",
+  "started_at": 1777109332000,
+  "completed_at": 1777109333000,
+  "status": "completed",
+  "args_hash": "02fa90d9e5ac0a4c3d0449fd10dccc24c80031a81376a1b73f3af7cc99e075dd",
+  "result_hash": "5b2701ab55a6d24707d92cc6412047a70143d191e978cfec02285b793729b214",
+  "invocation_origin": "user-tap",
+  "public_key": "79b5562e8fe654f94078b112e8a98ba7901f853ae695bed7e0e3910bad049664",
+  "suite": "motebit-jcs-ed25519-b64-v1",
+  "signature": "FAtRVX6T5K-BiYHXiy4kYI0V15pgr2UvCKtrtGh8mbw9D5DsnPXxAUzGmHjE1yaqlyxoaT1NbEQHTAN3FE_VBA"
+}

--- a/scripts/check-receipt-conformance.ts
+++ b/scripts/check-receipt-conformance.ts
@@ -42,25 +42,35 @@ async function main(): Promise<void> {
   const sec = await import(join(repoRoot, "packages/state-export-client/dist/index.js"));
 
   // Expected offline sovereign rung per fixture (verifier's `result.sovereign`).
-  // `example-receipt.json` is integrity-only (random motebit_id); every
-  // `sovereign-*.json` vector binds the key, so it must read sovereign.
-  const expectSovereign = (file: string): boolean => file.startsWith("sovereign-receipt");
+  // `example-receipt.json` is the one integrity-only vector (random motebit_id,
+  // not key-committed); EVERY other ExecutionReceipt fixture here binds the key
+  // (sovereign-receipt*, triad-*), so it must read sovereign. Expectation is
+  // "sovereign unless it's the known integrity-only fixture" — named-allowlist
+  // would silently expect the wrong rung for a future sovereign vector.
+  const INTEGRITY_ONLY = new Set(["example-receipt.json"]);
+  const expectSovereign = (file: string): boolean => !INTEGRITY_ONLY.has(file);
 
   const failures: string[] = [];
   const note = (m: string) => console.log(`  ${m}`);
 
   // Scope to ExecutionReceipt fixtures only — this gate checks cross-impl
   // RECEIPT conformance. The fixtures dir also holds other signed-artifact
-  // vectors (e.g. approval-decision-*.json, the "approve" governance band),
-  // which are a different shape verified by their own primitive
-  // (verifyApprovalDecision against a pinned approver key), not the receipt
-  // verifiers swept here. Shape-detect (task_id + result_hash) rather than
-  // name-match so a future non-receipt fixture can't silently re-break this gate.
+  // vectors: ApprovalDecisions (`approval_id` + `verdict`, no `task_id`) and
+  // ToolInvocationReceipts (`invocation_id` + `args_hash`, no `tools_used`),
+  // each verified by its own primitive — not the ExecutionReceipt verifiers
+  // swept here. Shape-detect on the markers UNIQUE to ExecutionReceipt
+  // (`task_id` + the `tools_used` array — ToolInvocationReceipt has neither
+  // `tools_used` nor an absent `invocation_id`) rather than name-match, so a
+  // future non-receipt fixture can't silently re-break this gate.
   const isReceiptFixture = (f: string): boolean => {
     if (!f.endsWith(".json")) return false;
     try {
       const o = JSON.parse(readFileSync(join(fixturesDir, f), "utf8")) as Record<string, unknown>;
-      return typeof o.task_id === "string" && typeof o.result_hash === "string";
+      return (
+        typeof o.task_id === "string" &&
+        Array.isArray(o.tools_used) &&
+        o.invocation_id === undefined
+      );
     } catch {
       return false;
     }


### PR DESCRIPTION
## Paired full-governance-triad fixture set — the linked triad, showable end to end

The standalone `approval-decision-*` fixtures (shipped in #142) each prove one band, but their `run_id`s don't link to any receipt — so the full triad couldn't be shown as **one coherent story**. The agency.computer PE cold-consumed them successfully and flagged exactly this: *"if you ever mint a paired set (ApprovalDecision + ExecutionReceipt sharing run_id/args_hash), that's the artifact that makes the full triad showable"* — and rightly refused to fake the linkage. This mints it for real.

### The set (one sovereign agent + the canonical approver)

| Fixture | Band | Signed by |
|---|---|---|
| `triad-approval-decision.json` | approve (consent) | approver key (pinned) |
| `triad-tool-invocation-receipt.json` | approve (executed call) | agent (sovereign) |
| `triad-execution-receipt.json` | approve (task) | agent (sovereign) |
| `triad-deny-receipt.json` | deny | agent (sovereign) |

### The linkage is cryptographic, not asserted
- **`args_hash` (H)** identical on the `ApprovalDecision` and the `ToolInvocationReceipt` — the human consented to the *exact* call that ran.
- **`run_id` (T)** on the decision = **`task_id` (T)** on both receipts — consent → execution.
- **`approval_id` (C) = `invocation_id` (C)** — the gated call and the executed call are one.

`mint-triad-fixture.mjs` refuses to write unless every signature verifies **and** every correlator matches **and** tamper is rejected (committed public seeds — reproducible byte-for-byte). Execution side is sovereign; consent side is approver-signed at the pinned rung (never sovereign).

### Gate-scoping fixes the new fixtures required
`check-receipt-conformance.ts`: (1) `expectSovereign` was name-based (`startsWith "sovereign-receipt"`) and would mis-expect the triad sovereign receipts → now "sovereign unless the known integrity-only `example-receipt.json`"; (2) the receipt-shape filter would have swept the `ToolInvocationReceipt` as an `ExecutionReceipt` → now keys on markers unique to `ExecutionReceipt` (`task_id` + `tools_used` array, no `invocation_id`). Conformance: **8 receipt vectors pass, 4 non-receipt excluded.**

The `governance-triad` doc gains a **"full triad, as one linked story"** section with the correlators, the offline verify-and-assert-linkage snippet, and the published approver + sovereign-agent keys. Fixtures + doc are non-published — live on `main` at merge, consumable via raw URL like the others. All 110 drift gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
