### PR TITLE
feat(crypto,verifier): verifyArtifact auto-detects + verifies ToolInvocationReceipt

### DIFF
--- a/.changeset/verifyartifact-tool-invocation-dispatch.md
+++ b/.changeset/verifyartifact-tool-invocation-dispatch.md
@@ -1,0 +1,14 @@
+---
+"@motebit/crypto": minor
+"@motebit/verifier": minor
+---
+
+`verifyArtifact` / `verify` now auto-detect and verify `ToolInvocationReceipt`s — close the cold-consume seam where a genuine receipt read as forged.
+
+A cold consumer (agency.computer) verifying a `ToolInvocationReceipt` through the canonical `verifyArtifact` path got `valid:false` — because `detectArtifactType` recognized `ExecutionReceipt` (keyed on `prompt_hash`) but not its sibling, so a genuine receipt fell through to the generic `type:"identity", valid:false` fallback. That conflates "wrong verifier" with "forged" — the one failure mode a proof tool can't have.
+
+- `@motebit/crypto`: `detectArtifactType` recognizes `ToolInvocationReceipt` on its unique `invocation_id` marker (disjoint from `ExecutionReceipt`'s `prompt_hash` — neither can be classified as the other); `verify()` dispatches it to a new `verifyToolInvocation` wrapper returning a `ToolInvocationVerifyResult` (`type: "tool-invocation"`). Additive: no existing artifact's verdict changes; the only behavior change is a genuine tool-invocation receipt now gets a real verdict.
+- `@motebit/verifier`: `verifyArtifact` computes the sovereign binding rung for `ToolInvocationReceipt`s (same `motebit_id → key` commitment as receipts), and `formatHuman` renders the tool/invocation/task/binding lines.
+- `@motebit/verify`: `--expect tool-invocation` accepted.
+
+Still deferred (consumer-forced): a distinct "unrecognized artifact type" result so genuinely-unknown artifacts (e.g. a flat `ApprovalDecision` consumed via `verifyArtifact`) read as unrecognized rather than `valid:false` — the general honesty floor, a separate `VerifyResult` variant.

--- a/packages/crypto/etc/crypto.api.md
+++ b/packages/crypto/etc/crypto.api.md
@@ -1370,6 +1370,17 @@ export function toBase64Url(data: Uint8Array): string;
 export const TOOL_INVOCATION_RECEIPT_SUITE: "motebit-jcs-ed25519-b64-v1";
 
 // @public (undocumented)
+export interface ToolInvocationVerifyResult extends BaseResult {
+    keySource?: "embedded";
+    // (undocumented)
+    signer?: string;
+    // (undocumented)
+    toolInvocation: SignableToolInvocationReceipt | null;
+    // (undocumented)
+    type: "tool-invocation";
+}
+
+// @public (undocumented)
 export interface TrustCredentialSubject {
     // (undocumented)
     failed_tasks: number;
@@ -1594,7 +1605,7 @@ export function verifyReceiptSequence(chain: ReceiptChainEntry[]): Promise<{
 export function verifyRelayMetadata(metadata: RelayMetadata, publicKey: Uint8Array): Promise<boolean>;
 
 // @public (undocumented)
-export type VerifyResult = IdentityVerifyResult | ReceiptVerifyResult | CredentialVerifyResult | PresentationVerifyResult | SkillVerifyResult;
+export type VerifyResult = IdentityVerifyResult | ReceiptVerifyResult | ToolInvocationVerifyResult | CredentialVerifyResult | PresentationVerifyResult | SkillVerifyResult;
 
 // @public
 export function verifyRetentionManifest(manifest: RetentionManifest, operatorPublicKey: Uint8Array): Promise<RetentionManifestVerifyResult>;

--- a/packages/crypto/src/__tests__/verify-artifacts.test.ts
+++ b/packages/crypto/src/__tests__/verify-artifacts.test.ts
@@ -30,6 +30,7 @@ import type {
 } from "@motebit/protocol";
 import {
   generateKeypair,
+  verify,
   ed25519Sign,
   ed25519Verify,
   createSignedToken,
@@ -2562,5 +2563,76 @@ describe("verifyRelayMetadata", () => {
     ).toBe(false);
     const other = await generateKeypair();
     expect(await verifyRelayMetadata(meta, other.publicKey)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verify() auto-detect dispatch for ToolInvocationReceipt
+// (regression: a genuine tool-invocation receipt used to fall through to a
+//  "valid:false identity" verdict — a true receipt reading as forged)
+// ---------------------------------------------------------------------------
+
+describe("verify() — ToolInvocationReceipt dispatch", () => {
+  async function makeToolReceipt(kp: { privateKey: Uint8Array; publicKey: Uint8Array }) {
+    const unsigned = {
+      invocation_id: "tc-1",
+      task_id: "task-1",
+      motebit_id: "motebit-x",
+      device_id: "device-1",
+      tool_name: "send_email",
+      started_at: 1000,
+      completed_at: 2000,
+      status: "completed" as const,
+      args_hash: await hashToolPayload({ to: "x@example.com" }),
+      result_hash: await hashToolPayload("sent"),
+    };
+    return signToolInvocationReceipt(
+      unsigned as Parameters<typeof signToolInvocationReceipt>[0],
+      kp.privateKey,
+      kp.publicKey,
+    );
+  }
+
+  it("detects + verifies a genuine ToolInvocationReceipt (not a failed identity)", async () => {
+    const kp = await generateKeypair();
+    const signed = await makeToolReceipt(kp);
+    const r = await verify(JSON.stringify(signed));
+    expect(r.type).toBe("tool-invocation");
+    expect(r.valid).toBe(true);
+  });
+
+  it("rejects a tampered ToolInvocationReceipt", async () => {
+    const kp = await generateKeypair();
+    const signed = await makeToolReceipt(kp);
+    const tampered = { ...signed, args_hash: "b".repeat(64) };
+    const r = await verify(JSON.stringify(tampered));
+    expect(r.type).toBe("tool-invocation");
+    expect(r.valid).toBe(false);
+  });
+
+  it("does NOT cross-classify with ExecutionReceipt (disjoint markers)", async () => {
+    const kp = await generateKeypair();
+    // A ToolInvocationReceipt (has invocation_id, no prompt_hash) → tool-invocation
+    const tool = await makeToolReceipt(kp);
+    expect((await verify(JSON.stringify(tool))).type).toBe("tool-invocation");
+    // An ExecutionReceipt (has prompt_hash, no invocation_id) → receipt
+    const exec = await signExecutionReceipt(
+      {
+        task_id: "task-2",
+        motebit_id: "motebit-x",
+        device_id: "device-1",
+        submitted_at: 1000,
+        completed_at: 2000,
+        status: "completed",
+        result: "ok",
+        tools_used: [],
+        memories_formed: 0,
+        prompt_hash: "0".repeat(64),
+        result_hash: "1".repeat(64),
+      } as unknown as Parameters<typeof signExecutionReceipt>[0],
+      kp.privateKey,
+      kp.publicKey,
+    );
+    expect((await verify(JSON.stringify(exec))).type).toBe("receipt");
   });
 });

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -25,6 +25,7 @@
 import type { MerkleTreeVersion } from "@motebit/protocol";
 import { verifyBySuite } from "./suite-dispatch.js";
 import { verifyMerkleInclusion, canonicalLeaf, resolveTreeHashVersion } from "./merkle.js";
+import { verifyToolInvocationReceipt, type SignableToolInvocationReceipt } from "./artifacts.js";
 // The @noble/ed25519 SHA-512 binding is performed in suite-dispatch.ts
 // as a side effect of module load. Importing verifyBySuite here is
 // enough to guarantee that the primitive is ready before any verify
@@ -220,6 +221,19 @@ export interface ReceiptVerifyResult extends BaseResult {
   delegations?: ReceiptVerifyResult[];
 }
 
+export interface ToolInvocationVerifyResult extends BaseResult {
+  type: "tool-invocation";
+  toolInvocation: SignableToolInvocationReceipt | null;
+  signer?: string;
+  /**
+   * Always `"embedded"` when present: resolved from the receipt's own
+   * `public_key` — proves byte-integrity, NOT identity binding (same caveat as
+   * `ReceiptVerifyResult.keySource`). The binding rung is computed by the
+   * `@motebit/verifier` wrapper, not asserted here.
+   */
+  keySource?: "embedded";
+}
+
 export interface CredentialVerifyResult extends BaseResult {
   type: "credential";
   credential: VerifiableCredential | null;
@@ -302,6 +316,7 @@ export interface SkillVerifyResult extends BaseResult {
 export type VerifyResult =
   | IdentityVerifyResult
   | ReceiptVerifyResult
+  | ToolInvocationVerifyResult
   | CredentialVerifyResult
   | PresentationVerifyResult
   | SkillVerifyResult;
@@ -642,6 +657,17 @@ function detectArtifactType(artifact: unknown): ArtifactType | null {
   // Verifiable Credential: has "credentialSubject" + "issuer" + "proof"
   if ("credentialSubject" in obj && "issuer" in obj && "proof" in obj) {
     return "credential";
+  }
+
+  // Tool-Invocation Receipt: has "invocation_id" + "tool_name" + "motebit_id"
+  // + "signature". Checked BEFORE the execution-receipt branch on its UNIQUE
+  // marker `invocation_id` (an ExecutionReceipt never carries one; conversely a
+  // ToolInvocationReceipt never carries `prompt_hash`), so the two are disjoint
+  // and neither can be classified as the other. Without this branch a genuine
+  // tool-invocation receipt fell through to `null` and `verify()` reported it as
+  // a failed identity artifact — a true receipt reading as forged.
+  if ("invocation_id" in obj && "tool_name" in obj && "motebit_id" in obj && "signature" in obj) {
+    return "tool-invocation";
   }
 
   // Execution Receipt: has "task_id" + "motebit_id" + "signature" + "prompt_hash"
@@ -1419,6 +1445,54 @@ export async function verifyReceipt(receipt: ExecutionReceipt): Promise<ReceiptV
   };
 }
 
+/**
+ * Verify a `ToolInvocationReceipt` resolved from auto-detection. Mirrors
+ * `verifyReceipt`: resolves the signer key from the receipt's own `public_key`
+ * (integrity, not identity binding — the rung is computed by `@motebit/verifier`)
+ * and dispatches to `verifyToolInvocationReceipt`. Returns a structured result
+ * with the same shape contract as the other arms, so a genuine tool-invocation
+ * receipt gets a real verdict from `verify()` instead of falling through to a
+ * misleading "invalid identity artifact."
+ */
+async function verifyToolInvocation(
+  receipt: SignableToolInvocationReceipt,
+): Promise<ToolInvocationVerifyResult> {
+  let publicKey: Uint8Array | null = null;
+  let signerDid: string | undefined;
+
+  if (receipt.public_key) {
+    try {
+      publicKey = hexToBytes(receipt.public_key);
+      if (publicKey.length === 32) {
+        signerDid = publicKeyToDidKey(publicKey);
+      } else {
+        publicKey = null;
+      }
+    } catch {
+      publicKey = null;
+    }
+  }
+
+  if (!publicKey) {
+    return {
+      type: "tool-invocation",
+      valid: false,
+      toolInvocation: receipt,
+      errors: [{ message: "No embedded public_key — cannot verify without known keys" }],
+    };
+  }
+
+  const valid = await verifyToolInvocationReceipt(receipt, publicKey);
+  return {
+    type: "tool-invocation",
+    valid,
+    toolInvocation: receipt,
+    signer: signerDid,
+    keySource: "embedded",
+    ...(valid ? {} : { errors: [{ message: "Ed25519 signature did not verify" }] }),
+  };
+}
+
 async function verifyReceiptDelegations(receipt: ExecutionReceipt): Promise<ReceiptVerifyResult[]> {
   if (!receipt.delegation_receipts || receipt.delegation_receipts.length === 0) {
     return [];
@@ -1872,6 +1946,7 @@ export async function verify(artifact: unknown, options?: VerifyOptions): Promis
       valid: false,
       ...(fallbackType === "identity" ? { identity: null } : {}),
       ...(fallbackType === "receipt" ? { receipt: null } : {}),
+      ...(fallbackType === "tool-invocation" ? { toolInvocation: null } : {}),
       ...(fallbackType === "credential" ? { credential: null } : {}),
       ...(fallbackType === "presentation" ? { presentation: null } : {}),
       ...(fallbackType === "skill"
@@ -1894,6 +1969,7 @@ export async function verify(artifact: unknown, options?: VerifyOptions): Promis
       valid: false,
       ...(detected === "identity" ? { identity: null } : {}),
       ...(detected === "receipt" ? { receipt: null } : {}),
+      ...(detected === "tool-invocation" ? { toolInvocation: null } : {}),
       ...(detected === "credential" ? { credential: null } : {}),
       ...(detected === "presentation" ? { presentation: null } : {}),
       ...(detected === "skill"
@@ -1920,6 +1996,7 @@ export async function verify(artifact: unknown, options?: VerifyOptions): Promis
         type: detected,
         valid: false,
         ...(detected === "receipt" ? { receipt: null } : {}),
+        ...(detected === "tool-invocation" ? { toolInvocation: null } : {}),
         ...(detected === "credential" ? { credential: null } : {}),
         ...(detected === "presentation" ? { presentation: null } : {}),
         ...(detected === "skill"
@@ -1942,6 +2019,8 @@ export async function verify(artifact: unknown, options?: VerifyOptions): Promis
       return verifyIdentity(resolved as string);
     case "receipt":
       return verifyReceipt(resolved as ExecutionReceipt);
+    case "tool-invocation":
+      return verifyToolInvocation(resolved as SignableToolInvocationReceipt);
     case "credential":
       return verifyCredential(
         resolved as VerifiableCredential,

--- a/packages/verifier/src/__tests__/lib.test.ts
+++ b/packages/verifier/src/__tests__/lib.test.ts
@@ -15,7 +15,11 @@ import * as ed from "@noble/ed25519";
 import { sha512 } from "@noble/hashes/sha2.js";
 
 import type { ExecutionReceipt } from "@motebit/crypto";
-import { deriveSovereignMotebitId } from "@motebit/crypto";
+import {
+  deriveSovereignMotebitId,
+  signToolInvocationReceipt,
+  hashToolPayload,
+} from "@motebit/crypto";
 
 import { formatHuman, verifyArtifact, verifyFile } from "../lib.js";
 
@@ -99,6 +103,32 @@ async function sovereignReceipt(): Promise<ExecutionReceipt> {
   return { ...withSuite, signature: toBase64Url(sig) };
 }
 
+// A sovereign-minted ToolInvocationReceipt: motebit_id commits to the key, same
+// as the execution receipt, signed through the canonical signer.
+async function sovereignToolInvocation() {
+  const sk = ed.utils.randomSecretKey();
+  const pk = await ed.getPublicKeyAsync(sk);
+  const pkHex = toHex(pk);
+  const unsigned = {
+    invocation_id: "tc-sovereign-test",
+    task_id: "task-sovereign-test",
+    motebit_id: await deriveSovereignMotebitId(pkHex),
+    public_key: pkHex,
+    device_id: "dev-verifier-1",
+    tool_name: "send_email",
+    started_at: 1_000_000,
+    completed_at: 1_001_000,
+    status: "completed" as const,
+    args_hash: await hashToolPayload({ to: "x@example.com" }),
+    result_hash: await hashToolPayload("sent"),
+  };
+  return signToolInvocationReceipt(
+    unsigned as Parameters<typeof signToolInvocationReceipt>[0],
+    sk,
+    pk,
+  );
+}
+
 // Tests write receipt files into a per-test tmp dir; collect them so
 // teardown is best-effort (tmp cleanup isn't load-bearing for
 // correctness).
@@ -115,6 +145,27 @@ afterEach(() => {
 });
 
 // ── tests ───────────────────────────────────────────────────────────
+
+describe("verifyArtifact — ToolInvocationReceipt dispatch + binding rung", () => {
+  it("verifies a genuine tool-invocation receipt as tool-invocation, sovereign:true", async () => {
+    const tir = await sovereignToolInvocation();
+    const result = await verifyArtifact(JSON.stringify(tir));
+    expect(result.type).toBe("tool-invocation");
+    expect(result.valid).toBe(true);
+    expect(result.sovereign).toBe(true);
+    const human = formatHuman(result);
+    expect(human).toContain("tool:");
+    expect(human).toContain("sovereign · motebit_id commits to the key");
+  });
+
+  it("does not read a genuine tool-invocation receipt as a failed identity artifact", async () => {
+    const tir = await sovereignToolInvocation();
+    const result = await verifyArtifact(JSON.stringify(tir));
+    // Regression guard: before dispatch, this returned { type: "identity", valid: false }.
+    expect(result.type).not.toBe("identity");
+    expect(result.valid).toBe(true);
+  });
+});
 
 describe("verifyArtifact — receipt binding rung (offline, receipt-alone)", () => {
   it("reports sovereign:true when motebit_id commits to the key", async () => {

--- a/packages/verifier/src/lib.ts
+++ b/packages/verifier/src/lib.ts
@@ -297,6 +297,16 @@ export async function verifyArtifact(
       typeof pk === "string" ? await verifySovereignBinding(result.receipt.motebit_id, pk) : false;
     return { ...result, sovereign };
   }
+  // ToolInvocationReceipts carry the same motebit_id → public_key commitment, so
+  // the sovereign rung is checkable offline from the artifact alone, identically.
+  if (result.valid && result.type === "tool-invocation" && result.toolInvocation) {
+    const pk = result.toolInvocation.public_key;
+    const sovereign =
+      typeof pk === "string"
+        ? await verifySovereignBinding(result.toolInvocation.motebit_id, pk)
+        : false;
+    return { ...result, sovereign };
+  }
   return result;
 }
 
@@ -359,6 +369,22 @@ function summarizeValid(result: VerifyResultWithBinding): ReadonlyArray<readonly
       out.push(["motebit:", result.receipt.motebit_id]);
       if (result.signer) out.push(["signer:", result.signer]);
       // Binding rung — checkable offline from the receipt alone.
+      out.push([
+        "binding:",
+        result.sovereign
+          ? "sovereign · motebit_id commits to the key (offline, no operator)"
+          : "integrity-only · signature valid; identity not bound",
+      ]);
+      return out;
+    }
+    case "tool-invocation": {
+      if (!result.toolInvocation) return [];
+      const out: Array<readonly [string, string]> = [];
+      out.push(["tool:", result.toolInvocation.tool_name]);
+      out.push(["invocation:", result.toolInvocation.invocation_id]);
+      out.push(["task:", result.toolInvocation.task_id]);
+      out.push(["motebit:", result.toolInvocation.motebit_id]);
+      if (result.signer) out.push(["signer:", result.signer]);
       out.push([
         "binding:",
         result.sovereign

--- a/packages/verify/src/cli.ts
+++ b/packages/verify/src/cli.ts
@@ -59,6 +59,7 @@ import { buildHardwareVerifiers } from "./adapters.js";
 const EXPECT_VALUES: readonly ArtifactType[] = [
   "identity",
   "receipt",
+  "tool-invocation",
   "credential",
   "presentation",
   "skill",


### PR DESCRIPTION
## `verifyArtifact` auto-detects + verifies `ToolInvocationReceipt`

Closes the cold-consume seam agency.computer hit: verifying a `ToolInvocationReceipt` through the canonical `verifyArtifact` path returned `valid:false` — because `detectArtifactType` recognized `ExecutionReceipt` (keyed on `prompt_hash`) but not its sibling, so a genuine receipt fell through to the generic `type:"identity", valid:false` fallback. That conflates **wrong-verifier** with **forged** — the one failure mode a proof tool can't have.

### Change
- **`@motebit/crypto`**: `detectArtifactType` recognizes `ToolInvocationReceipt` on its **unique** `invocation_id` marker (disjoint from `ExecutionReceipt`'s `prompt_hash` — neither classifies as the other; tested both directions). `verify()` dispatches via an internal `verifyToolInvocation` wrapper → new exported `ToolInvocationVerifyResult` (`type:"tool-invocation"`). **Purely additive** — no existing artifact's verdict changes.
- **`@motebit/verifier`**: `verifyArtifact` computes the sovereign binding rung for tool-invocation receipts (same `motebit_id → key` commitment); `formatHuman` renders tool/invocation/task/binding lines.
- **`@motebit/verify`**: `--expect tool-invocation` accepted.

### Review evidence
- **Detector collision-free**: only `ToolInvocationReceipt` carries `invocation_id`.
- **Union-widening safe**: full monorepo typecheck **139/139** — no exhaustive `switch` broke.
- **Additive**: execution + sovereign receipts unchanged (verified functionally).
- **Sibling-consistent**: mirrors `verifyReceipt` (incl. embedded-key resolution).
- **Surface-minimal**: dispatch wrapper internal; only the `ToolInvocationVerifyResult` type exported.

Tests: crypto detect/verify/tamper/no-cross-classify + verifier sovereign-rung/formatHuman/regression-guard. crypto **533** + verifier **42** pass; all **110** drift gates.

Forward-compatible: agency's TriadProof calls `verifyToolInvocationReceipt` explicitly + fixtures unchanged → can't break it, only lets it simplify.

Deferred (next arc): a distinct `"unrecognized type"` result so genuinely-unknown artifacts read as unrecognized rather than `valid:false` — the general honesty floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
