### PR TITLE
feat(crypto,verifier,verify): unrecognized artifacts report type "unknown" — verifyArtifact honesty floor

### DIFF
--- a/.changeset/verifyartifact-unrecognized-type-honesty-floor.md
+++ b/.changeset/verifyartifact-unrecognized-type-honesty-floor.md
@@ -1,0 +1,17 @@
+---
+"@motebit/crypto": minor
+"@motebit/verifier": minor
+"@motebit/verify": minor
+---
+
+`verify` / `verifyArtifact` report unrecognized artifacts as a distinct `type: "unknown"` instead of `valid:false` on a fabricated type — the honesty floor that keeps "I don't recognize this" from reading as "this is forged."
+
+Before, an artifact `detectArtifactType` didn't recognize returned `{ type: options.expectedType ?? "identity", valid: false }` — so an unrecognized blob (a flat `ApprovalDecision` consumed via `verifyArtifact`, or any foreign JSON) was indistinguishable from a _tampered identity file_. That conflates "unknown type / wrong verifier" with "forged known artifact" — the one ambiguity a proof tool can't have.
+
+- `@motebit/crypto`: new `UnknownVerifyResult` (`type:"unknown"`, `valid:false`, `reason:"unrecognized_artifact_type"`); `verify()`'s no-detection branch returns it. `detectArtifactType` never yields `"unknown"` (it returns `null`), so the dispatch switch stays exhaustive over exactly the detectable types.
+- `@motebit/verifier`: `formatHuman` renders `UNRECOGNIZED (unknown)`, not `INVALID`.
+- `@motebit/verify`: an unrecognized artifact exits **2** (usage/unrecognized) — distinct from 1 (invalid signature) — per the CLI exit-code contract.
+
+**Behavior change** (minor; `valid` is unchanged — still `false`): unrecognized input now reports `type:"unknown"` rather than the old `"identity"` (or `expectedType`) fallback. A consumer that branched on the fallback type for unrecognized input should switch on `type === "unknown"`.
+
+Completes the honesty pass begun with `ToolInvocationReceipt` auto-detect: recognized artifacts get a real verdict, unrecognized artifacts get an honest "I don't know this," and neither reads as forged.

--- a/apps/docs/content/docs/developer/governance-triad.mdx
+++ b/apps/docs/content/docs/developer/governance-triad.mdx
@@ -95,6 +95,8 @@ const ok = await verifyApprovalDecision(decision, hexToBytes(CANONICAL_APPROVER_
 
 > `@motebit/verify` (the CLI) and `@motebit/verifier` (the file/format library) are sibling packages; the low-level `verifyApprovalDecision` primitive lives in `@motebit/crypto` and is what both build on. For a browser, import from `@motebit/crypto` directly.
 
+> **Use `verifyApprovalDecision`, not the auto-detecting `verifyArtifact`/`verify`, for an `ApprovalDecision`.** Unlike receipts, an `ApprovalDecision` is verified against a *pinned approver key*, not auto-detected — so `verifyArtifact` reports it as `{ type: "unknown", valid: false, reason: "unrecognized_artifact_type" }`. That's the verifier being honest ("I don't recognize this type"), not a verdict that the decision is forged. Route `ApprovalDecision`s to `verifyApprovalDecision`; auto-detect handles the receipt family (`ExecutionReceipt`, `ToolInvocationReceipt`).
+
 What the signature commits to — and why it can't be replayed:
 
 - **`approval_id`** is the gated call's id, inside the signed body. A verdict can't be lifted onto a different call without breaking the signature.

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -3390,6 +3390,8 @@ const ok = await verifyApprovalDecision(decision, hexToBytes(CANONICAL_APPROVER_
 
 > `@motebit/verify` (the CLI) and `@motebit/verifier` (the file/format library) are sibling packages; the low-level `verifyApprovalDecision` primitive lives in `@motebit/crypto` and is what both build on. For a browser, import from `@motebit/crypto` directly.
 
+> **Use `verifyApprovalDecision`, not the auto-detecting `verifyArtifact`/`verify`, for an `ApprovalDecision`.** Unlike receipts, an `ApprovalDecision` is verified against a *pinned approver key*, not auto-detected — so `verifyArtifact` reports it as `{ type: "unknown", valid: false, reason: "unrecognized_artifact_type" }`. That's the verifier being honest ("I don't recognize this type"), not a verdict that the decision is forged. Route `ApprovalDecision`s to `verifyApprovalDecision`; auto-detect handles the receipt family (`ExecutionReceipt`, `ToolInvocationReceipt`).
+
 What the signature commits to — and why it can't be replayed:
 
 - **`approval_id`** is the gated call's id, inside the signed body. A verdict can't be lifted onto a different call without breaking the signature.

--- a/packages/crypto/etc/crypto.api.md
+++ b/packages/crypto/etc/crypto.api.md
@@ -1399,6 +1399,16 @@ export interface TrustCredentialSubject {
     trust_level: string;
 }
 
+// @public
+export interface UnknownVerifyResult extends BaseResult {
+    // (undocumented)
+    reason: "unrecognized_artifact_type";
+    // (undocumented)
+    type: "unknown";
+    // (undocumented)
+    valid: false;
+}
+
 // @public (undocumented)
 export interface VerifiableCredential<T = Record<string, unknown>> {
     // (undocumented)
@@ -1605,7 +1615,7 @@ export function verifyReceiptSequence(chain: ReceiptChainEntry[]): Promise<{
 export function verifyRelayMetadata(metadata: RelayMetadata, publicKey: Uint8Array): Promise<boolean>;
 
 // @public (undocumented)
-export type VerifyResult = IdentityVerifyResult | ReceiptVerifyResult | ToolInvocationVerifyResult | CredentialVerifyResult | PresentationVerifyResult | SkillVerifyResult;
+export type VerifyResult = IdentityVerifyResult | ReceiptVerifyResult | ToolInvocationVerifyResult | CredentialVerifyResult | PresentationVerifyResult | SkillVerifyResult | UnknownVerifyResult;
 
 // @public
 export function verifyRetentionManifest(manifest: RetentionManifest, operatorPublicKey: Uint8Array): Promise<RetentionManifestVerifyResult>;

--- a/packages/crypto/src/__tests__/index.test.ts
+++ b/packages/crypto/src/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import * as ed from "@noble/ed25519";
 import { sha512 } from "@noble/hashes/sha2.js";
-import { parse, verify } from "../index";
+import { parse, verify, generateKeypair, signApprovalDecision } from "../index";
 
 // @noble/ed25519 v3 requires explicit SHA-512 binding
 if (!ed.hashes.sha512) {
@@ -765,28 +765,32 @@ describe("verify — JSON string dispatch", () => {
     // since they use the same JSON.parse. So this path is essentially dead code
     // for valid detection. Let's verify the type mismatch paths instead.
     const result = await verify(42, { expectedType: "receipt" });
+    expect(result.type).toBe("unknown");
     expect(result.valid).toBe(false);
-    expect(result.errors![0]!.message).toBe("Unrecognized artifact format");
+    expect(result.errors![0]!.message).toBe('Unrecognized artifact format (expected "receipt")');
   });
 
-  it("returns unrecognized format for non-object non-string input", async () => {
+  it("returns unknown for non-object non-string input", async () => {
     const result = await verify(null);
+    expect(result.type).toBe("unknown");
     expect(result.valid).toBe(false);
     expect(result.errors![0]!.message).toBe("Unrecognized artifact format");
   });
 
-  it("returns unrecognized format with credential fallback type", async () => {
+  it("returns unknown (not a fake credential) for unrecognized input with expectedType", async () => {
     const result = await verify(42, { expectedType: "credential" });
+    expect(result.type).toBe("unknown");
     expect(result.valid).toBe(false);
-    expect((result as { credential: unknown }).credential).toBeNull();
-    expect(result.errors![0]!.message).toBe("Unrecognized artifact format");
+    expect(result.errors![0]!.message).toBe('Unrecognized artifact format (expected "credential")');
   });
 
-  it("returns unrecognized format with presentation fallback type", async () => {
+  it("returns unknown (not a fake presentation) for unrecognized input with expectedType", async () => {
     const result = await verify(42, { expectedType: "presentation" });
+    expect(result.type).toBe("unknown");
     expect(result.valid).toBe(false);
-    expect((result as { presentation: unknown }).presentation).toBeNull();
-    expect(result.errors![0]!.message).toBe("Unrecognized artifact format");
+    expect(result.errors![0]!.message).toBe(
+      'Unrecognized artifact format (expected "presentation")',
+    );
   });
 
   it("dispatches identity string to verifyIdentity", async () => {
@@ -997,14 +1001,51 @@ describe("verify — identity edge cases", () => {
 describe("verify — unrecognized object formats", () => {
   it("returns null detection for an object without known fields", async () => {
     const result = await verify({ foo: "bar", baz: 42 });
+    expect(result.type).toBe("unknown");
     expect(result.valid).toBe(false);
     expect(result.errors![0]!.message).toBe("Unrecognized artifact format");
   });
 
   it("returns null detection for an empty object", async () => {
     const result = await verify({});
+    expect(result.type).toBe("unknown");
     expect(result.valid).toBe(false);
     expect(result.errors![0]!.message).toBe("Unrecognized artifact format");
+  });
+
+  it("reports type 'unknown' with a distinct reason — NOT a forged known type", async () => {
+    const result = await verify({ foo: "bar" });
+    expect(result.type).toBe("unknown");
+    // The honesty floor: an unrecognized artifact is its own outcome, never a
+    // degenerate `type:"identity", valid:false` (which would read as a forgery).
+    expect(result.type).not.toBe("identity");
+    if (result.type === "unknown") {
+      expect(result.reason).toBe("unrecognized_artifact_type");
+    }
+  });
+
+  it("reports a non-auto-detected signed artifact (ApprovalDecision) as unknown, not invalid", async () => {
+    // ApprovalDecision verifies via verifyApprovalDecision, not auto-detect — so
+    // through verify() it is genuinely unrecognized, reported honestly as such.
+    const kp = await generateKeypair();
+    const decision = await signApprovalDecision(
+      {
+        approval_id: "ad-1",
+        motebit_id: "motebit-x",
+        device_id: "dev-1",
+        tool_name: "send_email",
+        args_hash: "a".repeat(64),
+        risk_level: 2,
+        verdict: "approved",
+        requested_at: 1000,
+        resolved_at: 2000,
+      } as Parameters<typeof signApprovalDecision>[0],
+      kp.privateKey,
+      kp.publicKey,
+    );
+    const result = await verify(JSON.stringify(decision));
+    expect(result.type).toBe("unknown");
+    expect(result.valid).toBe(false);
   });
 });
 

--- a/packages/crypto/src/__tests__/verify-skill.test.ts
+++ b/packages/crypto/src/__tests__/verify-skill.test.ts
@@ -105,9 +105,11 @@ describe("verify() — skill arm", () => {
     expect(result.steps.envelope.reason).toBe("ed25519_mismatch");
   });
 
-  it("--expectedType skill is honored when input is a non-skill", async () => {
-    const result = (await verify({} as unknown, { expectedType: "skill" })) as SkillVerifyResult;
-    expect(result.type).toBe("skill");
+  it("an unrecognized input with --expectedType skill reports unknown, not a fake skill", async () => {
+    // Post honesty-floor: expectedType no longer fabricates a degenerate
+    // `type:"skill"` for unrecognized input — it is reported as unknown.
+    const result = await verify({} as unknown, { expectedType: "skill" });
+    expect(result.type).toBe("unknown");
     expect(result.valid).toBe(false);
     expect(result.errors?.[0]?.message).toMatch(/Unrecognized/);
   });

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -313,13 +313,30 @@ export interface SkillVerifyResult extends BaseResult {
   };
 }
 
+/**
+ * The artifact is not a recognized Motebit type — `detectArtifactType` matched
+ * no branch. This is distinct from `valid: false` on a *recognized* type
+ * (which means "a known artifact whose signature/structure failed"). A consumer
+ * MUST be able to tell "I don't know what this is" apart from "this is a forged
+ * receipt/identity/credential" — conflating the two reads an unrecognized blob
+ * as a forgery. `valid` is always `false` (nothing was verified). Artifacts that
+ * verify through a type-specific primitive rather than auto-detect (e.g. a flat
+ * `ApprovalDecision` → `verifyApprovalDecision`) land here under `verify()`.
+ */
+export interface UnknownVerifyResult extends BaseResult {
+  type: "unknown";
+  valid: false;
+  reason: "unrecognized_artifact_type";
+}
+
 export type VerifyResult =
   | IdentityVerifyResult
   | ReceiptVerifyResult
   | ToolInvocationVerifyResult
   | CredentialVerifyResult
   | PresentationVerifyResult
-  | SkillVerifyResult;
+  | SkillVerifyResult
+  | UnknownVerifyResult;
 
 export type ArtifactType = VerifyResult["type"];
 
@@ -622,7 +639,11 @@ const SIG_SUFFIX = " -->";
 // Artifact detection
 // ===========================================================================
 
-function detectArtifactType(artifact: unknown): ArtifactType | null {
+// Detection yields a concrete artifact type or `null` (unrecognized). It never
+// yields "unknown" — that is a verify *result* the dispatcher synthesizes from
+// the `null` case, not a detectable input shape. Excluding it keeps `verify()`'s
+// dispatch switch exhaustive over exactly the detectable types.
+function detectArtifactType(artifact: unknown): Exclude<ArtifactType, "unknown"> | null {
   // String → JSON artifact OR YAML-frontmatter identity file. The
   // identity-file format is YAML frontmatter wrapped in `---` delimiters
   // and is structurally never JSON-parseable, so JSON-parse first; only
@@ -1939,28 +1960,25 @@ export async function verify(artifact: unknown, options?: VerifyOptions): Promis
   const detected = detectArtifactType(artifact);
 
   if (detected === null) {
-    // Return a generic failure — use identity as the default type for backward compat
-    const fallbackType = options?.expectedType ?? "identity";
+    // Unrecognized artifact type — distinct from "valid:false on a known type."
+    // Previously this returned a degenerate `type:"identity", valid:false`
+    // ("backward compat"), which made an unrecognized blob indistinguishable
+    // from a forged identity file. An honest verifier reports "I don't know
+    // what this is" as its own result so a consumer never reads unrecognized as
+    // forged. `valid` stays false (nothing was verified).
+    const expected = options?.expectedType;
     return {
-      type: fallbackType,
+      type: "unknown",
       valid: false,
-      ...(fallbackType === "identity" ? { identity: null } : {}),
-      ...(fallbackType === "receipt" ? { receipt: null } : {}),
-      ...(fallbackType === "tool-invocation" ? { toolInvocation: null } : {}),
-      ...(fallbackType === "credential" ? { credential: null } : {}),
-      ...(fallbackType === "presentation" ? { presentation: null } : {}),
-      ...(fallbackType === "skill"
-        ? {
-            envelope: null,
-            steps: {
-              envelope: { valid: false, reason: "wrong_suite" as SkillVerifyReason },
-              body_hash: null,
-              files: [],
-            },
-          }
-        : {}),
-      errors: [{ message: "Unrecognized artifact format" }],
-    } as VerifyResult;
+      reason: "unrecognized_artifact_type",
+      errors: [
+        {
+          message: expected
+            ? `Unrecognized artifact format (expected "${expected}")`
+            : "Unrecognized artifact format",
+        },
+      ],
+    };
   }
 
   if (options?.expectedType && options.expectedType !== detected) {

--- a/packages/identity-file/src/__tests__/desktop-export-roundtrip.test.ts
+++ b/packages/identity-file/src/__tests__/desktop-export-roundtrip.test.ts
@@ -19,7 +19,13 @@ import { verify as canonicalVerify } from "@motebit/crypto";
 async function verify(content: string) {
   const r = await canonicalVerify(content, { expectedType: "identity" });
   if (r.type !== "identity") {
-    return { valid: false, identity: null, error: "not an identity file" };
+    // Non-identity input now resolves to `type:"unknown"` (the honesty floor),
+    // not the old `type:"identity"` fallback — surface the canonical reason.
+    return {
+      valid: false,
+      identity: null,
+      error: r.errors?.[0]?.message ?? "not an identity file",
+    };
   }
   return {
     valid: r.valid,

--- a/packages/identity-file/src/__tests__/index.test.ts
+++ b/packages/identity-file/src/__tests__/index.test.ts
@@ -28,7 +28,14 @@ import {
 async function standaloneVerify(content: string) {
   const r = await canonicalVerify(content, { expectedType: "identity" });
   if (r.type !== "identity") {
-    return { valid: false, identity: null, error: "not an identity file" };
+    // Non-identity input now resolves to a distinct `type:"unknown"` (the
+    // honesty floor) rather than the old `type:"identity"` fallback — surface
+    // the canonical reason rather than a hardcoded string.
+    return {
+      valid: false,
+      identity: null,
+      error: r.errors?.[0]?.message ?? "not an identity file",
+    };
   }
   const error = r.errors?.[0]?.message;
   return {
@@ -223,12 +230,12 @@ describe("missing or malformed signature", () => {
 
     const result = await verify(content);
     expect(result.valid).toBe(false);
-    // Canonical `verify()` path: the dispatcher fails to recognize a
-    // string without `---` as any signed artifact type, returning the
-    // generic format error. Callers that want identity-specific error
-    // detail can fall back to `parse(content)` which still throws
-    // "Missing frontmatter opening ---".
-    expect(result.error).toBe("Unrecognized artifact format");
+    // Canonical `verify()` path: the dispatcher fails to recognize a string
+    // without `---` as any signed artifact type, returning a distinct
+    // `type:"unknown"` whose error carries the generic format reason. Callers
+    // that want identity-specific error detail can fall back to `parse(content)`
+    // which still throws "Missing frontmatter opening ---".
+    expect(result.error).toContain("Unrecognized artifact format");
   });
 
   it("parse throws on missing closing ---", () => {

--- a/packages/verifier/src/__tests__/lib.test.ts
+++ b/packages/verifier/src/__tests__/lib.test.ts
@@ -167,6 +167,22 @@ describe("verifyArtifact — ToolInvocationReceipt dispatch + binding rung", () 
   });
 });
 
+describe("verifyArtifact — unrecognized artifacts read as 'unknown', not invalid", () => {
+  it("reports type 'unknown' for an unrecognized object (not a forged identity)", async () => {
+    const result = await verifyArtifact(JSON.stringify({ foo: "bar" }));
+    expect(result.type).toBe("unknown");
+    expect(result.valid).toBe(false);
+    expect(result.type).not.toBe("identity");
+  });
+
+  it("formatHuman renders UNRECOGNIZED, not INVALID, for an unknown artifact", async () => {
+    const result = await verifyArtifact(JSON.stringify({ foo: "bar" }));
+    const human = formatHuman(result);
+    expect(human.split("\n")[0]).toBe("UNRECOGNIZED (unknown)");
+    expect(human).not.toContain("INVALID");
+  });
+});
+
 describe("verifyArtifact — receipt binding rung (offline, receipt-alone)", () => {
   it("reports sovereign:true when motebit_id commits to the key", async () => {
     const r = await sovereignReceipt();
@@ -263,7 +279,14 @@ describe("formatHuman", () => {
   });
 
   it("renders INVALID header + per-error lines", async () => {
-    const result = await verifyArtifact({ not: "a real artifact" });
+    // A recognized-but-failed artifact (here: a receipt that didn't verify) —
+    // distinct from UNRECOGNIZED, which an unrecognized blob now renders instead.
+    const result = {
+      type: "receipt" as const,
+      valid: false,
+      receipt: null,
+      errors: [{ message: "§11.2 violation: Ed25519 signature did not verify" }],
+    };
     const out = formatHuman(result);
     expect(out.split("\n")[0]).toMatch(/^INVALID /);
     // Every subsequent line starts with 2 spaces + "-" for error items.

--- a/packages/verifier/src/lib.ts
+++ b/packages/verifier/src/lib.ts
@@ -328,7 +328,13 @@ export async function verifyArtifact(
  *   ```
  */
 export function formatHuman(result: VerifyResultWithBinding): string {
-  const header = `${result.valid ? "VALID" : "INVALID"} (${result.type})`;
+  // "unknown" is unrecognized, NOT a failed-signature verdict — render it
+  // distinctly so a reader never mistakes "I don't know this artifact" for
+  // "this known artifact is forged."
+  const header =
+    result.type === "unknown"
+      ? "UNRECOGNIZED (unknown)"
+      : `${result.valid ? "VALID" : "INVALID"} (${result.type})`;
   const lines: string[] = [header];
 
   if (result.valid) {
@@ -443,5 +449,9 @@ function summarizeValid(result: VerifyResultWithBinding): ReadonlyArray<readonly
       }
       return out;
     }
+    case "unknown":
+      // Never reached — summarizeValid runs only for valid results, and an
+      // "unknown" is always valid:false (its detail renders via the error path).
+      return [];
   }
 }

--- a/packages/verify/src/__tests__/unrecognized-cli.test.ts
+++ b/packages/verify/src/__tests__/unrecognized-cli.test.ts
@@ -1,0 +1,61 @@
+/**
+ * `motebit-verify <file>` exit-code honesty for UNRECOGNIZED artifacts.
+ *
+ * CLAUDE.md Rule 5: the CLI's exit codes distinguish verified (0) /
+ * invalid-but-detected (1) / usage-or-unrecognized (2). An artifact that is not
+ * a recognized motebit type is NOT a failed signature — it must exit 2 and
+ * render UNRECOGNIZED, so a caller can tell "I can't process this" apart from
+ * "this known artifact is forged." End-to-end via `npx tsx` against the binary.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CLI_SRC = resolve(HERE, "..", "cli.ts");
+
+function runCli(args: readonly string[]): {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+} {
+  const result = spawnSync("npx", ["--yes", "tsx", CLI_SRC, ...args], {
+    encoding: "utf-8",
+    timeout: 30_000,
+  });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+describe("motebit-verify — unrecognized artifact exit code", () => {
+  let unknownPath: string;
+
+  beforeAll(() => {
+    const tmp = mkdtempSync(join(tmpdir(), "motebit-verify-unknown-"));
+    unknownPath = join(tmp, "unknown.json");
+    // Well-formed JSON, but not any recognized motebit artifact shape.
+    writeFileSync(unknownPath, JSON.stringify({ foo: "bar", baz: 42 }));
+  });
+
+  it("exits 2 (unrecognized), NOT 1 (invalid signature), for an unknown artifact", () => {
+    const res = runCli([unknownPath]);
+    expect(res.status, `stderr: ${res.stderr}`).toBe(2);
+  });
+
+  it("renders UNRECOGNIZED, not INVALID", () => {
+    const res = runCli([unknownPath]);
+    expect(res.stdout).toMatch(/UNRECOGNIZED \(unknown\)/);
+    expect(res.stdout).not.toMatch(/INVALID/);
+  });
+
+  it("--json reports type 'unknown' with the unrecognized reason", () => {
+    const res = runCli([unknownPath, "--json"]);
+    const parsed = JSON.parse(res.stdout) as { type: string; valid: boolean; reason?: string };
+    expect(parsed.type).toBe("unknown");
+    expect(parsed.valid).toBe(false);
+    expect(parsed.reason).toBe("unrecognized_artifact_type");
+  });
+});

--- a/packages/verify/src/cli.ts
+++ b/packages/verify/src/cli.ts
@@ -983,6 +983,10 @@ async function main(): Promise<number> {
   } else {
     process.stdout.write(`${formatHuman(result)}\n`);
   }
+  // Exit-code contract (CLAUDE.md Rule 5): 0 verified / 1 invalid-but-detected /
+  // 2 usage-or-unrecognized. An unrecognized artifact is NOT a failed signature —
+  // it maps to 2, so a caller can tell "I can't process this" from "bad sig."
+  if (result.type === "unknown") return 2;
   return result.valid ? 0 : 1;
 }
 


### PR DESCRIPTION
## Unrecognized artifacts report `type: "unknown"` — the honesty floor

Completes the `verifyArtifact` honesty pass begun in #146 (ToolInvocationReceipt auto-detect). Before, an artifact `detectArtifactType` didn't recognize returned `{ type: options.expectedType ?? "identity", valid: false }` — so an unrecognized blob (a flat `ApprovalDecision` consumed via `verifyArtifact`, or any foreign JSON) was indistinguishable from a **tampered identity file**. That conflates "unknown type / wrong verifier" with "forged known artifact" — the one ambiguity a proof tool can't have.

### Change
- **`@motebit/crypto`**: new `UnknownVerifyResult` (`type:"unknown"`, `valid:false`, `reason:"unrecognized_artifact_type"`); `verify()`'s no-detection branch returns it. `detectArtifactType`'s return type is narrowed to `Exclude<ArtifactType, "unknown"> | null` — it never yields `"unknown"` (returns `null`), keeping the dispatch switch exhaustive over exactly the detectable types.
- **`@motebit/verifier`**: `formatHuman` renders `UNRECOGNIZED (unknown)`, not `INVALID`.
- **`@motebit/verify`**: an unrecognized artifact exits **2** (usage/unrecognized) — distinct from 1 (invalid signature) — per the CLI exit-code contract (Rule 5).

### Behavior change (minor; `valid` unchanged — still `false`)
Unrecognized input now reports `type:"unknown"` rather than the old `"identity"`/`expectedType` fallback. Tests asserting the fallback were updated. A `ToolInvocationReceipt`/`ExecutionReceipt` still auto-detects; an `ApprovalDecision` (verified via `verifyApprovalDecision`, not auto-detect) now honestly reads `unknown` — governance-triad doc notes this.

### Review evidence
- **Union-widening safe**: full monorepo typecheck **139/139**.
- **Downstream audited**: the full dependent turbo run (typecheck + lint + test:coverage, **200/200**) caught one real consumer break — `identity-file`'s test helpers hardcoded a legacy message and relied on the old `type:"identity"` fallback; fixed to surface the canonical reason. Production consumers (`identity-file`, `create-motebit`, `daemon`) were already defensive against `type !== "identity"`.
- crypto **535** / verifier **44** / verify **51** tests; 110 drift gates; gates-effective **120/120**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
