### PR TITLE
fix(scripts): check-gates-effective fails clearly on concurrent modification

### DIFF
--- a/scripts/__tests__/check-gates-effective.test.ts
+++ b/scripts/__tests__/check-gates-effective.test.ts
@@ -1,0 +1,67 @@
+/**
+ * check-gates-effective — concurrent-modification detection.
+ *
+ * The meta-gate mutates real files in place to inject probes, so its verdict is
+ * only meaningful if the injected bytes are still on disk when the gate reads
+ * them. If a concurrent build / typecheck / formatter / second invocation
+ * rewrites a probe target mid-run, a gate "passing" is an artifact of the race,
+ * not a dead gate. Before this guard that surfaced as the misleading "one or
+ * more gates failed to catch a known violation" (a real false-fail observed
+ * 2026-06-07 when a `pnpm typecheck` ran alongside a push's pre-push hook).
+ *
+ * `findClobberedPerturbations()` is what lets the runner tell the two apart.
+ * Imported directly — `main()` is guarded behind a direct-invocation check, so
+ * importing the module does not execute the 120-probe run.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { writeFileSync, unlinkSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { writeFixture, findClobberedPerturbations } from "../check-gates-effective.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..", "..");
+const REL = "scripts/__tests__/__gate_probe__clobber_unit.txt";
+const ABS = resolve(ROOT, REL);
+
+let cleanup: (() => void) | null = null;
+afterEach(() => {
+  if (cleanup) {
+    try {
+      cleanup();
+    } catch {
+      /* best-effort deregister */
+    }
+    cleanup = null;
+  }
+  if (existsSync(ABS)) unlinkSync(ABS);
+});
+
+describe("check-gates-effective — concurrent-modification detection", () => {
+  it("reports no clobber when the perturbation is intact on disk", () => {
+    cleanup = writeFixture(REL, "probe-bytes\n");
+    expect(findClobberedPerturbations()).toEqual([]);
+  });
+
+  it("reports a clobber when the probe target is rewritten underneath the run", () => {
+    cleanup = writeFixture(REL, "probe-bytes\n");
+    // Simulate a concurrent writer clobbering the injected bytes.
+    writeFileSync(ABS, "rewritten by a concurrent process\n");
+    expect(findClobberedPerturbations()).toContain(REL);
+  });
+
+  it("reports a clobber when the probe target is deleted underneath the run", () => {
+    cleanup = writeFixture(REL, "probe-bytes\n");
+    unlinkSync(ABS); // deleted out from under us also counts as clobbered
+    expect(findClobberedPerturbations()).toContain(REL);
+  });
+
+  it("deregisters on cleanup — a restored perturbation is no longer tracked", () => {
+    const c = writeFixture(REL, "probe-bytes\n");
+    c(); // probe cleaned up
+    cleanup = null;
+    // Even though the file is gone, it was deregistered, so it is not reported.
+    expect(findClobberedPerturbations()).toEqual([]);
+  });
+});

--- a/scripts/check-gates-effective.ts
+++ b/scripts/check-gates-effective.ts
@@ -42,8 +42,8 @@
 
 import { spawnSync } from "node:child_process";
 import { writeFileSync, unlinkSync, existsSync, readFileSync, readdirSync } from "node:fs";
-import { resolve, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { resolve, dirname, relative } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
@@ -76,11 +76,41 @@ interface Probe {
 }
 
 /**
+ * Perturbations currently written to disk: absolute path → the exact bytes the
+ * probe wrote. This gate mutates real files in place to inject a known
+ * violation, so its verdict is only meaningful if those bytes are still on disk
+ * when the gate runs. If something external (a concurrent build / typecheck /
+ * formatter / a second invocation) rewrites a probe target mid-run, the gate
+ * sees content it didn't inject and a "pass" means nothing — it would otherwise
+ * be misreported as "the gate failed to catch a known violation." This registry
+ * lets the runner detect that race and abort with an honest message instead.
+ */
+const activePerturbations = new Map<string, string>();
+
+/**
+ * Probe targets whose on-disk bytes no longer match what the probe wrote —
+ * i.e. clobbered out from under the run. Empty in the normal isolated case.
+ */
+export function findClobberedPerturbations(): string[] {
+  const clobbered: string[] = [];
+  for (const [absolute, expected] of activePerturbations) {
+    let actual: string | null = null;
+    try {
+      actual = readFileSync(absolute, "utf-8");
+    } catch {
+      actual = null; // deleted underneath us also counts as clobbered
+    }
+    if (actual !== expected) clobbered.push(relative(ROOT, absolute));
+  }
+  return clobbered;
+}
+
+/**
  * Write a fixture file and return a cleanup that removes it. If the file
  * already exists (unlikely — prefix guards against this), refuse to
  * clobber.
  */
-function writeFixture(relativePath: string, content: string): () => void {
+export function writeFixture(relativePath: string, content: string): () => void {
   const absolute = resolve(ROOT, relativePath);
   if (existsSync(absolute)) {
     throw new Error(
@@ -88,7 +118,9 @@ function writeFixture(relativePath: string, content: string): () => void {
     );
   }
   writeFileSync(absolute, content);
+  activePerturbations.set(absolute, content);
   return () => {
+    activePerturbations.delete(absolute);
     if (existsSync(absolute)) unlinkSync(absolute);
   };
 }
@@ -101,8 +133,13 @@ function writeFixture(relativePath: string, content: string): () => void {
 function mutateFile(relativePath: string, mutate: (src: string) => string): () => void {
   const absolute = resolve(ROOT, relativePath);
   const original = readFileSync(absolute, "utf-8");
-  writeFileSync(absolute, mutate(original));
-  return () => writeFileSync(absolute, original);
+  const mutated = mutate(original);
+  writeFileSync(absolute, mutated);
+  activePerturbations.set(absolute, mutated);
+  return () => {
+    activePerturbations.delete(absolute);
+    writeFileSync(absolute, original);
+  };
 }
 
 const PROBES: ReadonlyArray<Probe> = [
@@ -2308,6 +2345,12 @@ function main(): void {
     process.exit(143);
   });
 
+  // Set if a probe target is clobbered out from under the run (concurrent
+  // build/typecheck/formatter/second-invocation). When this happens a gate
+  // "passing" is meaningless — abort with an honest message rather than
+  // misreport the gate as ineffective.
+  let concurrentModification: string[] | null = null;
+
   for (const probe of PROBES) {
     process.stderr.write(`\n▸ ${probe.script} — ${probe.proves}\n`);
     // Escape-hatch check. If a gate has a documented escape hatch currently
@@ -2346,6 +2389,14 @@ function main(): void {
       });
       gateExitCode = result.status;
       ok = gateExitCode !== null && gateExitCode !== 0;
+      // A gate "passing" (exit 0) is only meaningful if the perturbation was
+      // actually on disk when the gate read it. If it was clobbered mid-run,
+      // the apparent pass is an artifact of a non-isolated environment, not a
+      // dead gate — distinguish the two before we accuse the gate.
+      if (!ok) {
+        const clobbered = findClobberedPerturbations();
+        if (clobbered.length > 0) concurrentModification = clobbered;
+      }
     } catch (err) {
       error = err instanceof Error ? err.message : String(err);
     } finally {
@@ -2359,6 +2410,18 @@ function main(): void {
       activeCleanup = null;
     }
     results.push({ probe, gateExitCode, ok, error });
+    if (concurrentModification) break; // tree is unstable — remaining probes are unreliable too
+  }
+
+  if (concurrentModification) {
+    process.stderr.write(
+      `\n⚠ Concurrent modification detected — probe target(s) changed underneath the run:\n` +
+        concurrentModification.map((p) => `    ${p}`).join("\n") +
+        `\n\ncheck-gates-effective mutates files in place to inject probes, so it MUST run in isolation. ` +
+        `Something rewrote a probe target mid-run (a concurrent build, typecheck, formatter, or a second ` +
+        `invocation). This is NOT a gate failure — re-run it alone.\n`,
+    );
+    process.exit(2);
   }
 
   // Summary
@@ -2393,4 +2456,8 @@ function main(): void {
   process.stderr.write(`\n${provenCount} of ${PROBES.length} gates proven effective${skipNote}.\n`);
 }
 
-main();
+// Run only when invoked directly (pnpm check-gates-effective / tsx). Guarded so
+// the module can be imported by its own unit test without executing all probes.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main();
+}


### PR DESCRIPTION
## `check-gates-effective` fails clearly on concurrent modification, not misleadingly

The meta-gate mutates real files in place to inject probes, so a gate "passing" is only meaningful if the injected bytes are still on disk when the gate reads them. If a concurrent build / typecheck / formatter / second invocation rewrites a probe target mid-run, the gate sees content it didn't inject — and a pass was reported as *"one or more gates failed to catch a known violation … the gate is decoration masquerading as defense."* That points at the wrong cause. (Real false-fail observed 2026-06-07 when a `pnpm typecheck` ran alongside a push's pre-push hook — cost a full ~10-min hook cycle chasing a non-bug.)

### Change
- Track each probe's injected bytes in an `activePerturbations` registry (`writeFixture`/`mutateFile` register on apply, deregister on cleanup).
- `findClobberedPerturbations()` reports targets whose on-disk bytes no longer match what the probe wrote (rewritten or deleted underneath the run).
- On an unexpected gate pass (exit 0), check for clobber **first**; if found, abort with *"Concurrent modification detected — … MUST run in isolation … This is NOT a gate failure — re-run it alone"* and exit **2** (distinct from the exit-1 "gate is ineffective" verdict). Remaining probes are skipped — an unstable tree makes them all unreliable.
- `main()` is guarded behind a direct-invocation check (`import.meta.url === argv[1]`) so the detector is unit-testable without executing all 120 probes.

### Why this and not full isolation
Per-probe worktree isolation would be heavy (~120 probes). This is the proportionate fix: it converts a misleading false-fail into an actionable message. It can't false-*pass* (the race skews toward false-fail; clobber is only consulted when a gate unexpectedly passes), so it's a trust/UX fix, not a safety hole.

### Verification
- Gate still runs **120/120** when invoked directly (proves the `import.meta` guard didn't disable it).
- Unit test (`scripts/__tests__/check-gates-effective.test.ts`): intact → no clobber; rewritten / deleted target → reported; deregistered-on-cleanup → not reported (4/4).
- Format + 110 drift gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
