### PR TITLE
chore(hygiene): drop 2 verified-dead exports

### DIFF
--- a/.changeset/drop-dead-internal-exports.md
+++ b/.changeset/drop-dead-internal-exports.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+Remove the dead internal `isPlanEmpty` helper from the `up` subcommand — it was exported but had zero callers (not a CLI command or public API). No behavior change.

--- a/apps/cli/src/subcommands/up.ts
+++ b/apps/cli/src/subcommands/up.ts
@@ -193,16 +193,6 @@ export async function applyMotebitYaml(opts: ApplyOptions): Promise<ApplyResult>
   }
 }
 
-/** True if the plan would write nothing (regardless of prune flag). */
-export function isPlanEmpty(plan: Plan): boolean {
-  return (
-    plan.add.length === 0 &&
-    plan.update.length === 0 &&
-    plan.prune.length === 0 &&
-    plan.configUnchanged
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Pure diffPlan — no IO. Exported for tests.
 // ---------------------------------------------------------------------------

--- a/services/relay/src/dispute-orchestration.ts
+++ b/services/relay/src/dispute-orchestration.ts
@@ -41,9 +41,6 @@ const logger = createLogger({ service: "relay", module: "dispute-orchestration" 
 /** §6.6 adjudication window — the orchestrator's deferred attempt deadline. */
 export const ORCHESTRATION_DEADLINE_MS = 72 * 60 * 60 * 1000;
 
-/** Per-attempt timeout — the per-request fan-out deadline (one attempt). */
-export const ORCHESTRATION_PER_ATTEMPT_TIMEOUT_MS = 10_000;
-
 /** Backoff cap — no single inter-attempt gap exceeds this. */
 const ORCHESTRATION_BACKOFF_CAP_MS = 30 * 60 * 1000;
 


### PR DESCRIPTION
The two clearly-leftover zero-ref exports from the export triage (the other 5 flagged exports are deliberate unwired seams — left for a product decision).

- **`apps/cli` up.ts**: `isPlanEmpty` — exported helper, zero callers, not a CLI command or public API.
- **`services/relay` dispute-orchestration.ts**: `ORCHESTRATION_PER_ATTEMPT_TIMEOUT_MS` — exported const, never read (orchestrator uses `ORCHESTRATION_DEADLINE_MS` + the backoff cap).

Verified: build + typecheck + lint + test for `motebit` + `@motebit/relay` (53 tasks), both published binaries boot (`check-dist-smoke`), format clean. Patch changeset for `motebit` (published-package src change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)