### PR TITLE
chore(hygiene): resolve the 5 unwired export seams — 4 remove, 1 wire

### DIFF
--- a/.changeset/drop-list-archived-receipts.md
+++ b/.changeset/drop-list-archived-receipts.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+Remove the unused `listArchivedReceipts` helper — it listed an in-memory per-REPL session archive (not a durable store) and had zero callers; the by-id `getArchivedReceipt` (used within a single `invoke` run) stays. No behavior change.

--- a/apps/cli/src/receipt.ts
+++ b/apps/cli/src/receipt.ts
@@ -48,11 +48,6 @@ export function getArchivedReceipt(taskId: string): ExecutionReceipt | undefined
   return ARCHIVE.get(taskId);
 }
 
-/** List archived task_ids in insertion order. */
-export function listArchivedReceipts(): ExecutionReceipt[] {
-  return Array.from(ARCHIVE.values());
-}
-
 /** Clear the session archive. Used by tests. */
 export function clearReceiptArchive(): void {
   ARCHIVE.clear();

--- a/apps/web/src/storage.ts
+++ b/apps/web/src/storage.ts
@@ -380,34 +380,6 @@ export function setTTSKey(vendor: TTSVendorKey, key: string | null): void {
   setVendorKey(vendor, key);
 }
 
-/**
- * @deprecated Use `VendorKey` and `getVendorKey` / `setVendorKey`.
- *
- * Reason: see `TTSVendorKey` above — STT keys share the unified
- * `VendorKey` namespace because every supported vendor is dual-purpose.
- */
-export type STTVendorKey = VendorKey;
-
-/**
- * @deprecated Use `getVendorKey`.
- *
- * Reason: see `TTSVendorKey` above — direction-tagged accessor is a
- * legacy shape from the Whisper-cloud-STT-only era.
- */
-export function getSTTKey(vendor: STTVendorKey): string | null {
-  return getVendorKey(vendor);
-}
-
-/**
- * @deprecated Use `setVendorKey`.
- *
- * Reason: see `TTSVendorKey` above — direction-tagged accessor is a
- * legacy shape from the Whisper-cloud-STT-only era.
- */
-export function setSTTKey(vendor: STTVendorKey, key: string | null): void {
-  setVendorKey(vendor, key);
-}
-
 // === Sovereignty Ceiling CTA ===
 
 const CEILING_KEY = "motebit-ceiling-shown";

--- a/packages/wallet-solana/src/constants.ts
+++ b/packages/wallet-solana/src/constants.ts
@@ -8,9 +8,6 @@ export const USDC_MINT_MAINNET = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 /** Devnet USDC mint (base58). Useful for tests and development. */
 export const USDC_MINT_DEVNET = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
 
-/** USDC has 6 decimals on Solana — same as motebit micro-units. */
-export const USDC_DECIMALS = 6;
-
 /**
  * Thrown when a USDC transfer is attempted but the agent's wallet
  * holds less than the requested amount. Distinct from RPC failures

--- a/services/browser-sandbox/src/auth.ts
+++ b/services/browser-sandbox/src/auth.ts
@@ -183,20 +183,3 @@ export function requireAuth(opts: RequireAuthOptions): MiddlewareHandler {
     throw new ServiceError("permission_denied", "missing or invalid bearer token");
   };
 }
-
-/**
- * @deprecated Use `requireAuth({ legacyApiToken, trustedRelayPublicKeyHex })` instead.
- *
- * Reason: the v1 shared-bearer model has been superseded by the
- * relay-mediated `aud`-bound signed-token flow (see file header).
- * This shim is preserved for the dualAuth transition window — when
- * both paths are off and only `MOTEBIT_API_TOKEN` is set, behavior is
- * unchanged. Removed once `MOTEBIT_TRUSTED_RELAY_PUBKEY` is the sole
- * production auth path.
- *
- * (No `since`/`removed in` semver — `0.0.0-private` package per
- * `docs/doctrine/deprecation-lifecycle.md` § Private packages.)
- */
-export function requireBearer(expectedToken: string): MiddlewareHandler {
-  return requireAuth({ legacyApiToken: expectedToken, trustedRelayPublicKeyHex: null });
-}

--- a/services/relay/.env.example
+++ b/services/relay/.env.example
@@ -190,3 +190,10 @@ MOTEBIT_TREASURY_RECONCILIATION_INTERVAL_MS=900000
 # fee leg the reconciler audits). See docs/doctrine/treasury-custody.md
 # § "Solana p2p-fee reconciliation".
 MOTEBIT_SOLANA_TREASURY_RECONCILIATION_INTERVAL_MS=900000
+
+# Expo push access token — activates mobile push-wake. When set, the relay
+# constructs an ExpoPushAdapter and attemptPushWake sends a minimal wake-signal
+# (motebit_id, pending count, ts — no message body) to the mobile devices that
+# registered via POST /api/v1/agents/push-token. Absent → push-wake cleanly
+# off (the full chain is built; this is the deliberate activation switch).
+EXPO_ACCESS_TOKEN=

--- a/services/relay/src/index.ts
+++ b/services/relay/src/index.ts
@@ -161,6 +161,7 @@ import { startBatchWithdrawalLoop, getPendingWithdrawalsSummary } from "./batch-
 import { registerAgentRoutes } from "./agents.js";
 import { createFederationCallbacks } from "./federation-callbacks.js";
 import { registerTaskRoutes } from "./tasks.js";
+import { ExpoPushAdapter } from "./push-adapter.js";
 import { TaskQueue } from "./task-queue.js";
 import { registerCommandRoutes, handleCommandResponse } from "./command-route.js";
 import Stripe from "stripe";
@@ -1594,6 +1595,16 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
     getEmergencyFreeze(),
   );
 
+  // Mobile push-wake adapter — env-gated like the Solana/x402 capabilities.
+  // The full chain is already live (mobile registers Expo tokens via
+  // POST /api/v1/agents/push-token → relay_push_tokens; attemptPushWake reads
+  // them); this is the one construction that activates it. Absent token →
+  // undefined → attemptPushWake cleanly no-ops (no push, no dishonest claim).
+  const pushAdapter = process.env.EXPO_ACCESS_TOKEN
+    ? new ExpoPushAdapter({ accessToken: process.env.EXPO_ACCESS_TOKEN })
+    : undefined;
+  logger.info("relay.push_wake", { enabled: pushAdapter !== undefined });
+
   // --- Task routes (submission, polling, receipt settlement) ---
   await registerTaskRoutes({
     app,
@@ -1615,6 +1626,7 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
     isAgentRevoked,
     platformFeeRate,
     railRegistry,
+    pushAdapter,
   });
 
   // --- Helper: count all connected WebSocket clients ---


### PR DESCRIPTION
The "deliberate-but-unwired" exports were a false category. Motebit's intent: a capability is **wired+live or absent** — exported-but-doing-nothing is decoration masquerading as defense. Checked each against reality (verify-first flipped two of them):

**4 removed** (superseded leftovers / no consumer):
- `requireBearer` (browser-sandbox) — @deprecated shim; routes use `requireAuth` (live).
- `getSTTKey`/`setSTTKey` + orphaned `STTVendorKey` (web) — @deprecated; STT keys moved to unified BYOK storage.
- `USDC_DECIMALS` (wallet-solana) — redundant by design; the integer micro-unit money model encodes it.
- `listArchivedReceipts` (cli) — operates on an **in-memory per-REPL map**, not a durable archive; a `motebit receipts` command would always be empty (a new lie). `getArchivedReceipt`/`archiveReceipt` (used within a single `invoke` run) stay.

**1 wired** (`ExpoPushAdapter`, relay) — the sharpest: mobile registers Expo tokens → relay stores them (`relay_push_tokens`) → `attemptPushWake` reads + sends, **but the relay never constructed the only adapter** → push-wake was a structural no-op *and the transparency declaration documented a wake that never fired*. Fixed: construct it **env-gated on `EXPO_ACCESS_TOKEN`** (same pattern as Solana/x402). Token → fires; absent → cleanly off. `relay.push_wake {enabled}` startup log; `EXPO_ACCESS_TOKEN` added to `.env.example` (check-deploy-parity). Transparency declaration unchanged — now true rather than dormant.

Verification: all affected packages build/typecheck/lint/test; both published binaries boot (dist-smoke); 110 drift gates + check-deploy-parity pass; format clean. Patch changesets for `motebit` (the two cli src removals). Other packages private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)