### PR TITLE
feat(crypto,verifier,verify): opt-in strict hash-binding verification

### DIFF
--- a/.changeset/strict-hash-binding-verify.md
+++ b/.changeset/strict-hash-binding-verify.md
@@ -1,0 +1,15 @@
+---
+"@motebit/crypto": minor
+"@motebit/verifier": minor
+"@motebit/verify": minor
+---
+
+Add opt-in strict hash-binding verification — close the "valid signature ≠ self-consistent receipt" gap.
+
+A valid Ed25519 signature proves a receipt's bytes are authentic, but **not** that its `result_hash` actually equals `SHA-256(result)` (the spec formula in `spec/execution-ledger-v1.md` § Hash fields). Nothing enforced that — so a mis-minted `ExecutionReceipt` whose `result_hash` doesn't bind its own `result` field still verified `valid:true, sovereign:true`, while a third party recomputing the hash per spec would get a mismatch. A signed receipt whose `result_hash` nobody can reproduce from its `result` is a signed number, not a proof.
+
+- `@motebit/crypto`: `VerifyOptions.strictHashBinding` — when `true`, `verify()`/`verifyReceipt()` recompute `hex(SHA-256(UTF-8(result)))` for `ExecutionReceipt`s and reject a mismatch (`valid:false`, `result_hash`-path error). Default `false` (signature-only, unchanged). Only `ExecutionReceipt` carries a raw `result`; `ToolInvocationReceipt` (args/result committed by hash only) and other types are unaffected. Verified opt-in-safe: every motebit-produced ExecutionReceipt already satisfies the formula.
+- `@motebit/verifier`: `verifyArtifact`/`verifyFile` forward `strictHashBinding`.
+- `@motebit/verify`: `motebit-verify <receipt> --strict`.
+
+Use this when you mint receipts and want the in-browser/CLI ✓ to mean _both_ "authentic signature" AND "internally self-consistent" — not just the former.

--- a/packages/crypto/etc/crypto.api.md
+++ b/packages/crypto/etc/crypto.api.md
@@ -1596,10 +1596,11 @@ export interface VerifyOptions {
     // (undocumented)
     expectedType?: ArtifactType;
     hardwareAttestation?: HardwareAttestationVerifiers;
+    strictHashBinding?: boolean;
 }
 
 // @public
-export function verifyReceipt(receipt: ExecutionReceipt): Promise<ReceiptVerifyResult>;
+export function verifyReceipt(receipt: ExecutionReceipt, options?: VerifyOptions): Promise<ReceiptVerifyResult>;
 
 // @public
 export function verifyReceiptChain(receipt: SignableReceipt, knownKeys: KnownKeys): Promise<ReceiptVerification>;

--- a/packages/crypto/src/__tests__/verify-artifacts.test.ts
+++ b/packages/crypto/src/__tests__/verify-artifacts.test.ts
@@ -31,6 +31,7 @@ import type {
 import {
   generateKeypair,
   verify,
+  hash,
   ed25519Sign,
   ed25519Verify,
   createSignedToken,
@@ -2634,5 +2635,61 @@ describe("verify() — ToolInvocationReceipt dispatch", () => {
       kp.publicKey,
     );
     expect((await verify(JSON.stringify(exec))).type).toBe("receipt");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verify() — strict hash binding (result_hash must equal SHA-256(result))
+// A valid signature proves authenticity, NOT self-consistency. Strict mode
+// catches a signed-but-mis-minted receipt whose result_hash a third party
+// can't reproduce from result — the "signed number nobody can reproduce" bug.
+// ---------------------------------------------------------------------------
+
+describe("verify() — strictHashBinding", () => {
+  async function signedReceipt(resultHash: string, result = "did the thing") {
+    const kp = await generateKeypair();
+    return signExecutionReceipt(
+      {
+        task_id: "t1",
+        motebit_id: "m",
+        device_id: "d1",
+        submitted_at: 1,
+        completed_at: 2,
+        status: "completed",
+        result,
+        tools_used: [],
+        memories_formed: 0,
+        prompt_hash: "a".repeat(64),
+        result_hash: resultHash,
+      } as unknown as Parameters<typeof signExecutionReceipt>[0],
+      kp.privateKey,
+      kp.publicKey,
+    );
+  }
+
+  it("a spec-correct receipt (result_hash == sha256(result)) passes strict", async () => {
+    const result = "reconciled 1,284 payouts; 3 flagged";
+    const r = await signedReceipt(await hash(new TextEncoder().encode(result)), result);
+    expect((await verify(JSON.stringify(r))).valid).toBe(true); // default
+    expect((await verify(JSON.stringify(r), { strictHashBinding: true })).valid).toBe(true);
+  });
+
+  it("a signed-but-self-inconsistent receipt passes default but FAILS strict", async () => {
+    const result = "reconciled 1,284 payouts; 3 flagged";
+    // result_hash binds the JSON-quoted string (the canonicalSha256-of-a-string trap),
+    // not the raw result — the signature is still valid over this body.
+    const wrong = await hash(new TextEncoder().encode(`"${result}"`));
+    const r = await signedReceipt(wrong, result);
+    const def = await verify(JSON.stringify(r));
+    expect(def.valid).toBe(true); // signature is authentic
+    const strict = await verify(JSON.stringify(r), { strictHashBinding: true });
+    expect(strict.valid).toBe(false);
+    expect(strict.errors?.[0]?.message).toMatch(/result_hash does not equal/);
+  });
+
+  it("default (no strict) is unchanged — only checks the signature", async () => {
+    const r = await signedReceipt("f".repeat(64), "anything"); // result_hash unrelated to result
+    expect((await verify(JSON.stringify(r))).valid).toBe(true);
+    expect((await verify(JSON.stringify(r), { strictHashBinding: true })).valid).toBe(false);
   });
 });

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -26,6 +26,7 @@ import type { MerkleTreeVersion } from "@motebit/protocol";
 import { verifyBySuite } from "./suite-dispatch.js";
 import { verifyMerkleInclusion, canonicalLeaf, resolveTreeHashVersion } from "./merkle.js";
 import { verifyToolInvocationReceipt, type SignableToolInvocationReceipt } from "./artifacts.js";
+import { hash } from "./signing.js";
 // The @noble/ed25519 SHA-512 binding is performed in suite-dispatch.ts
 // as a side effect of module load. Importing verifyBySuite here is
 // enough to guarantee that the primitive is ready before any verify
@@ -355,6 +356,22 @@ export interface VerifyOptions {
    * `hardware-attestation.ts::HardwareAttestationVerifiers`.
    */
   hardwareAttestation?: HardwareAttestationVerifiers;
+  /**
+   * When `true`, additionally verify that an `ExecutionReceipt`'s `result_hash`
+   * equals `hex(SHA-256(UTF-8(result)))` — the spec formula
+   * (`spec/execution-ledger-v1.md` § Hash fields). Default `false`
+   * (signature-only), for backward compatibility AND because a valid signature
+   * proves the bytes are authentic, NOT that the receipt is internally
+   * self-consistent. Strict mode catches a receipt whose committed
+   * `result_hash` does not bind its own `result` field — a mis-minted receipt
+   * that would otherwise read `valid:true` yet be unrecomputable by a third
+   * party (the "signed number nobody can reproduce" failure). On mismatch the
+   * receipt verifies `valid:false` with a `result_hash`-path error. Only
+   * `ExecutionReceipt` carries a raw `result` to check; other artifact types
+   * (incl. `ToolInvocationReceipt`, which commits args/result by hash only) are
+   * unaffected.
+   */
+  strictHashBinding?: boolean;
 }
 
 // ===========================================================================
@@ -1402,7 +1419,10 @@ async function verifyReceiptSignature(
  * directly against motebit X's own public key, without trusting the
  * relay's word.
  */
-export async function verifyReceipt(receipt: ExecutionReceipt): Promise<ReceiptVerifyResult> {
+export async function verifyReceipt(
+  receipt: ExecutionReceipt,
+  options?: VerifyOptions,
+): Promise<ReceiptVerifyResult> {
   // Resolve public key: embedded in receipt, or fail
   let publicKey: Uint8Array | null = null;
   let signerDid: string | undefined;
@@ -1455,9 +1475,25 @@ export async function verifyReceipt(receipt: ExecutionReceipt): Promise<ReceiptV
     });
   }
 
+  // Strict mode: the signature proves authenticity, NOT that result_hash binds
+  // the result field. Recompute it per spec and reject a self-inconsistent
+  // receipt (one whose result_hash a third party can't reproduce from result).
+  let resultHashOk = true;
+  if (options?.strictHashBinding) {
+    const expected = await hash(new TextEncoder().encode(receipt.result));
+    resultHashOk = expected === receipt.result_hash;
+    if (!resultHashOk) {
+      errors.push({
+        message:
+          "result_hash does not equal hex(SHA-256(result)) — receipt is not self-consistent (strict mode)",
+        path: "result_hash",
+      });
+    }
+  }
+
   return {
     type: "receipt",
-    valid: sigResult.valid && delegationErrors.length === 0,
+    valid: sigResult.valid && delegationErrors.length === 0 && resultHashOk,
     receipt,
     signer: signerDid,
     keySource: "embedded",
@@ -2036,7 +2072,7 @@ export async function verify(artifact: unknown, options?: VerifyOptions): Promis
     case "identity":
       return verifyIdentity(resolved as string);
     case "receipt":
-      return verifyReceipt(resolved as ExecutionReceipt);
+      return verifyReceipt(resolved as ExecutionReceipt, options);
     case "tool-invocation":
       return verifyToolInvocation(resolved as SignableToolInvocationReceipt);
     case "credential":

--- a/packages/verifier/src/__tests__/lib.test.ts
+++ b/packages/verifier/src/__tests__/lib.test.ts
@@ -18,7 +18,9 @@ import type { ExecutionReceipt } from "@motebit/crypto";
 import {
   deriveSovereignMotebitId,
   signToolInvocationReceipt,
+  signExecutionReceipt,
   hashToolPayload,
+  hash,
 } from "@motebit/crypto";
 
 import { formatHuman, verifyArtifact, verifyFile } from "../lib.js";
@@ -508,5 +510,41 @@ describe("formatHuman", () => {
     const synthetic = { type: "presentation" as const, valid: true, presentation: null };
     const out = formatHuman(synthetic);
     expect(out.split("\n")[0]).toBe("VALID (presentation)");
+  });
+});
+
+describe("verifyArtifact — strictHashBinding forwards to crypto", () => {
+  async function signedReceipt(resultHash: string, result: string) {
+    const sk = ed.utils.randomSecretKey();
+    const pk = await ed.getPublicKeyAsync(sk);
+    return signExecutionReceipt(
+      {
+        task_id: "t1",
+        motebit_id: await deriveSovereignMotebitId(toHex(pk)),
+        public_key: toHex(pk),
+        device_id: "d1",
+        submitted_at: 1,
+        completed_at: 2,
+        status: "completed",
+        result,
+        tools_used: [],
+        memories_formed: 0,
+        prompt_hash: "a".repeat(64),
+        result_hash: resultHash,
+      } as unknown as Parameters<typeof signExecutionReceipt>[0],
+      sk,
+      pk,
+    );
+  }
+
+  it("a signed-but-self-inconsistent receipt is valid+sovereign by default, rejected under strict", async () => {
+    const result = "reconciled 1,284 payouts; 3 flagged";
+    const wrong = await hash(new TextEncoder().encode(`"${result}"`)); // the canonicalSha256-of-string trap
+    const r = await signedReceipt(wrong, result);
+    const def = await verifyArtifact(JSON.stringify(r));
+    expect(def.valid).toBe(true);
+    expect(def.sovereign).toBe(true); // the green badge passes — exactly why strict is needed
+    const strict = await verifyArtifact(JSON.stringify(r), { strictHashBinding: true });
+    expect(strict.valid).toBe(false);
   });
 });

--- a/packages/verifier/src/lib.ts
+++ b/packages/verifier/src/lib.ts
@@ -71,6 +71,15 @@ export interface VerifyFileOptions {
    * `@motebit/verify` wires all four leaves automatically.
    */
   readonly hardwareAttestation?: HardwareAttestationVerifiers;
+  /**
+   * When `true`, additionally verify an `ExecutionReceipt`'s `result_hash`
+   * equals `hex(SHA-256(UTF-8(result)))` (the spec formula). A valid signature
+   * proves the bytes are authentic but NOT that `result_hash` binds the
+   * `result` field; strict mode rejects a self-inconsistent receipt — one whose
+   * committed hash a third party can't reproduce from its own `result`.
+   * Forwarded to `@motebit/crypto::verify`. Default `false`.
+   */
+  readonly strictHashBinding?: boolean;
 }
 
 /**
@@ -276,7 +285,8 @@ export async function verifyArtifact(
   const cryptoOpts: VerifyOptions | undefined =
     opts?.expectedType !== undefined ||
     opts?.clockSkewSeconds !== undefined ||
-    opts?.hardwareAttestation !== undefined
+    opts?.hardwareAttestation !== undefined ||
+    opts?.strictHashBinding !== undefined
       ? {
           ...(opts.expectedType !== undefined && { expectedType: opts.expectedType }),
           ...(opts.clockSkewSeconds !== undefined && {
@@ -284,6 +294,9 @@ export async function verifyArtifact(
           }),
           ...(opts.hardwareAttestation !== undefined && {
             hardwareAttestation: opts.hardwareAttestation,
+          }),
+          ...(opts.strictHashBinding !== undefined && {
+            strictHashBinding: opts.strictHashBinding,
           }),
         }
       : undefined;

--- a/packages/verify/src/cli.ts
+++ b/packages/verify/src/cli.ts
@@ -99,6 +99,7 @@ interface ParsedArgs {
   readonly json: boolean;
   readonly expectedType?: ArtifactType;
   readonly clockSkewSeconds?: number;
+  readonly strictHashBinding?: boolean;
   readonly bundleId?: string;
   readonly androidAttestationApplicationIdPath?: string;
   readonly rpId?: string;
@@ -129,6 +130,7 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
   let json = false;
   let expectedType: ArtifactType | undefined;
   let clockSkewSeconds: number | undefined;
+  let strictHashBinding = false;
   let bundleId: string | undefined;
   let androidAttestationApplicationIdPath: string | undefined;
   let rpId: string | undefined;
@@ -151,6 +153,10 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
         break;
       case "--json":
         json = true;
+        i++;
+        break;
+      case "--strict":
+        strictHashBinding = true;
         i++;
         break;
       case "--expect":
@@ -228,6 +234,7 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
     json,
     ...(expectedType !== undefined && { expectedType }),
     ...(clockSkewSeconds !== undefined && { clockSkewSeconds }),
+    ...(strictHashBinding && { strictHashBinding }),
     ...(bundleId !== undefined && { bundleId }),
     ...(androidAttestationApplicationIdPath !== undefined && {
       androidAttestationApplicationIdPath,
@@ -464,6 +471,9 @@ function renderHelp(): string {
     "  --json                    Print structured JSON instead of human-readable.",
     "  --expect <type>           Require the artifact to be of the named type.",
     "  --clock-skew <seconds>    Allow N seconds of clock skew.",
+    "  --strict                  Also verify an ExecutionReceipt's result_hash",
+    "                            equals SHA-256(result) — reject a signed receipt",
+    "                            whose hash doesn't bind its own result.",
     "  --bundle-id <id>          Override the expected iOS bundle ID for App Attest",
     "                            (default: com.motebit.mobile).",
     "  --android-attestation-application-id <path>",
@@ -970,6 +980,7 @@ async function main(): Promise<number> {
     result = await verifyFile(args.file, {
       ...(args.expectedType !== undefined && { expectedType: args.expectedType }),
       ...(args.clockSkewSeconds !== undefined && { clockSkewSeconds: args.clockSkewSeconds }),
+      ...(args.strictHashBinding && { strictHashBinding: true }),
       hardwareAttestation,
     });
   } catch (err) {


### PR DESCRIPTION
Closes the "valid signature ≠ self-consistent receipt" gap that agency.computer's minting work surfaced and then cold-confirmed in their own receipts.

A valid Ed25519 signature proves a receipt's bytes are authentic, but nothing checked that `result_hash` equals `SHA-256(result)` (the spec formula, `execution-ledger-v1` § Hash fields). A mis-minted `ExecutionReceipt` whose `result_hash` doesn't bind its own `result` verified `valid:true, sovereign:true` while a third party recomputing per spec gets a mismatch — a signed number, not a proof.

- **`@motebit/crypto`**: `VerifyOptions.strictHashBinding` — `verify()`/`verifyReceipt()` recompute `hex(SHA-256(UTF-8(result)))` for `ExecutionReceipt`s and reject a mismatch (`valid:false`, `result_hash`-path error). Default `false` (signature-only). Only `ExecutionReceipt` carries a raw `result`; `ToolInvocationReceipt` + others unaffected. Opt-in-safe: every motebit-produced ExecutionReceipt already satisfies the formula.
- **`@motebit/verifier`**: `verifyArtifact`/`verifyFile` forward `strictHashBinding`.
- **`@motebit/verify`**: `motebit-verify <receipt> --strict`.

Proven: a signed-but-self-inconsistent receipt (the `canonicalSha256`-of-a-string trap) reads `valid+sovereign` by default but is rejected under strict — the exact failure mode agency would have shipped.

crypto 179 + verifier 45 + verify 51 pass; 110 drift gates; api-surface aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)