### PR TITLE
docs(developer): fix result_hash recipe drift that shipped a cold-integrator bug

### DIFF
--- a/apps/docs/content/docs/developer/delegation.mdx
+++ b/apps/docs/content/docs/developer/delegation.mdx
@@ -30,11 +30,11 @@ _motebit.search.example.com TXT "v=motebit1 url=https://search.example.com/.well
 
 Fields:
 
-| Field | Required | Description |
-|-------|----------|-------------|
-| `v=motebit1` | Yes | Protocol version identifier |
-| `url=` | Yes | URL to the signed `motebit.md` identity file |
-| `endpoint=` | No | MCP server endpoint URL |
+| Field        | Required | Description                                  |
+| ------------ | -------- | -------------------------------------------- |
+| `v=motebit1` | Yes      | Protocol version identifier                  |
+| `url=`       | Yes      | URL to the signed `motebit.md` identity file |
+| `endpoint=`  | No       | MCP server endpoint URL                      |
 
 ### Well-known fallback
 
@@ -89,7 +89,7 @@ The `motebit_task` synthetic tool is the delegation entry point. It accepts a pr
 
 1. Receives the prompt via MCP tool call.
 2. Executes the task using its own tools (e.g., `web_search`, `read_url`). The service may use AI reasoning or execute tools directly — the protocol does not prescribe how the work is done.
-3. Hashes the prompt and the canonicalized result with SHA-256.
+3. Hashes the prompt and result strings with SHA-256 (`hex(SHA-256(UTF-8(string)))` — the raw bytes, not canonicalized).
 4. Constructs an `ExecutionReceipt` with task metadata.
 5. Signs the receipt with its Ed25519 private key.
 6. Returns the signed receipt to the caller.
@@ -104,11 +104,11 @@ The `motebit_task` synthetic tool is the delegation entry point. It accepts a pr
   submitted_at: number;   // Timestamp (ms since epoch)
   completed_at: number;   // Timestamp (ms since epoch)
   status: "completed" | "failed";
-  result: string;         // Canonicalized result data
+  result: string;         // The result, as a string (you choose the encoding; result_hash commits to these exact bytes)
   tools_used: string[];   // Which tools were invoked
   memories_formed: number; // How many memories the service formed
-  prompt_hash: string;    // SHA-256 of the original prompt
-  result_hash: string;    // SHA-256 of the canonicalized result
+  prompt_hash: string;    // hex(SHA-256(UTF-8(prompt))) — plain SHA-256 of the prompt string
+  result_hash: string;    // hex(SHA-256(UTF-8(result))) — plain SHA-256 of the result string (NOT canonicalized)
   signature: string;      // Ed25519 signature (base64url)
 }
 ```
@@ -254,7 +254,7 @@ const deps = wireServerDeps(runtime, {
   identityFileContent,
   embedText,
   verifySignedToken,
-  handleAgentTask,  // Your async generator that yields receipts
+  handleAgentTask, // Your async generator that yields receipts
 });
 
 // 3. Start the server
@@ -318,4 +318,4 @@ When connecting with `--motebit`, the client creates a short-lived signed token 
 
 ### Receipt integrity
 
-Execution receipts use canonical JSON serialization (sorted keys, recursive) before signing. This ensures the same receipt always produces the same signature regardless of JSON key ordering. The `prompt_hash` and `result_hash` fields allow independent verification that the prompt wasn't modified and the result matches what was signed.
+Execution receipts use canonical JSON serialization (sorted keys, recursive) over the **body** before signing — this ensures the same receipt always produces the same signature regardless of JSON key ordering. Note the two are different operations: the _body_ is JCS-canonicalized for the signature, but `prompt_hash` and `result_hash` are plain `hex(SHA-256(UTF-8(string)))` over the raw `prompt`/`result` strings — **not** canonicalized (canonicalization is only for object-valued hashes like a `ToolInvocationReceipt`'s `args_hash`). These two fields allow independent verification that the prompt wasn't modified and the result matches what was signed: recompute `SHA-256` over the exact `result` bytes and compare.

--- a/apps/docs/content/docs/developer/first-service-agent.mdx
+++ b/apps/docs/content/docs/developer/first-service-agent.mdx
@@ -285,7 +285,7 @@ Discover agents on the relay:
 
 This queries `GET /api/v1/agents/discover` and lists registered services with their capabilities. Your agent appears with the tool names from `src/tools.ts`.
 
-When the AI encounters a task that matches your agent's capability, it delegates automatically. For example, if your agent exposes a `calculate` tool and a user asks "what is 127 * 43?", the AI recognizes it can delegate to your service.
+When the AI encounters a task that matches your agent's capability, it delegates automatically. For example, if your agent exposes a `calculate` tool and a user asks "what is 127 \* 43?", the AI recognizes it can delegate to your service.
 
 You can also manually connect:
 
@@ -319,7 +319,7 @@ Every task produces a signed `ExecutionReceipt`. Here is what one looks like:
   "tools_used": ["calculate"],
   "memories_formed": 0,
   "prompt_hash": "a1b2c3d4e5f6...sha256-of-the-original-prompt",
-  "result_hash": "f6e5d4c3b2a1...sha256-of-the-canonical-result",
+  "result_hash": "f6e5d4c3b2a1...sha256-of-the-utf8-result-string",
   "relay_task_id": "01953abc-def0-7abc-8def-0123456789ef",
   "signature": "base64url-encoded-ed25519-signature"
 }
@@ -327,15 +327,15 @@ Every task produces a signed `ExecutionReceipt`. Here is what one looks like:
 
 Key fields:
 
-| Field | What it proves |
-|-------|---------------|
-| `motebit_id` | Which agent executed the task |
-| `signature` | Ed25519 signature over all other fields — tamper-evident |
-| `prompt_hash` | SHA-256 of the original prompt — proves the prompt was not modified |
-| `result_hash` | SHA-256 of the canonical result — proves the result matches what was signed |
-| `relay_task_id` | Cryptographic binding to the relay's economic identity for this task — prevents cross-task replay |
-| `tools_used` | Which tools were invoked during execution |
-| `delegation_receipts` | (Optional) Nested receipts from sub-delegated work — chain of custody proof for multi-hop delegation |
+| Field                 | What it proves                                                                                                                                                                                                                     |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `motebit_id`          | Which agent executed the task                                                                                                                                                                                                      |
+| `signature`           | Ed25519 signature over all other fields — tamper-evident                                                                                                                                                                           |
+| `prompt_hash`         | SHA-256 of the original prompt — proves the prompt was not modified                                                                                                                                                                |
+| `result_hash`         | `hex(SHA-256(UTF-8(result)))` — plain SHA-256 of the result string (not canonicalized; canonicalization applies to object-valued fields like `args_hash`, never to the string `result`). Proves the result matches what was signed |
+| `relay_task_id`       | Cryptographic binding to the relay's economic identity for this task — prevents cross-task replay                                                                                                                                  |
+| `tools_used`          | Which tools were invoked during execution                                                                                                                                                                                          |
+| `delegation_receipts` | (Optional) Nested receipts from sub-delegated work — chain of custody proof for multi-hop delegation                                                                                                                               |
 
 The signature covers the canonical JSON serialization of all fields except `signature`. Keys are sorted recursively for deterministic output. Since `relay_task_id` is inside the signature, an attacker cannot replay a receipt from one task against another — tampering breaks the signature.
 
@@ -367,13 +367,13 @@ For Fly.io deployment, create a `Dockerfile` and `fly.toml`. The reference imple
 
 Required environment variables for production:
 
-| Variable | Purpose |
-|----------|---------|
-| `MOTEBIT_SYNC_URL` | Relay URL for registration and task routing |
-| `MOTEBIT_API_TOKEN` | Auth token for relay API |
-| `MOTEBIT_PASSPHRASE` | Passphrase for Ed25519 key decryption |
+| Variable                  | Purpose                                                                          |
+| ------------------------- | -------------------------------------------------------------------------------- |
+| `MOTEBIT_SYNC_URL`        | Relay URL for registration and task routing                                      |
+| `MOTEBIT_API_TOKEN`       | Auth token for relay API                                                         |
+| `MOTEBIT_PASSPHRASE`      | Passphrase for Ed25519 key decryption                                            |
 | `MOTEBIT_PRIVATE_KEY_HEX` | (Optional) Private key as hex — avoids passphrase-based decryption in production |
-| `MOTEBIT_PUBLIC_URL` | Public URL where other agents can reach your service |
+| `MOTEBIT_PUBLIC_URL`      | Public URL where other agents can reach your service                             |
 
 Deploy:
 
@@ -444,8 +444,24 @@ Study it for production patterns: result canonicalization, error handling, sub-d
 ## Next steps
 
 <Cards>
-  <Card title="Agent-to-Agent Delegation" href="/docs/developer/delegation" description="The full delegation protocol — discovery, verification, receipts, and receipt chains." />
-  <Card title="Budget & Settlement" href="/docs/developer/budget-settlement" description="How budget allocation, cost estimation, and receipt-based settlement work." />
-  <Card title="MCP Server Mode" href="/docs/developer/mcp-server" description="All synthetic tools, transport options, and server configuration." />
-  <Card title="Credentials" href="/docs/developer/credentials" description="Verifiable credentials — reputation, gradient, and trust attestations." />
+  <Card
+    title="Agent-to-Agent Delegation"
+    href="/docs/developer/delegation"
+    description="The full delegation protocol — discovery, verification, receipts, and receipt chains."
+  />
+  <Card
+    title="Budget & Settlement"
+    href="/docs/developer/budget-settlement"
+    description="How budget allocation, cost estimation, and receipt-based settlement work."
+  />
+  <Card
+    title="MCP Server Mode"
+    href="/docs/developer/mcp-server"
+    description="All synthetic tools, transport options, and server configuration."
+  />
+  <Card
+    title="Credentials"
+    href="/docs/developer/credentials"
+    description="Verifiable credentials — reputation, gradient, and trust attestations."
+  />
 </Cards>

--- a/apps/docs/content/docs/developer/multi-hop.mdx
+++ b/apps/docs/content/docs/developer/multi-hop.mdx
@@ -60,12 +60,12 @@ Bob's `tools_used` array records `"read_url(delegated)"` — an explicit signal 
 
 ### Environment variables
 
-| Variable | Service | Purpose |
-|----------|---------|---------|
-| `MOTEBIT_DELEGATE_READ_URL` | Bob | Charlie's MCP endpoint URL (e.g., `https://charlie.fly.dev/mcp`) |
-| `MOTEBIT_DELEGATE_TARGET_ID` | Bob | Charlie's `motebit_id` for relay task submission |
-| `MOTEBIT_SYNC_URL` | Both | Relay URL for budget allocation and settlement |
-| `MOTEBIT_PRIVATE_KEY_HEX` | Both | Ed25519 private key for receipt signing |
+| Variable                     | Service | Purpose                                                          |
+| ---------------------------- | ------- | ---------------------------------------------------------------- |
+| `MOTEBIT_DELEGATE_READ_URL`  | Bob     | Charlie's MCP endpoint URL (e.g., `https://charlie.fly.dev/mcp`) |
+| `MOTEBIT_DELEGATE_TARGET_ID` | Bob     | Charlie's `motebit_id` for relay task submission                 |
+| `MOTEBIT_SYNC_URL`           | Both    | Relay URL for budget allocation and settlement                   |
+| `MOTEBIT_PRIVATE_KEY_HEX`    | Both    | Ed25519 private key for receipt signing                          |
 
 ## Budget flow
 
@@ -100,7 +100,7 @@ The `ExecutionReceipt` type (from `@motebit/sdk`) includes an optional `delegati
 interface ExecutionReceipt {
   task_id: string;
   motebit_id: MotebitId;
-  public_key?: string;         // signer's Ed25519 public key (hex)
+  public_key?: string; // signer's Ed25519 public key (hex)
   device_id: DeviceId;
   submitted_at: number;
   completed_at: number;
@@ -108,11 +108,11 @@ interface ExecutionReceipt {
   result: string;
   tools_used: string[];
   memories_formed: number;
-  prompt_hash: string;         // SHA-256 of the original prompt
-  result_hash: string;         // SHA-256 of the canonicalized result
-  relay_task_id?: string;      // binds receipt to the relay's economic identity
-  delegation_receipts?: ExecutionReceipt[];  // nested sub-delegation proofs
-  signature: string;           // Ed25519 over canonical JSON of all other fields
+  prompt_hash: string; // hex(SHA-256(UTF-8(prompt))) — plain SHA-256 of the prompt string
+  result_hash: string; // hex(SHA-256(UTF-8(result))) — plain SHA-256 of the result string (NOT canonicalized)
+  relay_task_id?: string; // binds receipt to the relay's economic identity
+  delegation_receipts?: ExecutionReceipt[]; // nested sub-delegation proofs
+  signature: string; // Ed25519 over canonical JSON of all other fields
 }
 ```
 
@@ -231,8 +231,14 @@ const { task_id: subRelayTaskId } = await taskResp.json();
 ```typescript
 // Authenticate with a signed token
 const token = await createSignedToken(
-  { mid: myMotebitId, did: myDeviceId, iat: Date.now(), exp: Date.now() + 300_000,
-    jti: crypto.randomUUID(), aud: "task:submit" },
+  {
+    mid: myMotebitId,
+    did: myDeviceId,
+    iat: Date.now(),
+    exp: Date.now() + 300_000,
+    jti: crypto.randomUUID(),
+    aud: "task:submit",
+  },
   myPrivateKey,
 );
 


### PR DESCRIPTION
The developer docs described `result_hash`/`prompt_hash` as "SHA-256 of the **canonical** result" in six places across three guides. The spec (`execution-ledger-v1` § Hash fields) is exact and different:

```
result_hash = hex(SHA-256(UTF-8(result_string)))   // plain SHA-256 of the STRING
prompt_hash = hex(SHA-256(UTF-8(prompt_string)))   // same
```

`result`/`prompt` are **strings** — there is no canonicalization step. "Canonical" reads as JCS (`canonicalSha256`), which is the recipe for **object-valued** hashes like a `ToolInvocationReceipt`'s `args_hash` — never for the string `result`.

**This drift wasn't cosmetic — it shipped a bug.** A cold integrator (agency.computer, consuming only our published docs + packages) followed it, set `result_hash = canonicalSha256(object)`, and shipped a signed receipt whose `result_hash` a third party couldn't reproduce from its own `result` field — the exact "signed number nobody can verify" failure the product exists to prevent. Surfaced via the cross-repo dogfooding loop. This is the synchronization-invariant fix: spec is canonical, siblings drifted, correct all in one pass.

Fixed in `first-service-agent`, `delegation`, `multi-hop`: the hash fields now state the plain-SHA-256-of-the-string recipe explicitly and distinguish it from the object-valued `args_hash` (correctly canonical JSON). `governance-triad`'s `args_hash` = "canonical arguments" is correct and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)