### PR TITLE
fix(spatial): migrate @ricky0123/vad-web 0.0.22 → 0.0.30

### DIFF
--- a/apps/spatial/package.json
+++ b/apps/spatial/package.json
@@ -34,7 +34,7 @@
     "@motebit/verify": "workspace:*",
     "@motebit/voice": "workspace:*",
     "@motebit/wallet-solana": "workspace:*",
-    "@ricky0123/vad-web": "^0.0.22",
+    "@ricky0123/vad-web": "^0.0.30",
     "three": "^0.170.0"
   },
   "devDependencies": {

--- a/apps/spatial/src/voice-pipeline.ts
+++ b/apps/spatial/src/voice-pipeline.ts
@@ -363,16 +363,23 @@ export class SpatialVoicePipeline {
         return;
       }
 
-      // MicVAD uses a static factory method .new()
+      const stream = this.mediaStream; // narrowed non-null by the guard above
+
+      // MicVAD uses a static factory method .new(). vad-web 0.0.30 replaced the
+      // `stream` option with getStream/pauseStream/resumeStream — we hand it our
+      // existing mic stream and keep that stream's lifecycle ours (no-op
+      // pause/resume), the same shape apps/desktop uses.
       const vad = await MicVAD.new({
-        stream: this.mediaStream,
+        getStream: () => Promise.resolve(stream),
+        pauseStream: () => Promise.resolve(),
+        resumeStream: () => Promise.resolve(stream),
         positiveSpeechThreshold: 0.6 - this.config.vadSensitivity * 0.3,
         negativeSpeechThreshold: 0.3 - this.config.vadSensitivity * 0.1,
         onSpeechStart: () => this.onVADSpeechStart(),
         onSpeechEnd: () => this.onVADSpeechEnd(),
       });
 
-      vad.start();
+      await vad.start(); // 0.0.30: start() is async
       this.vadInstance = vad;
     } catch {
       this.sileroFailed = true;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -817,8 +817,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/wallet-solana
       '@ricky0123/vad-web':
-        specifier: ^0.0.22
-        version: 0.0.22
+        specifier: ^0.0.30
+        version: 0.0.30
       three:
         specifier: ^0.170.0
         version: 0.170.0
@@ -5161,9 +5161,6 @@ packages:
 
   '@react-navigation/routers@7.5.3':
     resolution: {integrity: sha512-1tJHg4KKRJuQ1/EvJxatrMef3NZXEPzwUIUZ3n1yJ2t7Q97siwRtbynRpQG9/69ebbtiZ8W3ScOZF/OmhvM4Rg==}
-
-  '@ricky0123/vad-web@0.0.22':
-    resolution: {integrity: sha512-679R6sfwXx4jkquK+FJ9RC2W29oulWC+9ZINK6LVpuy90IBV7UaTGNN79oQXufpJTJs5z4X/22nw1DQ4+Rh8CA==}
 
   '@ricky0123/vad-web@0.0.30':
     resolution: {integrity: sha512-cJyYrh4YeeUBJcbR9Bic/bFDyB9qBkAepvpuWM3vLxnAi7bC3VHzf51UeNdT+OtY4D7MLAgV8iJMc4z41ZnaWg==}
@@ -14673,10 +14670,6 @@ snapshots:
   '@react-navigation/routers@7.5.3':
     dependencies:
       nanoid: 3.3.12
-
-  '@ricky0123/vad-web@0.0.22':
-    dependencies:
-      onnxruntime-web: 1.14.0
 
   '@ricky0123/vad-web@0.0.30':
     dependencies:


### PR DESCRIPTION
`@ricky0123/vad-web` ships breaking changes in 0.0.x bumps — **0.0.30 removed `RealTimeVADOptions.stream`**, the option `apps/spatial/voice-pipeline.ts` passed to `MicVAD.new`, which red-wedged the `production-minor-patch` dependabot group (#153). It's since been isolated into its own `vad:` dependabot group, but the actual migration still had to happen.

Migrated `apps/spatial` to the 0.0.30 API, matching the pattern `apps/desktop` already runs on 0.0.30:
- `stream: mediaStream` → `getStream: () => Promise.resolve(stream)` + no-op `pauseStream`/`resumeStream` (mic stream's lifecycle stays ours)
- `vad.start()` → `await vad.start()` (`start()` is async in 0.0.30)

vad-web stays an optional, fallback-guarded dynamic import — a load failure still degrades to `sileroFailed` cleanly. `apps/spatial` is private (no changeset). Lockfile change scoped to vad-web only; typecheck/lint/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)