### PR TITLE
feat(relay): count motebit acquisition — the funnel's intake metric (Phase 0 spine)

### DIFF
--- a/services/relay/src/__tests__/health-summary.test.ts
+++ b/services/relay/src/__tests__/health-summary.test.ts
@@ -17,6 +17,10 @@ function insertAgent(
   db: import("@motebit/persistence").DatabaseDriver,
   motebitId: string,
   lastHeartbeatMs: number,
+  // Defaults to the heartbeat time (the common "registered == last seen" case);
+  // pass distinct to model a veteran motebit that registered long ago but is
+  // still active — the case that proves new_* keys on registration, not liveness.
+  registeredAtMs: number = lastHeartbeatMs,
 ) {
   db.prepare(
     `INSERT OR IGNORE INTO agent_registry
@@ -27,7 +31,7 @@ function insertAgent(
     "pk",
     "http://example/mcp",
     "[]",
-    lastHeartbeatMs,
+    registeredAtMs,
     lastHeartbeatMs,
     lastHeartbeatMs + 15 * 60_000,
   );
@@ -88,6 +92,9 @@ describe("aggregateHealthSummary", () => {
     expect(out.motebits.active_24h).toBe(0);
     expect(out.motebits.active_7d).toBe(0);
     expect(out.motebits.active_30d).toBe(0);
+    expect(out.motebits.new_24h).toBe(0);
+    expect(out.motebits.new_7d).toBe(0);
+    expect(out.motebits.new_30d).toBe(0);
     expect(out.federation.peer_count).toBe(0);
     expect(out.federation.federation_settlements_7d).toBe(0);
     expect(out.tasks.settlements_7d).toBe(0);
@@ -114,6 +121,32 @@ describe("aggregateHealthSummary", () => {
     expect(out.motebits.active_24h).toBe(2); // fresh + yesterday
     expect(out.motebits.active_7d).toBe(3); // + this-week
     expect(out.motebits.active_30d).toBe(4); // + this-month (stale excluded)
+    // registered_at == heartbeat here, so acquisition mirrors activity.
+    expect(out.motebits.new_24h).toBe(2);
+    expect(out.motebits.new_7d).toBe(3);
+    expect(out.motebits.new_30d).toBe(4);
+  });
+
+  it("counts acquisition by registration window, independent of activity", () => {
+    const now = Date.UTC(2026, 3, 15, 12, 0, 0);
+    // Veteran: registered 60d ago, still active 1h ago. Active, NOT newly minted.
+    insertAgent(relay.moteDb.db, "veteran", now - 1 * 60 * 60 * 1000, now - 60 * DAY_MS);
+    // Newcomer: registered AND active 1h ago. Both active and new.
+    insertAgent(relay.moteDb.db, "newcomer", now - 1 * 60 * 60 * 1000, now - 1 * 60 * 60 * 1000);
+    // Dormant newcomer: registered 2d ago, but silent since (heartbeat 2d ago).
+    // New within 7d, but not active in 24h — proves the two axes are orthogonal.
+    insertAgent(relay.moteDb.db, "dormant-new", now - 2 * DAY_MS, now - 2 * DAY_MS);
+
+    const out = aggregateHealthSummary(relay.moteDb.db, now);
+    // Activity (last_heartbeat): veteran + newcomer in 24h; + dormant-new in 7d.
+    expect(out.motebits.active_24h).toBe(2);
+    expect(out.motebits.active_7d).toBe(3);
+    // Acquisition (registered_at): only newcomer in 24h; + dormant-new in 7d;
+    // veteran registered 60d ago so it counts in neither — active but not new.
+    expect(out.motebits.new_24h).toBe(1);
+    expect(out.motebits.new_7d).toBe(2);
+    expect(out.motebits.new_30d).toBe(2);
+    expect(out.motebits.total_registered).toBe(3);
   });
 
   it("sums settlements + fees over 7d / 30d windows", () => {

--- a/services/relay/src/health-summary.ts
+++ b/services/relay/src/health-summary.ts
@@ -8,10 +8,12 @@
  *
  * Four classes of signal:
  *
- *   1. Motebit registry — total registered + activity windows
- *      (last-heartbeat within 24h / 7d / 30d). Activity is the proof
- *      that registered identities are doing work, not just sitting in
- *      the DB.
+ *   1. Motebit registry — total registered, activity windows
+ *      (last-heartbeat within 24h / 7d / 30d), and acquisition windows
+ *      (newly registered within 24h / 7d / 30d). Activity proves
+ *      registered identities are doing work; acquisition is the funnel's
+ *      intake — "are we minting new motebits, and is it growing" — the
+ *      sovereign-userbase signal motebit Inc had no number for.
  *   2. Federation — peer count by state, federation-settlement volume
  *      over the trailing 7d. The federation-settlement count is the
  *      sharpest external-traffic signal: cross-relay settlements only
@@ -41,6 +43,18 @@ export interface HealthMotebits {
   active_24h: number;
   active_7d: number;
   active_30d: number;
+  /**
+   * Newly minted motebits within the window — the acquisition curve, i.e. the
+   * funnel's intake. Keyed on `registered_at`, which the registration upsert
+   * leaves untouched on re-registration (`ON CONFLICT … DO UPDATE` omits it),
+   * so this counts *first* registrations (new identities), never heartbeats.
+   * `active_*` answers "are registered motebits doing work"; `new_*` answers
+   * "are we acquiring new ones, and is it growing" — the sovereign-userbase
+   * sibling of the subscribers block's `created_7d` / `created_30d`.
+   */
+  new_24h: number;
+  new_7d: number;
+  new_30d: number;
 }
 
 export interface HealthFederation {
@@ -113,6 +127,23 @@ export function aggregateHealthSummary(
     active_30d: count(
       db,
       "SELECT COUNT(*) AS n FROM agent_registry WHERE last_heartbeat >= ?",
+      cutoff30d,
+    ),
+    // Acquisition — first-registration windows (registered_at is write-once;
+    // see the field doc). Counts new motebits minted, not heartbeats.
+    new_24h: count(
+      db,
+      "SELECT COUNT(*) AS n FROM agent_registry WHERE registered_at >= ?",
+      cutoff24h,
+    ),
+    new_7d: count(
+      db,
+      "SELECT COUNT(*) AS n FROM agent_registry WHERE registered_at >= ?",
+      cutoff7d,
+    ),
+    new_30d: count(
+      db,
+      "SELECT COUNT(*) AS n FROM agent_registry WHERE registered_at >= ?",
       cutoff30d,
     ),
   };


### PR DESCRIPTION
## What

motebit Inc had no number for *"are we acquiring users, and is it growing."* The relay already counted **total + active** motebits, but activity is liveness, not growth — it can't distinguish a new mint from a returning heartbeat.

This adds **acquisition windows** to the motebits health block — `new_24h` / `new_7d` / `new_30d` — keyed on `agent_registry.registered_at`. That column is **write-once**: the registration upsert's `ON CONFLICT … DO UPDATE` deliberately omits `registered_at`, so re-registration preserves first-mint time, making it a true acquisition timestamp (not a heartbeat). Surfaced through the existing `GET /api/v1/admin/health` route — **zero new schema**.

## Why

This is the **measurement spine of the onboarding funnel** (Phase 0): a front door you can't count is still no funnel. It's the sovereign-userbase sibling of the subscribers block's `created_7d` / `created_30d`.

## Tests

New case — *"acquisition by registration window, independent of activity"* — proves `new_*` keys on `registered_at`: a 60-day veteran with a fresh heartbeat counts as **active but not new**. 7/7 green; relay + operator typecheck clean.

## Next increments (not in this PR)

- The deliberate onboarding *moment* in `apps/web` (front-door UX: mint → register → count).
- Waitlist-fold + email↔`motebit_id` contact link.
- Wire `new_*` into the operator console Health panel (additive; operator reads the relay JSON via its own type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)