### PR TITLE
feat(web): first-launch onboarding moment — the sovereign funnel's front door

### DIFF
--- a/.changeset/web-onboarding-moment.md
+++ b/.changeset/web-onboarding-moment.md
@@ -1,0 +1,13 @@
+---
+"@motebit/web": minor
+---
+
+The first-launch onboarding moment — the sovereign funnel's front door (Phase 0, increment 2).
+
+A fresh sovereign mint used to happen silently with no acknowledgement, and the relay never heard about it. The web app now surfaces a calm, one-time moment on first launch: **"Your motebit is ready,"** the new identity's word-fingerprint (a recognition aid via `wordFingerprint`), and a choice — **Begin** announces the motebit to the canonical relay's durable intake ledger (so it's counted), **Stay private** keeps it fully local and uncounted.
+
+- New `WebApp.announceMotebit()` — a direct, deterministic relay action (like `startSync`, not routed through the AI loop). Signs with the genesis key (on first launch the device key _is_ the genesis key, so the relay's id↔key binding check passes) and POSTs to `DEFAULT_RELAY_URL`, independent of whether sync is enabled. Best-effort: returns a typed result, never throws.
+- `WebApp.isFirstLaunch` is now surfaced from `bootstrapIdentity` (it was previously computed but unused).
+- The moment is runtime-driven and shows exactly once per identity: it gates on `isFirstLaunch` + a persisted announce decision (`motebit-announce-intent`). A "Begin" that can't reach the relay (offline) retries silently on a later launch until the relay confirms intake (`motebit-announced`); "Stay private" never announces. The old passive welcome overlay (everyone-sees-it floating tagline) is replaced.
+
+Mint stays sovereign and fully local; announcing is consented intake, never a gate. Verified: web typecheck + build clean, all 15 e2e smoke tests pass, all 111 drift gates pass.

--- a/.changeset/web-onboarding-moment.md
+++ b/.changeset/web-onboarding-moment.md
@@ -4,7 +4,7 @@
 
 The first-launch onboarding moment — the sovereign funnel's front door (Phase 0, increment 2).
 
-A fresh sovereign mint used to happen silently with no acknowledgement, and the relay never heard about it. The web app now surfaces a calm, one-time moment on first launch: **"Your motebit is ready,"** the new identity's word-fingerprint (a recognition aid via `wordFingerprint`), and a choice — **Begin** announces the motebit to the canonical relay's durable intake ledger (so it's counted), **Stay private** keeps it fully local and uncounted.
+A fresh sovereign mint used to happen silently with no acknowledgement, and the relay never heard about it. The web app now surfaces a calm, one-time moment on first launch: **"Your motebit is born,"** the new identity's word-fingerprint (a recognition aid via `wordFingerprint`), and a choice — **Begin** announces the motebit to the canonical relay's durable intake ledger (so it's counted), **Stay private** keeps it fully local and uncounted.
 
 - New `WebApp.announceMotebit()` — a direct, deterministic relay action (like `startSync`, not routed through the AI loop). Signs with the genesis key (on first launch the device key _is_ the genesis key, so the relay's id↔key binding check passes) and POSTs to `DEFAULT_RELAY_URL`, independent of whether sync is enabled. Best-effort: returns a typed result, never throws.
 - `WebApp.isFirstLaunch` is now surfaced from `bootstrapIdentity` (it was previously computed but unused).

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -578,26 +578,69 @@
         pointer-events: auto;
         transform: translateX(-50%) translateY(0);
       }
-      .welcome-name {
-        font-size: 14px;
+      .welcome-headline {
+        font-size: 15px;
         font-weight: 600;
         color: var(--text-primary);
         letter-spacing: 0.04em;
       }
-      .welcome-tagline {
+      .welcome-subcopy {
         font-size: 12px;
         color: var(--text-muted);
         text-align: center;
+        max-width: 320px;
+        line-height: 1.5;
+        margin-top: 2px;
       }
-      .welcome-link {
-        font-size: 11px;
+      /* The motebit's word-fingerprint — a recognition aid for the new identity. */
+      .welcome-fingerprint {
+        font-family: "SF Mono", "Menlo", monospace;
+        font-size: 12px;
+        color: var(--accent-text);
+        letter-spacing: 0.02em;
+        margin-top: 8px;
+      }
+      .welcome-actions {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        margin-top: 14px;
+      }
+      .welcome-begin {
+        font-family: inherit;
+        font-size: 13px;
+        font-weight: 500;
+        color: #fff;
+        background: var(--accent);
+        border: none;
+        border-radius: 18px;
+        padding: 8px 22px;
+        cursor: pointer;
+        transition:
+          opacity 0.2s ease,
+          transform 0.1s ease;
+      }
+      .welcome-begin:hover {
+        opacity: 0.9;
+      }
+      .welcome-begin:active {
+        transform: scale(0.97);
+      }
+      .welcome-begin:disabled {
+        opacity: 0.55;
+        cursor: default;
+      }
+      .welcome-stay {
+        font-size: 12px;
         color: var(--text-ghost);
-        text-decoration: none;
-        margin-top: 6px;
+        background: none;
+        border: none;
+        cursor: pointer;
+        font-family: inherit;
         transition: color 0.2s ease;
       }
-      .welcome-link:hover {
-        color: var(--accent-text);
+      .welcome-stay:hover {
+        color: var(--text-muted);
       }
 
       /* Toast notifications */
@@ -9805,48 +9848,22 @@
       </div>
     </div>
 
-    <!-- First-visit welcome — no card, just floating text below the creature -->
+    <!-- First-launch onboarding moment — the sovereign funnel's front door.
+         Runtime-driven: main.ts shows it only on a fresh sovereign mint, fills
+         the word-fingerprint, and wires Begin (announce) / Stay private. Hidden
+         and inert until then. -->
     <div id="welcome-overlay">
-      <span class="welcome-name">motebit</span>
-      <span class="welcome-tagline">A droplet of intelligence under surface tension</span>
-      <a class="welcome-link" href="https://docs.motebit.com" target="_blank" rel="noopener"
-        >Learn more &rarr;</a
+      <span class="welcome-headline">Your motebit is ready</span>
+      <span class="welcome-subcopy"
+        >This device created a private identity for your agent. You can join the Motebit relay now,
+        or stay local.</span
       >
+      <span class="welcome-fingerprint" id="welcome-fingerprint"></span>
+      <div class="welcome-actions">
+        <button class="welcome-begin" id="welcome-begin" type="button">Begin</button>
+        <button class="welcome-stay" id="welcome-stay" type="button">Stay private</button>
+      </div>
     </div>
-    <script>
-      (function () {
-        var el = document.getElementById("welcome-overlay");
-        if (!el) return;
-        if (localStorage.getItem("motebit_welcome_dismissed")) {
-          el.remove();
-          return;
-        }
-        // Let the creature breathe for a moment before the text fades in
-        requestAnimationFrame(function () {
-          setTimeout(function () {
-            el.classList.add("show");
-          }, 1200);
-        });
-        function dismiss() {
-          if (!el.parentNode) return;
-          el.classList.remove("show");
-          localStorage.setItem("motebit_welcome_dismissed", "1");
-          el.addEventListener("transitionend", function () {
-            el.remove();
-          });
-        }
-        el.addEventListener("click", function (e) {
-          if (e.target.classList.contains("welcome-link")) return;
-          dismiss();
-        });
-        // Dismiss when user starts interacting
-        document.getElementById("chat-input")?.addEventListener("focus", dismiss, { once: true });
-        // Also dismiss after a while — it's context, not a gate
-        setTimeout(function () {
-          if (el.parentNode) dismiss();
-        }, 12000);
-      })();
-    </script>
 
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -9853,7 +9853,7 @@
          the word-fingerprint, and wires Begin (announce) / Stay private. Hidden
          and inert until then. -->
     <div id="welcome-overlay">
-      <span class="welcome-headline">Your motebit is ready</span>
+      <span class="welcome-headline">Your motebit is born</span>
       <span class="welcome-subcopy"
         >This device created a private identity for your agent. You can join the Motebit relay now,
         or stay local.</span

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -10,7 +10,11 @@ import {
   saveProxyToken,
   clearProxyToken,
   saveBalance,
+  getAnnounceIntent,
+  setAnnounceIntent,
+  isAnnounced,
 } from "./storage";
+import { wordFingerprint } from "@motebit/sdk";
 import { ProxySession } from "@motebit/runtime";
 import type { ProxyProviderConfig } from "@motebit/runtime";
 import { deriveInteriorColor } from "./ui/color-picker";
@@ -432,6 +436,73 @@ async function autoInitWebLLM(model: string = DEFAULT_WEBLLM_MODEL): Promise<voi
   }
 }
 
+/**
+ * The first-launch onboarding moment — the consented metabolic intake of the
+ * sovereign funnel. On a fresh sovereign mint it surfaces the new identity (its
+ * word-fingerprint) and offers to join the relay: "Begin" announces the motebit
+ * (default), "Stay private" keeps it fully local. Both are one-time decisions;
+ * a returning user never re-sees it.
+ *
+ * The mint itself already happened silently in `app.bootstrap()` — this moment
+ * is the first conscious encounter with the identity plus the network-join
+ * choice, not a gate on minting. Announce is best-effort: a tapped "Begin" that
+ * can't reach the relay (offline) retries silently on a later launch.
+ */
+function runOnboardingMoment(): void {
+  const el = document.getElementById("welcome-overlay");
+  if (!el) return;
+
+  const intent = getAnnounceIntent();
+
+  // Retry a prior "Begin" whose announce never reached the relay — silent, no
+  // re-show. Once the relay confirms intake (`isAnnounced`), this stops firing.
+  if (intent === "yes" && !isAnnounced()) {
+    void app.announceMotebit();
+  }
+
+  // Show the moment once: only a fresh sovereign mint that hasn't yet decided.
+  if (!app.isFirstLaunch || intent !== null) {
+    el.remove();
+    return;
+  }
+
+  const fp = document.getElementById("welcome-fingerprint");
+  if (fp && app.publicKeyHex) {
+    try {
+      fp.textContent = wordFingerprint(app.publicKeyHex, { words: 3 });
+    } catch {
+      // Non-fatal — leave the recognition aid empty.
+    }
+  }
+
+  const beginBtn = document.getElementById("welcome-begin");
+  const stayBtn = document.getElementById("welcome-stay");
+
+  const dismiss = (): void => {
+    el.classList.remove("show");
+    el.addEventListener("transitionend", () => el.remove(), { once: true });
+  };
+
+  beginBtn?.addEventListener("click", () => {
+    // Optimistic + calm: record intent, enter the app immediately, announce in
+    // the background. The user shouldn't wait on a network outcome they can't
+    // observe; failure is silent and retries next launch.
+    setAnnounceIntent("yes");
+    void app.announceMotebit();
+    dismiss();
+  });
+
+  stayBtn?.addEventListener("click", () => {
+    setAnnounceIntent("no");
+    dismiss();
+  });
+
+  // Let the creature breathe before the moment fades in.
+  requestAnimationFrame(() => {
+    setTimeout(() => el.classList.add("show"), 1000);
+  });
+}
+
 async function bootstrap(): Promise<void> {
   await app.init(canvas!);
 
@@ -455,6 +526,9 @@ async function bootstrap(): Promise<void> {
     requestAnimationFrame(loop);
   };
   requestAnimationFrame(loop);
+
+  // First-launch onboarding moment (the sovereign funnel's front door).
+  runOnboardingMoment();
 
   // Restore soul color from localStorage
   const soulColor = loadSoulColor();

--- a/apps/web/src/storage.ts
+++ b/apps/web/src/storage.ts
@@ -138,6 +138,56 @@ export function clearSyncUrl(): void {
   }
 }
 
+// === Onboarding moment (sovereign-funnel intake) ===
+//
+// Two pieces of state drive the first-launch "Your motebit is ready" moment:
+//   - announce intent: "yes" (the user tapped Begin — wants to join the relay)
+//     or "no" (Stay private — never announce). Its presence ALSO means the
+//     moment has been shown + decided, so it never shows twice.
+//   - announced: the relay confirmed intake. Lets a "yes" intent retry silently
+//     on later launches if the first announce failed (offline), without ever
+//     re-announcing once it has landed.
+
+const ANNOUNCE_INTENT_KEY = "motebit-announce-intent";
+const ANNOUNCED_KEY = "motebit-announced";
+
+export type AnnounceIntent = "yes" | "no";
+
+/** The user's announce decision, or null if the moment hasn't been decided yet. */
+export function getAnnounceIntent(): AnnounceIntent | null {
+  try {
+    const v = localStorage.getItem(ANNOUNCE_INTENT_KEY);
+    return v === "yes" || v === "no" ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setAnnounceIntent(intent: AnnounceIntent): void {
+  try {
+    localStorage.setItem(ANNOUNCE_INTENT_KEY, intent);
+  } catch {
+    // localStorage unavailable
+  }
+}
+
+/** True once the relay has recorded this motebit's intake — gates retry. */
+export function isAnnounced(): boolean {
+  try {
+    return localStorage.getItem(ANNOUNCED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function markAnnounced(): void {
+  try {
+    localStorage.setItem(ANNOUNCED_KEY, "1");
+  } catch {
+    // localStorage unavailable
+  }
+}
+
 // === Governance Config ===
 
 import { DEFAULT_GOVERNANCE_CONFIG, type GovernanceConfig } from "@motebit/sdk";

--- a/apps/web/src/web-app.ts
+++ b/apps/web/src/web-app.ts
@@ -73,9 +73,11 @@ import {
   bootstrapIdentity,
   rotateIdentityKeys,
   registerDeviceWithRelay,
+  announceMotebit,
   writeRestoredIdentity,
   type BootstrapConfigStore,
   type IdentityStorage,
+  type AnnounceMotebitResult,
 } from "@motebit/core-identity";
 import {
   createSignedToken,
@@ -127,6 +129,8 @@ import {
   loadColdStartOptIn,
   loadProviderConfig,
   loadSyncUrl,
+  DEFAULT_RELAY_URL,
+  markAnnounced,
 } from "./storage.js";
 import { LocalStorageKeyringAdapter } from "./browser-keyring";
 import { EncryptedKeyStore } from "./encrypted-keystore";
@@ -396,6 +400,13 @@ export class UnbootedWebApp {
   private _deviceId = "";
   private _publicKeyHex = "";
   /**
+   * True when this launch minted a fresh sovereign identity (no prior config).
+   * Drives the one-time "Your motebit is ready" onboarding moment. Set once at
+   * bootstrap; the moment + its announce intent persist in localStorage, so a
+   * returning user (isFirstLaunch=false) never re-sees it.
+   */
+  private _isFirstLaunch = false;
+  /**
    * The orphaned motebit_id when bootstrap detected divergent state on
    * launch (config claimed an identity but the keystore probe came back
    * empty). `null` for the common path. Surfaces the field for the UI
@@ -562,6 +573,7 @@ export class UnbootedWebApp {
     this._motebitId = result.motebitId;
     this._deviceId = result.deviceId;
     this._publicKeyHex = result.publicKeyHex;
+    this._isFirstLaunch = result.isFirstLaunch;
     this._divergedFromMotebitId = result.divergedFromMotebitId ?? null;
     this._localEventStore = storage.eventStore;
     this._identityStorage = storage.identityStorage;
@@ -2166,6 +2178,47 @@ export class UnbootedWebApp {
 
   get publicKeyHex(): string {
     return this._publicKeyHex;
+  }
+
+  /** True when this launch minted a fresh sovereign identity — drives the onboarding moment. */
+  get isFirstLaunch(): boolean {
+    return this._isFirstLaunch;
+  }
+
+  // === Sovereign-funnel intake ===
+
+  /**
+   * Announce this motebit to the canonical relay's durable intake ledger — the
+   * consented metabolic intake of the sovereign funnel. Direct, deterministic
+   * relay action (like {@link startSync}); NOT routed through the AI loop.
+   *
+   * Signs with the genesis key (on a first-launch sovereign mint the device key
+   * IS the genesis key, so the relay's id↔key binding check passes) and POSTs
+   * to {@link DEFAULT_RELAY_URL} — independent of whether the user has enabled
+   * sync. Best-effort: returns a typed result, never throws; marks the motebit
+   * announced only on confirmation so a failed attempt retries on next launch.
+   */
+  async announceMotebit(): Promise<AnnounceMotebitResult> {
+    if (!this._motebitId || !this._publicKeyHex) {
+      return { ok: false, code: "unknown", message: "Identity not bootstrapped" };
+    }
+    const privateKeyHex = await this.keyStore.loadPrivateKey();
+    if (privateKeyHex == null || privateKeyHex === "") {
+      return { ok: false, code: "unknown", message: "No signing key available" };
+    }
+    const privKeyBytes = new Uint8Array(privateKeyHex.length / 2);
+    for (let i = 0; i < privateKeyHex.length; i += 2) {
+      privKeyBytes[i / 2] = parseInt(privateKeyHex.slice(i, i + 2), 16);
+    }
+    const result = await announceMotebit({
+      motebitId: this._motebitId,
+      publicKey: this._publicKeyHex,
+      privateKey: privKeyBytes,
+      surface: "web",
+      relayUrl: DEFAULT_RELAY_URL,
+    });
+    if (result.ok) markAnnounced();
+    return result;
   }
 
   // === Key Rotation ===


### PR DESCRIPTION
## What & why

Phase 0, increment 2 — the consumer-facing front door that drives the intake ledger from #163.

A fresh sovereign mint used to happen **silently** with no acknowledgement, and the relay never heard about it — so no web user was ever counted. The web app now surfaces a calm, one-time moment on first launch:

- **"Your motebit is ready"** + subcopy explaining the device created a private identity
- the new identity's **word-fingerprint** (recognition aid via `wordFingerprint`)
- a choice: **Begin** announces the motebit to the relay's durable intake ledger (counted), **Stay private** keeps it fully local and uncounted

## Changes

- **New `WebApp.announceMotebit()`** — a direct, deterministic relay action (like `startSync`, **not** routed through the AI loop). Signs with the genesis key (on first launch the device key *is* the genesis key, so the relay's id↔key binding check from #163 passes) and POSTs to `DEFAULT_RELAY_URL`, independent of whether sync is enabled. Best-effort: typed result, never throws; marks announced only on relay confirmation.
- **`WebApp.isFirstLaunch`** surfaced from `bootstrapIdentity` (previously computed but unused).
- **Runtime-driven moment** (`main.ts` `runOnboardingMoment`): shows exactly once per identity, gated on `isFirstLaunch` + a persisted decision (`motebit-announce-intent`). A "Begin" that can't reach the relay (offline) retries silently on a later launch until intake is confirmed (`motebit-announced`); "Stay private" never announces. Replaces the old passive everyone-sees-it welcome overlay.
- **Storage helpers** (`storage.ts`): `getAnnounceIntent` / `setAnnounceIntent` / `isAnnounced` / `markAnnounced`, following the `motebit-*` key convention.

The mint stays sovereign and fully local; announcing is **consented intake, never a gate**. The overlay is a small floating prompt (not a full-screen backdrop), so the creature/chat stay interactive — ignoring it = stay local, the sovereign-correct default.

## Verification

- Web typecheck + production build clean
- **All 15 e2e smoke tests pass** (the deterministic suite from #161)
- **All 111 drift gates pass**, including `check-affordance-routing` (Begin is a direct action, not a prompt)

UX copy ("ready" headline, subcopy, button labels) per the agreed design; happy to tune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)