### PR TITLE
fix(web): restore calm first-launch — silent announce, no interstitial

### DIFF
--- a/.changeset/web-calm-onboarding.md
+++ b/.changeset/web-calm-onboarding.md
@@ -1,0 +1,15 @@
+---
+"@motebit/web": patch
+---
+
+Restore calm software on first launch — replace the onboarding interstitial with a silent announce.
+
+The #165 onboarding moment shipped a Begin / Stay-private decision plus a raw key-fingerprint on the first-launch splash. That violated motebit's own calm-software law ("do not confirm what the user can already see"): it forced the user to make a skeptical decision about a benign, "none"-sensitivity act (announcing a public id + key to the home relay), dramatizing trivial first-party infrastructure as a privacy choice — and gave no feedback when tapped.
+
+This reverts the interstitial and re-homes the intake correctly:
+
+- The first-launch overlay is calm again — "Your motebit is born" + the droplet tagline, a quiet line that fades on its own. No buttons, no decision, no fingerprint on the splash (the word-fingerprint is a recognition aid that belongs in the Agents/identity panel, not cold on hello).
+- The announce now fires **silently on the first network action** — `WebApp.startSync()`, where the motebit establishes relay presence, gated on `isAnnounced` so it runs once until the relay confirms and never re-announces. A purely-local motebit that never touches the relay is never announced and stays uncounted — the sovereignty promise kept exactly, and the count becomes "engaged motebits," not page-loaders.
+- Removes the dead onboarding-moment code (`runOnboardingMoment`, the announce-intent storage). The `announceMotebit()` primitive and the intake ledger from #163 are unchanged — only _where_ the announce is triggered moved, from a launch-time prompt to a silent network-action hook.
+
+Backend counting is unchanged and still real (top-of-funnel, distinct from Stripe's paid-only view); the mistake was surfacing it as a decision, not building it.

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -579,68 +579,25 @@
         transform: translateX(-50%) translateY(0);
       }
       .welcome-headline {
-        font-size: 15px;
+        font-size: 14px;
         font-weight: 600;
         color: var(--text-primary);
         letter-spacing: 0.04em;
       }
-      .welcome-subcopy {
+      .welcome-tagline {
         font-size: 12px;
         color: var(--text-muted);
         text-align: center;
-        max-width: 320px;
-        line-height: 1.5;
-        margin-top: 2px;
       }
-      /* The motebit's word-fingerprint — a recognition aid for the new identity. */
-      .welcome-fingerprint {
-        font-family: "SF Mono", "Menlo", monospace;
-        font-size: 12px;
-        color: var(--accent-text);
-        letter-spacing: 0.02em;
-        margin-top: 8px;
-      }
-      .welcome-actions {
-        display: flex;
-        align-items: center;
-        gap: 14px;
-        margin-top: 14px;
-      }
-      .welcome-begin {
-        font-family: inherit;
-        font-size: 13px;
-        font-weight: 500;
-        color: #fff;
-        background: var(--accent);
-        border: none;
-        border-radius: 18px;
-        padding: 8px 22px;
-        cursor: pointer;
-        transition:
-          opacity 0.2s ease,
-          transform 0.1s ease;
-      }
-      .welcome-begin:hover {
-        opacity: 0.9;
-      }
-      .welcome-begin:active {
-        transform: scale(0.97);
-      }
-      .welcome-begin:disabled {
-        opacity: 0.55;
-        cursor: default;
-      }
-      .welcome-stay {
-        font-size: 12px;
+      .welcome-link {
+        font-size: 11px;
         color: var(--text-ghost);
-        background: none;
-        border: none;
-        cursor: pointer;
-        font-family: inherit;
+        text-decoration: none;
+        margin-top: 6px;
         transition: color 0.2s ease;
       }
-      .welcome-stay:hover {
-        color: var(--text-muted);
+      .welcome-link:hover {
+        color: var(--accent-text);
       }
 
       /* Toast notifications */
@@ -9848,22 +9805,51 @@
       </div>
     </div>
 
-    <!-- First-launch onboarding moment — the sovereign funnel's front door.
-         Runtime-driven: main.ts shows it only on a fresh sovereign mint, fills
-         the word-fingerprint, and wires Begin (announce) / Stay private. Hidden
-         and inert until then. -->
+    <!-- First-visit welcome — calm floating text below the creature. No
+         decision, no chrome: a quiet acknowledgement of the new motebit that
+         fades on its own. Announcing to the relay is NOT decided here — it
+         happens silently on the first network action (see web-app startSync). -->
     <div id="welcome-overlay">
       <span class="welcome-headline">Your motebit is born</span>
-      <span class="welcome-subcopy"
-        >This device created a private identity for your agent. You can join the Motebit relay now,
-        or stay local.</span
+      <span class="welcome-tagline">A droplet of intelligence under surface tension</span>
+      <a class="welcome-link" href="https://docs.motebit.com" target="_blank" rel="noopener"
+        >Learn more &rarr;</a
       >
-      <span class="welcome-fingerprint" id="welcome-fingerprint"></span>
-      <div class="welcome-actions">
-        <button class="welcome-begin" id="welcome-begin" type="button">Begin</button>
-        <button class="welcome-stay" id="welcome-stay" type="button">Stay private</button>
-      </div>
     </div>
+    <script>
+      (function () {
+        var el = document.getElementById("welcome-overlay");
+        if (!el) return;
+        if (localStorage.getItem("motebit_welcome_dismissed")) {
+          el.remove();
+          return;
+        }
+        // Let the creature breathe for a moment before the text fades in
+        requestAnimationFrame(function () {
+          setTimeout(function () {
+            el.classList.add("show");
+          }, 1200);
+        });
+        function dismiss() {
+          if (!el.parentNode) return;
+          el.classList.remove("show");
+          localStorage.setItem("motebit_welcome_dismissed", "1");
+          el.addEventListener("transitionend", function () {
+            el.remove();
+          });
+        }
+        el.addEventListener("click", function (e) {
+          if (e.target.classList.contains("welcome-link")) return;
+          dismiss();
+        });
+        // Dismiss when user starts interacting
+        document.getElementById("chat-input")?.addEventListener("focus", dismiss, { once: true });
+        // Also dismiss after a while — it's context, not a gate
+        setTimeout(function () {
+          if (el.parentNode) dismiss();
+        }, 12000);
+      })();
+    </script>
 
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -10,11 +10,7 @@ import {
   saveProxyToken,
   clearProxyToken,
   saveBalance,
-  getAnnounceIntent,
-  setAnnounceIntent,
-  isAnnounced,
 } from "./storage";
-import { wordFingerprint } from "@motebit/sdk";
 import { ProxySession } from "@motebit/runtime";
 import type { ProxyProviderConfig } from "@motebit/runtime";
 import { deriveInteriorColor } from "./ui/color-picker";
@@ -436,73 +432,6 @@ async function autoInitWebLLM(model: string = DEFAULT_WEBLLM_MODEL): Promise<voi
   }
 }
 
-/**
- * The first-launch onboarding moment — the consented metabolic intake of the
- * sovereign funnel. On a fresh sovereign mint it surfaces the new identity (its
- * word-fingerprint) and offers to join the relay: "Begin" announces the motebit
- * (default), "Stay private" keeps it fully local. Both are one-time decisions;
- * a returning user never re-sees it.
- *
- * The mint itself already happened silently in `app.bootstrap()` — this moment
- * is the first conscious encounter with the identity plus the network-join
- * choice, not a gate on minting. Announce is best-effort: a tapped "Begin" that
- * can't reach the relay (offline) retries silently on a later launch.
- */
-function runOnboardingMoment(): void {
-  const el = document.getElementById("welcome-overlay");
-  if (!el) return;
-
-  const intent = getAnnounceIntent();
-
-  // Retry a prior "Begin" whose announce never reached the relay — silent, no
-  // re-show. Once the relay confirms intake (`isAnnounced`), this stops firing.
-  if (intent === "yes" && !isAnnounced()) {
-    void app.announceMotebit();
-  }
-
-  // Show the moment once: only a fresh sovereign mint that hasn't yet decided.
-  if (!app.isFirstLaunch || intent !== null) {
-    el.remove();
-    return;
-  }
-
-  const fp = document.getElementById("welcome-fingerprint");
-  if (fp && app.publicKeyHex) {
-    try {
-      fp.textContent = wordFingerprint(app.publicKeyHex, { words: 3 });
-    } catch {
-      // Non-fatal — leave the recognition aid empty.
-    }
-  }
-
-  const beginBtn = document.getElementById("welcome-begin");
-  const stayBtn = document.getElementById("welcome-stay");
-
-  const dismiss = (): void => {
-    el.classList.remove("show");
-    el.addEventListener("transitionend", () => el.remove(), { once: true });
-  };
-
-  beginBtn?.addEventListener("click", () => {
-    // Optimistic + calm: record intent, enter the app immediately, announce in
-    // the background. The user shouldn't wait on a network outcome they can't
-    // observe; failure is silent and retries next launch.
-    setAnnounceIntent("yes");
-    void app.announceMotebit();
-    dismiss();
-  });
-
-  stayBtn?.addEventListener("click", () => {
-    setAnnounceIntent("no");
-    dismiss();
-  });
-
-  // Let the creature breathe before the moment fades in.
-  requestAnimationFrame(() => {
-    setTimeout(() => el.classList.add("show"), 1000);
-  });
-}
-
 async function bootstrap(): Promise<void> {
   await app.init(canvas!);
 
@@ -526,9 +455,6 @@ async function bootstrap(): Promise<void> {
     requestAnimationFrame(loop);
   };
   requestAnimationFrame(loop);
-
-  // First-launch onboarding moment (the sovereign funnel's front door).
-  runOnboardingMoment();
 
   // Restore soul color from localStorage
   const soulColor = loadSoulColor();

--- a/apps/web/src/storage.ts
+++ b/apps/web/src/storage.ts
@@ -138,40 +138,17 @@ export function clearSyncUrl(): void {
   }
 }
 
-// === Onboarding moment (sovereign-funnel intake) ===
+// === Sovereign-funnel intake ===
 //
-// Two pieces of state drive the first-launch "Your motebit is ready" moment:
-//   - announce intent: "yes" (the user tapped Begin — wants to join the relay)
-//     or "no" (Stay private — never announce). Its presence ALSO means the
-//     moment has been shown + decided, so it never shows twice.
-//   - announced: the relay confirmed intake. Lets a "yes" intent retry silently
-//     on later launches if the first announce failed (offline), without ever
-//     re-announcing once it has landed.
+// The motebit announces itself to the relay's durable intake ledger on its
+// first network action (enabling sync), silently — never via a launch-time
+// prompt. This flag records that the relay has confirmed intake, so the
+// announce fires only until it first lands: never re-announced, and retried on
+// the next connect if it failed.
 
-const ANNOUNCE_INTENT_KEY = "motebit-announce-intent";
 const ANNOUNCED_KEY = "motebit-announced";
 
-export type AnnounceIntent = "yes" | "no";
-
-/** The user's announce decision, or null if the moment hasn't been decided yet. */
-export function getAnnounceIntent(): AnnounceIntent | null {
-  try {
-    const v = localStorage.getItem(ANNOUNCE_INTENT_KEY);
-    return v === "yes" || v === "no" ? v : null;
-  } catch {
-    return null;
-  }
-}
-
-export function setAnnounceIntent(intent: AnnounceIntent): void {
-  try {
-    localStorage.setItem(ANNOUNCE_INTENT_KEY, intent);
-  } catch {
-    // localStorage unavailable
-  }
-}
-
-/** True once the relay has recorded this motebit's intake — gates retry. */
+/** True once the relay has recorded this motebit's intake — gates the silent announce. */
 export function isAnnounced(): boolean {
   try {
     return localStorage.getItem(ANNOUNCED_KEY) === "1";

--- a/apps/web/src/web-app.ts
+++ b/apps/web/src/web-app.ts
@@ -130,6 +130,7 @@ import {
   loadProviderConfig,
   loadSyncUrl,
   DEFAULT_RELAY_URL,
+  isAnnounced,
   markAnnounced,
 } from "./storage.js";
 import { LocalStorageKeyringAdapter } from "./browser-keyring";
@@ -400,13 +401,6 @@ export class UnbootedWebApp {
   private _deviceId = "";
   private _publicKeyHex = "";
   /**
-   * True when this launch minted a fresh sovereign identity (no prior config).
-   * Drives the one-time "Your motebit is ready" onboarding moment. Set once at
-   * bootstrap; the moment + its announce intent persist in localStorage, so a
-   * returning user (isFirstLaunch=false) never re-sees it.
-   */
-  private _isFirstLaunch = false;
-  /**
    * The orphaned motebit_id when bootstrap detected divergent state on
    * launch (config claimed an identity but the keystore probe came back
    * empty). `null` for the common path. Surfaces the field for the UI
@@ -573,7 +567,6 @@ export class UnbootedWebApp {
     this._motebitId = result.motebitId;
     this._deviceId = result.deviceId;
     this._publicKeyHex = result.publicKeyHex;
-    this._isFirstLaunch = result.isFirstLaunch;
     this._divergedFromMotebitId = result.divergedFromMotebitId ?? null;
     this._localEventStore = storage.eventStore;
     this._identityStorage = storage.identityStorage;
@@ -2180,23 +2173,22 @@ export class UnbootedWebApp {
     return this._publicKeyHex;
   }
 
-  /** True when this launch minted a fresh sovereign identity — drives the onboarding moment. */
-  get isFirstLaunch(): boolean {
-    return this._isFirstLaunch;
-  }
-
   // === Sovereign-funnel intake ===
 
   /**
    * Announce this motebit to the canonical relay's durable intake ledger — the
-   * consented metabolic intake of the sovereign funnel. Direct, deterministic
-   * relay action (like {@link startSync}); NOT routed through the AI loop.
+   * metabolic intake of the sovereign funnel. Fired silently on the first
+   * network action (see {@link startSync}), never via a launch-time prompt: a
+   * purely-local motebit that never touches the relay is never announced and
+   * stays uncounted, and a benign "none"-sensitivity existence announcement is
+   * not something to make the user decide. Calm software — no interstitial.
    *
-   * Signs with the genesis key (on a first-launch sovereign mint the device key
-   * IS the genesis key, so the relay's id↔key binding check passes) and POSTs
-   * to {@link DEFAULT_RELAY_URL} — independent of whether the user has enabled
-   * sync. Best-effort: returns a typed result, never throws; marks the motebit
-   * announced only on confirmation so a failed attempt retries on next launch.
+   * Signs with the genesis key (on a sovereign mint the first device key IS the
+   * genesis key, so the relay's id↔key binding check passes) and POSTs to
+   * {@link DEFAULT_RELAY_URL}. Best-effort: returns a typed result, never
+   * throws; marks the motebit announced only on confirmation, so callers can
+   * gate on {@link isAnnounced} and a failed attempt retries on the next
+   * network action.
    */
   async announceMotebit(): Promise<AnnounceMotebitResult> {
     if (!this._motebitId || !this._publicKeyHex) {
@@ -3448,6 +3440,16 @@ export class UnbootedWebApp {
         "[motebit] device self-registration threw:",
         err instanceof Error ? err.message : String(err),
       );
+    }
+
+    // First network action → announce to the intake ledger, silently. Enabling
+    // sync is the motebit's first relay presence; that's the calm, consent-free
+    // moment to be counted (a purely-local motebit never reaches here and stays
+    // uncounted). Best-effort + idempotent: gated on `isAnnounced` so it runs
+    // only until the relay first confirms, never re-announces, never blocks
+    // sync, and retries on the next connect if it fails.
+    if (!isAnnounced()) {
+      void this.announceMotebit();
     }
 
     // Derive deterministic encryption key, then erase raw key bytes.


### PR DESCRIPTION
## Why

The #165 onboarding moment shipped a **Begin / Stay-private** decision plus a raw key-fingerprint on first launch. Tested live, it broke motebit's own calm-software law ("do not confirm what the user can already see"): it forced the user to make a *skeptical decision* about a benign, "none"-sensitivity act (announcing a public id + key to the home relay) — dramatizing trivial first-party infrastructure as a privacy choice — and gave no feedback when tapped. Not Jobsian.

## What changed

- **Calm first-launch restored** — "Your motebit is born" + the droplet tagline, a quiet line that fades on its own. No buttons, no decision, no fingerprint on the splash.
- **Announce moved to the first network action** — fires *silently* in `WebApp.startSync()` (where the motebit establishes relay presence), gated on `isAnnounced` so it runs once until the relay confirms and never re-announces. A purely-local motebit that never touches the relay is **never announced and stays uncounted** — the sovereignty promise kept exactly; the count becomes "engaged motebits," not page-loaders.
- **Removed dead code** — `runOnboardingMoment`, the announce-intent storage. The `announceMotebit()` primitive + the intake ledger from #163 are unchanged; only *where* the announce triggers moved (launch-time prompt → silent network-action hook).
- The word-fingerprint belongs in the Agents/identity panel (a pre-existing held fork), not cold on the splash — so it's just removed here, no gap created.

## Verification

- Web typecheck + build clean, **15/15 e2e pass**, **all 111 drift gates pass**

Backend counting is unchanged and still real (top-of-funnel, distinct from Stripe's paid-only view). The mistake was surfacing it as a decision, not building it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)