### PR TITLE
feat(web): defer model setup to first message — stop occluding the creature

### DIFF
--- a/.changeset/web-defer-setup-to-first-message.md
+++ b/.changeset/web-defer-setup-to-first-message.md
@@ -1,0 +1,13 @@
+---
+"@motebit/web": minor
+---
+
+Defer model setup to the first message — stop occluding the creature with a "Connect a model" overlay on load.
+
+First run used to demand setup before the user had done anything: a centered "Connect a model" prompt painted across the creature's face (low-contrast, occluding the hero), and on capable devices a multi-GB WebLLM download kicked off automatically. Both are un-calm — setup before intent.
+
+Now the first run is just the creature + the calm "born" welcome. Nothing inference-y happens on load (no localhost probe — already removed — no auto-download, no overlay). A subscriber's saved cloud provider still auto-connects. When a user without a model **sends their first message**, motebit answers inline — "I need a model to think. Choose one in Settings — on-device, your own key, or motebit cloud." — and opens Settings straight to the Intelligence (provider) tab. Setup follows intent, never precedes it.
+
+- `updateConnectPrompt` retires the empty-state overlay (only ever hides now); the connect-prompt node serves solely as the boot-time WebLLM progress surface for a returning on-device user, which un-hides itself.
+- Removed the on-load WebLLM auto-download from both boot paths; the saved-on-device-WebLLM path is unchanged.
+- New `openProviderSettings` chat callback → `settings.openToTab("intelligence")`.

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -15,7 +15,7 @@ import { ProxySession } from "@motebit/runtime";
 import type { ProxyProviderConfig } from "@motebit/runtime";
 import { deriveInteriorColor } from "./ui/color-picker";
 import { initColorPicker } from "./ui/color-picker";
-import { checkWebGPU, WebLLMProvider, PROXY_BASE_URL } from "./providers";
+import { WebLLMProvider, PROXY_BASE_URL } from "./providers";
 import { cleanConversationHistory } from "./bootstrap";
 import { initChat, addMessage, showToast } from "./ui/chat";
 import { initSettings } from "./ui/settings";
@@ -79,6 +79,7 @@ const colorPicker = initColorPicker(ctx, () => {
 
 const chatAPI = initChat(ctx, {
   openSettings: () => settings.open(),
+  openProviderSettings: () => settings.openToTab("intelligence"),
   openConversations: () => conversations.open(),
   openShortcuts: () => openShortcutDialog(),
 });
@@ -362,12 +363,18 @@ async function autoInitProxy(): Promise<boolean> {
 
 /** Fallback: load a language model into the browser via WebLLM. */
 async function autoInitWebLLM(model: string = DEFAULT_WEBLLM_MODEL): Promise<void> {
+  const prompt = document.getElementById("connect-prompt");
   const heading = document.getElementById("connect-prompt-heading");
   const text = document.getElementById("connect-prompt-text");
   const btn = document.getElementById("connect-prompt-btn");
   const progress = document.getElementById("connect-prompt-progress");
   const fill = document.getElementById("connect-prompt-progress-fill");
 
+  // The empty-state overlay is retired (updateConnectPrompt only hides), so this
+  // progress path un-hides the node itself. Only reached for a returning user
+  // who already chose on-device WebLLM — legitimate "waking up" feedback they
+  // opted into, never an uninvited first-run prompt.
+  if (prompt) prompt.classList.remove("hidden");
   if (heading) heading.textContent = "Waking up";
   if (text) text.textContent = "Preparing...";
   if (btn) btn.style.display = "none";
@@ -394,12 +401,11 @@ async function autoInitWebLLM(model: string = DEFAULT_WEBLLM_MODEL): Promise<voi
     settings.updateModelIndicator();
     settings.updateConnectPrompt();
   } catch {
-    if (heading) heading.textContent = "Connect a model";
-    if (text)
-      text.textContent =
-        "Open Settings to choose a provider — on-device, your own key, or motebit cloud.";
-    if (btn) btn.style.display = "";
-    if (progress) progress.style.display = "none";
+    // Don't fall back to the occluding empty-state overlay — hide it and nudge
+    // via a calm toast. The user can reconnect from Settings; the first-message
+    // path (chat.ts) will also guide them if they just try to talk.
+    if (prompt) prompt.classList.add("hidden");
+    showToast("Couldn't load the on-device model — reconnect in Settings.");
   }
 }
 
@@ -452,9 +458,10 @@ async function bootstrap(): Promise<void> {
   const savedConfig = loadProviderConfig();
   if (savedConfig != null) {
     if (savedConfig.mode === "motebit-cloud") {
-      // For cloud users, always go through autoInitProxy to handle token refresh
-      void autoInitProxy().then(async (ok) => {
-        if (!ok && checkWebGPU()) await autoInitWebLLM();
+      // For cloud users, always go through autoInitProxy to handle token refresh.
+      // No WebLLM fallback on load — if the token's stale, the first message
+      // guides them to reconnect (deferred setup), never an uninvited download.
+      void autoInitProxy().then(() => {
         settings.updateConnectPrompt();
       });
     } else if (savedConfig.mode === "on-device" && savedConfig.backend === "webllm") {
@@ -470,12 +477,11 @@ async function bootstrap(): Promise<void> {
       }
     }
   } else {
-    // First visit — no subscription yet. Boot sequence: subscriber proxy →
-    // WebLLM (in-browser, zero-config, no permission) → connect prompt. Local
-    // server inference is opt-in via Settings (never probed on load — see the
-    // note on autoInitLocalInference's removal above).
-    void autoInitProxy().then(async (ok) => {
-      if (!ok && checkWebGPU()) await autoInitWebLLM();
+    // First visit — nothing inference-y on load. Setup is deferred to the first
+    // message (chat.ts), so the first run is just the creature + the calm
+    // welcome: no localhost probe, no auto-download, no occluding "connect a
+    // model" overlay. A subscriber proxy still auto-connects if one exists.
+    void autoInitProxy().then(() => {
       settings.updateConnectPrompt();
     });
   }

--- a/apps/web/src/ui/chat.ts
+++ b/apps/web/src/ui/chat.ts
@@ -599,6 +599,8 @@ function failureCopy(code: string, retryAfterSeconds?: number): string {
 
 export interface ChatCallbacks {
   openSettings(): void;
+  /** Open Settings straight to the provider/model (Intelligence) tab — the deferred-setup landing. */
+  openProviderSettings?(): void;
   openConversations?(): void;
   openShortcuts?(): void;
 }
@@ -651,7 +653,14 @@ export function initChat(ctx: WebContext, callbacks: ChatCallbacks): ChatAPI {
     }
 
     if (!ctx.app.isProviderConnected) {
-      addMessage("system", "No provider connected. Open settings to configure one.");
+      // Deferred setup: the user expressed intent, so now is the moment to pick
+      // a brain — not an uninvited prompt on load. Guide them and open Settings
+      // to the provider tab.
+      addMessage(
+        "system",
+        "I need a model to think. Choose one in Settings — on-device, your own key, or motebit cloud.",
+      );
+      (callbacks.openProviderSettings ?? callbacks.openSettings)();
       return;
     }
 
@@ -882,7 +891,11 @@ export function initChat(ctx: WebContext, callbacks: ChatCallbacks): ChatAPI {
   /** Execute a multi-step plan and stream progress into chat. */
   async function executePlanInChat(goal: string): Promise<void> {
     if (!ctx.app.isProviderConnected) {
-      addMessage("system", "No provider connected. Open settings to configure one.");
+      addMessage(
+        "system",
+        "I need a model to think. Choose one in Settings — on-device, your own key, or motebit cloud.",
+      );
+      (callbacks.openProviderSettings ?? callbacks.openSettings)();
       return;
     }
 

--- a/apps/web/src/ui/settings.ts
+++ b/apps/web/src/ui/settings.ts
@@ -1581,11 +1581,13 @@ export function initSettings(ctx: WebContext, deps: SettingsDeps): SettingsAPI {
   }
 
   function updateConnectPrompt(): void {
-    if (ctx.app.isProviderConnected) {
-      connectPrompt.classList.add("hidden");
-    } else {
-      connectPrompt.classList.remove("hidden");
-    }
+    // Calm first-run: the "Connect a model" empty-state overlay is retired — it
+    // occluded the creature and demanded setup before the user expressed any
+    // intent. Setup is deferred to the first message (chat.ts guides the user
+    // into Settings then). So this only ever HIDES the element; the connect-
+    // prompt node now serves solely as the boot-time WebLLM progress surface,
+    // which un-hides itself in autoInitWebLLM. Never un-hide as an empty state.
+    connectPrompt.classList.add("hidden");
   }
 
   return { open, openToTab, close, updateModelIndicator, updateConnectPrompt };


### PR DESCRIPTION
## Why

First run demanded setup before the user did anything: a centered "Connect a model" prompt painted across the creature's face (low-contrast, occluding the hero), plus an automatic multi-GB WebLLM download on capable devices. Setup before intent — un-calm. (Follow-up to #167, which killed the eager localhost probe.)

## What changed

- First run is now just the creature + the calm "born" welcome. **Nothing inference-y on load** — no localhost probe (gone in #167), no auto-download, no overlay. A subscriber's saved cloud provider still auto-connects.
- When a user without a model **sends their first message**, motebit answers inline — *"I need a model to think. Choose one in Settings — on-device, your own key, or motebit cloud."* — and opens Settings to the **Intelligence (provider) tab**. Setup follows intent, never precedes it.
- `updateConnectPrompt` retires the empty-state overlay (only ever hides now); the connect-prompt node is solely the boot-time WebLLM progress surface for a returning on-device user (un-hides itself).
- Removed on-load WebLLM auto-download from both boot paths; saved on-device-WebLLM path unchanged.
- New `openProviderSettings` chat callback → `settings.openToTab("intelligence")`.

## Verification

- typecheck + build clean, **15/15 e2e pass**, **all 111 drift gates pass**

Closes the first-run pile-up: #167 (no scary permission) + this (no occluding setup overlay) = creature-first, talk-first, setup-on-intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)