### PR TITLE
feat(relay): free first-taste cloud credit — the activation engine (off by default)

### DIFF
--- a/.changeset/relay-free-credit-activation.md
+++ b/.changeset/relay-free-credit-activation.md
@@ -1,0 +1,17 @@
+---
+"@motebit/relay": minor
+---
+
+Free "first taste" cloud-inference credit — the activation engine (off by default).
+
+A brand-new motebit has no provider, so its first message hits a setup wall (pay / bring an API key / download a model) — where most new users bounce, and why the funnel counts ~nobody. This grants a small one-time free balance so a fresh motebit can just talk on motebit cloud, then meets the normal upgrade prompt when it runs out. It reuses the entire existing economic loop: the grant is a `deposit` with a distinctive `free-credit:<motebit_id>` reference, so the proxy-token → balance → debit → 402 → upgrade path already handles everything downstream (and activates the dormant free-tier scaffolding in `services/proxy`).
+
+Granted at `POST /api/v1/agents/:motebitId/proxy-token` — the moment a motebit first reaches for cloud inference.
+
+**Spend is OFF by default.** The code ships complete but grants nothing (and costs nothing) until the operator sets `MOTEBIT_FREE_CREDIT_USD` > 0. Three caps then bound exposure:
+
+- **one-time per motebit** (idempotent on the `free-credit:<id>` ledger reference),
+- **per-IP per day** (`MOTEBIT_FREE_CREDIT_IP_DAILY_CAP`, default 10) — minting a fresh motebit is free, so the per-motebit grant alone is sybil-drainable; this is the casual-abuse cap (migration v33 `relay_free_grants`),
+- **global daily budget** (`MOTEBIT_FREE_CREDIT_DAILY_BUDGET_USD`, default 25) — the hard backstop on total give-away per day regardless of IP rotation.
+
+This is the relay-side engine. The web ignition (attempting the free cloud on the user's first message, on intent — never phoning home on boot) ships next; the feature is user-visible only once both land and a budget is configured.

--- a/services/relay/src/__tests__/free-credit.test.ts
+++ b/services/relay/src/__tests__/free-credit.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Free "first taste" credit — the activation grant. Asserts the three caps
+ * (one-time per motebit, per-IP daily, global daily budget), the off-by-default
+ * behavior, and that the grant flows through the proxy-token endpoint so a fresh
+ * motebit's token carries a usable balance.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createSyncRelay } from "../index.js";
+import type { SyncRelay } from "../index.js";
+import { grantFreeCreditIfEligible, type FreeCreditConfig } from "../free-credit.js";
+import { getAccountBalance, toMicro } from "../accounts.js";
+
+const API_TOKEN = "test-token";
+const NOW = Date.UTC(2026, 5, 9, 12, 0, 0);
+
+// Small, explicit config so the caps are easy to hit in tests.
+const CFG: FreeCreditConfig = {
+  amountMicro: toMicro(0.1),
+  ipDailyCap: 2,
+  dailyBudgetMicro: toMicro(0.25), // fits exactly two 0.10 grants, not a third
+};
+
+async function createTestRelay(): Promise<SyncRelay> {
+  return createSyncRelay({
+    apiToken: API_TOKEN,
+    enableDeviceAuth: true,
+    x402: {
+      payToAddress: "0x0000000000000000000000000000000000000000",
+      network: "eip155:84532",
+      testnet: true,
+    },
+  });
+}
+
+describe("grantFreeCreditIfEligible", () => {
+  let relay: SyncRelay;
+  let db: import("@motebit/persistence").DatabaseDriver;
+
+  beforeEach(async () => {
+    relay = await createTestRelay();
+    db = relay.moteDb.db;
+  });
+  afterEach(async () => {
+    await relay.close();
+  });
+
+  it("is inert when disabled (amount 0) — grants nothing", () => {
+    const r = grantFreeCreditIfEligible(db, "m-off", "1.1.1.1", {
+      config: { ...CFG, amountMicro: 0 },
+      nowMs: NOW,
+    });
+    expect(r).toEqual({ granted: false, reason: "disabled" });
+    expect(getAccountBalance(db, "m-off")).toBeNull();
+  });
+
+  it("grants once, then is idempotent for the same motebit", () => {
+    const first = grantFreeCreditIfEligible(db, "m1", "1.1.1.1", { config: CFG, nowMs: NOW });
+    expect(first).toEqual({ granted: true, amountMicro: toMicro(0.1) });
+    expect(getAccountBalance(db, "m1")?.balance).toBe(toMicro(0.1));
+
+    const second = grantFreeCreditIfEligible(db, "m1", "1.1.1.1", { config: CFG, nowMs: NOW });
+    expect(second).toEqual({ granted: false, reason: "already_granted" });
+    // Balance unchanged — no double grant.
+    expect(getAccountBalance(db, "m1")?.balance).toBe(toMicro(0.1));
+  });
+
+  it("caps grants per IP per day (different motebits, same IP)", () => {
+    // Generous budget so the IP cap (not the global budget) is what bites.
+    const cfg = { ...CFG, dailyBudgetMicro: toMicro(1) };
+    const ip = "2.2.2.2";
+    expect(grantFreeCreditIfEligible(db, "a", ip, { config: cfg, nowMs: NOW }).granted).toBe(true);
+    expect(grantFreeCreditIfEligible(db, "b", ip, { config: cfg, nowMs: NOW }).granted).toBe(true);
+    // Third from the same IP exceeds ipDailyCap=2.
+    expect(grantFreeCreditIfEligible(db, "c", ip, { config: cfg, nowMs: NOW })).toEqual({
+      granted: false,
+      reason: "ip_cap",
+    });
+    // A different IP is unaffected.
+    expect(grantFreeCreditIfEligible(db, "c", "3.3.3.3", { config: cfg, nowMs: NOW }).granted).toBe(
+      true,
+    );
+  });
+
+  it("enforces the global daily budget regardless of IP", () => {
+    // Budget fits exactly two grants (0.25 > 0.20, < 0.30). Each from a fresh IP.
+    expect(
+      grantFreeCreditIfEligible(db, "x", "10.0.0.1", { config: CFG, nowMs: NOW }).granted,
+    ).toBe(true);
+    expect(
+      grantFreeCreditIfEligible(db, "y", "10.0.0.2", { config: CFG, nowMs: NOW }).granted,
+    ).toBe(true);
+    // Third would push 0.30 > 0.25 budget — rejected even from a brand-new IP.
+    expect(grantFreeCreditIfEligible(db, "z", "10.0.0.3", { config: CFG, nowMs: NOW })).toEqual({
+      granted: false,
+      reason: "daily_budget",
+    });
+  });
+
+  it("the per-IP cap resets on a new day", () => {
+    const ip = "4.4.4.4";
+    grantFreeCreditIfEligible(db, "d1", ip, { config: CFG, nowMs: NOW });
+    grantFreeCreditIfEligible(db, "d2", ip, { config: CFG, nowMs: NOW });
+    expect(grantFreeCreditIfEligible(db, "d3", ip, { config: CFG, nowMs: NOW }).granted).toBe(
+      false,
+    );
+    // Next day, same IP, fresh budget — allowed again.
+    const nextDay = NOW + 24 * 60 * 60 * 1000;
+    expect(grantFreeCreditIfEligible(db, "d3", ip, { config: CFG, nowMs: nextDay }).granted).toBe(
+      true,
+    );
+  });
+});
+
+describe("POST /api/v1/agents/:motebitId/proxy-token — free credit lands in the token", () => {
+  let relay: SyncRelay;
+
+  beforeEach(async () => {
+    relay = await createTestRelay();
+    // Enable a generous free credit for the duration of this test.
+    process.env.MOTEBIT_FREE_CREDIT_USD = "0.50";
+  });
+  afterEach(async () => {
+    delete process.env.MOTEBIT_FREE_CREDIT_USD;
+    await relay.close();
+  });
+
+  it("a fresh motebit's first proxy-token carries the granted balance", async () => {
+    const motebitId = crypto.randomUUID();
+    const res = await relay.app.request(`/api/v1/agents/${motebitId}/proxy-token`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { balance: number; balance_usd: number; models: string[] };
+    expect(body.balance).toBe(toMicro(0.5));
+    expect(body.balance_usd).toBeCloseTo(0.5);
+    // bal > 0 ⇒ models are populated (the proxy will serve).
+    expect(body.models.length).toBeGreaterThan(0);
+    // Idempotent: a second token request does not double-grant.
+    const res2 = await relay.app.request(`/api/v1/agents/${motebitId}/proxy-token`, {
+      method: "POST",
+    });
+    const body2 = (await res2.json()) as { balance: number };
+    expect(body2.balance).toBe(toMicro(0.5));
+  });
+});

--- a/services/relay/src/free-credit.ts
+++ b/services/relay/src/free-credit.ts
@@ -1,0 +1,146 @@
+/**
+ * Free "first taste" of cloud inference — the activation unlock.
+ *
+ * A brand-new motebit has no provider, so its first message hits a setup wall
+ * (pay / bring an API key / download a model). That wall is where most new
+ * users bounce. This grants a small one-time free balance so a fresh motebit
+ * can just talk on motebit cloud, then meets the normal upgrade prompt when the
+ * credit runs out. It reuses the entire existing economic loop — the grant is
+ * recorded as a `deposit` with a distinctive `free-credit:<motebit_id>` ledger
+ * reference, so the proxy-token / balance / debit / 402 / upgrade path already
+ * handles everything downstream. (Activates the dormant free-tier scaffolding in
+ * services/proxy — see `FREE_MODEL_ALLOWLIST` there.)
+ *
+ * SPEND IS OFF BY DEFAULT. The feature is inert unless the operator sets
+ * `MOTEBIT_FREE_CREDIT_USD` > 0 — the code ships complete, but grants nothing
+ * (and costs nothing) until a budget is configured. Three caps bound exposure:
+ *   1. one-time per motebit (idempotent on the `free-credit:<id>` reference),
+ *   2. per-IP per day (`MOTEBIT_FREE_CREDIT_IP_DAILY_CAP`, default 10) — minting
+ *      a fresh motebit is free, so the per-motebit grant alone is sybil-drainable;
+ *      this is the casual-abuse cap,
+ *   3. a global daily budget (`MOTEBIT_FREE_CREDIT_DAILY_BUDGET_USD`, default 25)
+ *      — the hard backstop on total give-away per day regardless of IP rotation.
+ *
+ * Best-effort: any failure returns "not granted" and never breaks token issuance.
+ */
+
+import type { DatabaseDriver } from "@motebit/persistence";
+import { getOrCreateAccount, creditAccount, toMicro } from "./accounts.js";
+import { createLogger } from "./logger.js";
+
+const logger = createLogger({ service: "free-credit" });
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface FreeCreditConfig {
+  /** Amount granted per new motebit, in micro-units. 0 ⇒ feature off. */
+  amountMicro: number;
+  /** Max grants per source IP per day. */
+  ipDailyCap: number;
+  /** Hard global cap on total free credit granted per day, in micro-units. */
+  dailyBudgetMicro: number;
+}
+
+function envNum(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw == null || raw === "") return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+/** Read the free-credit config from env. Defaults keep the feature OFF (amount 0). */
+export function freeCreditConfigFromEnv(): FreeCreditConfig {
+  return {
+    amountMicro: toMicro(envNum("MOTEBIT_FREE_CREDIT_USD", 0)),
+    ipDailyCap: Math.floor(envNum("MOTEBIT_FREE_CREDIT_IP_DAILY_CAP", 10)),
+    dailyBudgetMicro: toMicro(envNum("MOTEBIT_FREE_CREDIT_DAILY_BUDGET_USD", 25)),
+  };
+}
+
+export type FreeCreditResult =
+  | { granted: true; amountMicro: number }
+  | {
+      granted: false;
+      reason: "disabled" | "already_granted" | "ip_cap" | "daily_budget" | "error";
+    };
+
+/** UTC day key (YYYY-MM-DD) for the per-IP daily counter + budget window. */
+function dayKey(nowMs: number): string {
+  return new Date(nowMs).toISOString().slice(0, 10);
+}
+
+/**
+ * Grant the one-time free credit to `motebitId` if eligible. Idempotent: a
+ * motebit that already received it (or any failure / cap hit) is a no-op.
+ * Returns whether it granted, for logging — callers ignore it and just re-read
+ * the balance afterward.
+ */
+export function grantFreeCreditIfEligible(
+  db: DatabaseDriver,
+  motebitId: string,
+  ip: string,
+  opts?: { config?: FreeCreditConfig; nowMs?: number },
+): FreeCreditResult {
+  const cfg = opts?.config ?? freeCreditConfigFromEnv();
+  const nowMs = opts?.nowMs ?? Date.now();
+
+  if (cfg.amountMicro <= 0) return { granted: false, reason: "disabled" };
+
+  try {
+    const ref = `free-credit:${motebitId}`;
+
+    // 1. One-time per motebit — the grant reference is unique per identity.
+    const existing = db
+      .prepare("SELECT 1 AS n FROM relay_transactions WHERE reference_id = ? LIMIT 1")
+      .get(ref) as { n: number } | undefined;
+    if (existing) return { granted: false, reason: "already_granted" };
+
+    const dayStart = nowMs - (nowMs % DAY_MS);
+    const day = dayKey(nowMs);
+
+    // 2. Global daily budget — sum of today's free-credit grants.
+    const spentRow = db
+      .prepare(
+        `SELECT COALESCE(SUM(amount), 0) AS spent FROM relay_transactions
+         WHERE reference_id LIKE 'free-credit:%' AND created_at >= ?`,
+      )
+      .get(dayStart) as { spent: number } | undefined;
+    const spent = spentRow?.spent ?? 0;
+    if (spent + cfg.amountMicro > cfg.dailyBudgetMicro) {
+      logger.warn("free-credit.daily_budget_reached", { spent, day });
+      return { granted: false, reason: "daily_budget" };
+    }
+
+    // 3. Per-IP daily cap.
+    const ipRow = db
+      .prepare("SELECT count FROM relay_free_grants WHERE ip = ? AND day = ?")
+      .get(ip, day) as { count: number } | undefined;
+    if ((ipRow?.count ?? 0) >= cfg.ipDailyCap) {
+      return { granted: false, reason: "ip_cap" };
+    }
+
+    // Grant: credit the account, then bump the per-IP counter.
+    getOrCreateAccount(db, motebitId);
+    creditAccount(
+      db,
+      motebitId,
+      cfg.amountMicro,
+      "deposit",
+      ref,
+      "Welcome credit — free first taste of motebit cloud",
+    );
+    db.prepare(
+      `INSERT INTO relay_free_grants (ip, day, count) VALUES (?, ?, 1)
+       ON CONFLICT(ip, day) DO UPDATE SET count = count + 1`,
+    ).run(ip, day);
+
+    logger.info("free-credit.granted", { motebitId, amountMicro: cfg.amountMicro, ip, day });
+    return { granted: true, amountMicro: cfg.amountMicro };
+  } catch (err) {
+    logger.warn("free-credit.error", {
+      motebitId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { granted: false, reason: "error" };
+  }
+}

--- a/services/relay/src/migrations.ts
+++ b/services/relay/src/migrations.ts
@@ -1454,4 +1454,24 @@ export const relayMigrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 33,
+    name: "free_credit_ip_grants",
+    up: (db) => {
+      // Per-IP daily counter for the "free first taste" credit grant — the
+      // casual-abuse cap on free cloud inference (a fresh motebit can be minted
+      // for free, so the per-motebit grant alone is sybil-drainable; this bounds
+      // grants per source IP per day). The global daily budget cap and the
+      // one-time-per-motebit check live in free-credit.ts (the latter keyed on
+      // the `free-credit:<motebit_id>` ledger reference, so no column here).
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS relay_free_grants (
+          ip    TEXT NOT NULL,
+          day   TEXT NOT NULL,
+          count INTEGER NOT NULL DEFAULT 0,
+          PRIMARY KEY (ip, day)
+        );
+      `);
+    },
+  },
 ];

--- a/services/relay/src/subscriptions.ts
+++ b/services/relay/src/subscriptions.ts
@@ -15,6 +15,8 @@ import type { DatabaseDriver } from "@motebit/persistence";
 import { canonicalJson, sign, toBase64Url } from "@motebit/encryption";
 import type { RelayIdentity } from "./federation.js";
 import { createLogger } from "./logger.js";
+import { grantFreeCreditIfEligible } from "./free-credit.js";
+import { getClientIp } from "./middleware.js";
 import {
   getAccountBalance,
   getOrCreateAccount,
@@ -144,6 +146,13 @@ export function registerProxyTokenRoutes(
   /** @internal */
   app.post("/api/v1/agents/:motebitId/proxy-token", async (c) => {
     const motebitId = c.req.param("motebitId");
+
+    // Activation: grant a fresh motebit its one-time free "first taste" credit
+    // (inert unless MOTEBIT_FREE_CREDIT_USD is set; one-time + per-IP + global-
+    // budget capped — see free-credit.ts). This is the moment a brand-new
+    // motebit first reaches for cloud inference, so it's where the credit lands;
+    // the balance read below then includes it and the token carries it.
+    grantFreeCreditIfEligible(db, motebitId, getClientIp(c));
 
     const account = getAccountBalance(db, motebitId);
     const balance = account?.balance ?? 0;


### PR DESCRIPTION
## Why

The calm first-run (#166–#168) now dead-ends at a setup wall: a brand-new motebit has no provider, so its first message demands pay / bring-a-key / download-a-model. That's where new users bounce — and why the funnel counts ~nobody. This is the activation unlock: a small one-time free balance so a fresh motebit can **just talk** on motebit cloud, then meet the normal upgrade prompt when it runs out.

It reuses the **entire existing economic loop** — the grant is a `deposit` with a distinctive `free-credit:<motebit_id>` reference, so proxy-token → balance → debit → 402 → upgrade already handles everything downstream (and activates the dormant free-tier scaffolding in `services/proxy`). Granted at `POST /api/v1/agents/:motebitId/proxy-token` — the moment a motebit first reaches for cloud.

## Safety: spend is OFF by default

The code ships complete but grants **nothing (and costs nothing)** until the operator sets `MOTEBIT_FREE_CREDIT_USD` > 0. Three caps then bound exposure:

- **one-time per motebit** — idempotent on the `free-credit:<id>` ledger reference
- **per-IP/day** (`MOTEBIT_FREE_CREDIT_IP_DAILY_CAP`, default 10) — minting a fresh motebit is free, so the per-motebit grant alone is sybil-drainable; this is the casual-abuse cap (migration v33 `relay_free_grants`)
- **global daily budget** (`MOTEBIT_FREE_CREDIT_DAILY_BUDGET_USD`, default 25) — the hard backstop regardless of IP rotation

## Verification

- 6 free-credit tests (each cap + off-by-default + the proxy-token endpoint carrying the grant), **full relay suite 1281 pass**, all 111 drift gates, typecheck clean.

This is the relay-side **engine**. The web **ignition** (attempt the free cloud on the user's first message — on intent, never phoning home on boot) is the follow-up; the feature is user-visible only once both land **and** a budget env is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)