### PR TITLE
feat(web): free first-taste ignition — instant first answer, no setup

### DIFF
--- a/.changeset/web-free-cloud-ignition.md
+++ b/.changeset/web-free-cloud-ignition.md
@@ -1,0 +1,13 @@
+---
+"@motebit/web": minor
+---
+
+Free first-taste ignition — a brand-new user gets an instant first answer, no setup.
+
+The companion to the relay's free-credit engine: when a fresh motebit (no provider) sends its **first message**, the web now tries the free "first taste" on motebit cloud before asking the user to set anything up. It fetches a proxy-token from the relay — which grants the one-time free credit if the operator has enabled it — and connects. Thinking dots show during the brief connect; on success the message just sends; only if the free cloud isn't available (disabled / exhausted / offline) does it fall back to the calm "choose a model in Settings" guide.
+
+- `getSyncUrl` falls back to `DEFAULT_RELAY_URL` so a sync-less fresh motebit can reach the relay for a token. Bootstrap is **only called on the first message (intent)** — boot no longer fetches a proxy-token, so a purely-local motebit still never phones home on load (and free credit is never spent on bounces).
+- New `tryFreeCloud` chat callback → `autoInitProxy()`; the no-provider send path attempts it before guiding to Settings.
+- Once connected, `onProviderReady` saves the `motebit-cloud` config (as today), so later boots reconnect on the remaining credit.
+
+With the relay engine, this completes the activation path: land → meet the creature → type → instant answer on the house → upgrade when the taste runs out. User-visible only when the operator sets a free-credit budget.

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -10,6 +10,7 @@ import {
   saveProxyToken,
   clearProxyToken,
   saveBalance,
+  DEFAULT_RELAY_URL,
 } from "./storage";
 import { ProxySession } from "@motebit/runtime";
 import type { ProxyProviderConfig } from "@motebit/runtime";
@@ -80,6 +81,11 @@ const colorPicker = initColorPicker(ctx, () => {
 const chatAPI = initChat(ctx, {
   openSettings: () => settings.open(),
   openProviderSettings: () => settings.openToTab("intelligence"),
+  // First-message activation: attempt the free "first taste" on motebit cloud
+  // (fetches a proxy-token from the relay, which grants the one-time free credit
+  // if enabled). Resolves true if a provider got connected. This is the only
+  // moment a fresh, sync-less motebit contacts the relay — on intent.
+  tryFreeCloud: () => autoInitProxy(),
   openConversations: () => conversations.open(),
   openShortcuts: () => openShortcutDialog(),
 });
@@ -323,7 +329,11 @@ const DEFAULT_WEBLLM_MODEL = "Llama-3.2-3B-Instruct-q4f16_1-MLC";
 /** Shared proxy session — handles token lifecycle across all surfaces. */
 const proxySession = new ProxySession(
   {
-    getSyncUrl: () => loadSyncUrl(),
+    // Fall back to the canonical relay so a fresh motebit (no saved sync URL)
+    // can still fetch a proxy-token — that's where the free "first taste" credit
+    // is granted. Bootstrap is only CALLED on intent (first message), never on
+    // load, so this never phones home for a purely-local user.
+    getSyncUrl: () => loadSyncUrl() ?? DEFAULT_RELAY_URL,
     getMotebitId: () => localStorage.getItem("motebit:motebit_id"),
     loadToken: () => loadProxyToken(),
     saveToken: (data) => {
@@ -477,13 +487,12 @@ async function bootstrap(): Promise<void> {
       }
     }
   } else {
-    // First visit — nothing inference-y on load. Setup is deferred to the first
-    // message (chat.ts), so the first run is just the creature + the calm
-    // welcome: no localhost probe, no auto-download, no occluding "connect a
-    // model" overlay. A subscriber proxy still auto-connects if one exists.
-    void autoInitProxy().then(() => {
-      settings.updateConnectPrompt();
-    });
+    // First visit — nothing inference-y on load, and crucially NO relay contact:
+    // we don't fetch a proxy-token on boot (that would phone home + spend free
+    // credit on bounces). The free cloud is attempted only on the first message
+    // (chat.ts → tryFreeCloud), on intent. First run is just the creature + the
+    // calm welcome. Nothing to connect yet; reflect the no-provider state.
+    settings.updateConnectPrompt();
   }
 
   // For returning users with saved config, update prompt immediately

--- a/apps/web/src/ui/chat.ts
+++ b/apps/web/src/ui/chat.ts
@@ -601,6 +601,13 @@ export interface ChatCallbacks {
   openSettings(): void;
   /** Open Settings straight to the provider/model (Intelligence) tab — the deferred-setup landing. */
   openProviderSettings?(): void;
+  /**
+   * Attempt the free "first taste" on motebit cloud — fetch a proxy-token (the
+   * relay grants the one-time free credit if enabled) and connect. Resolves true
+   * if a provider got connected. Called on the first message of a fresh motebit
+   * with no provider, before falling back to the setup guide.
+   */
+  tryFreeCloud?(): Promise<boolean>;
   openConversations?(): void;
   openShortcuts?(): void;
 }
@@ -653,15 +660,27 @@ export function initChat(ctx: WebContext, callbacks: ChatCallbacks): ChatAPI {
     }
 
     if (!ctx.app.isProviderConnected) {
-      // Deferred setup: the user expressed intent, so now is the moment to pick
-      // a brain — not an uninvited prompt on load. Guide them and open Settings
-      // to the provider tab.
-      addMessage(
-        "system",
-        "I need a model to think. Choose one in Settings — on-device, your own key, or motebit cloud.",
-      );
-      (callbacks.openProviderSettings ?? callbacks.openSettings)();
-      return;
+      // Activation: the user expressed intent, so try the free "first taste" on
+      // motebit cloud before asking them to set anything up. Show the thinking
+      // dots so the connect isn't a dead pause; on success we fall through and
+      // send. Only guide to Settings if the free cloud isn't available (disabled
+      // / exhausted / offline). This is the first (and only, until they sync)
+      // moment a fresh motebit contacts the relay — on intent, never on load.
+      const connecting = showThinkingIndicator();
+      let connected = false;
+      try {
+        connected = (await callbacks.tryFreeCloud?.()) ?? false;
+      } finally {
+        connecting.remove();
+      }
+      if (!connected) {
+        addMessage(
+          "system",
+          "I need a model to think. Choose one in Settings — on-device, your own key, or motebit cloud.",
+        );
+        (callbacks.openProviderSettings ?? callbacks.openSettings)();
+        return;
+      }
     }
 
     addMessage("user", text);


### PR DESCRIPTION
## Why

Companion to #169 (the relay free-credit engine). #169 grants the credit; this is the **ignition** that lets a brand-new user actually use it — completing the activation path so a fresh visitor gets an **instant first answer with zero setup**.

## What changed

When a fresh motebit (no provider) sends its **first message**, the web tries the free first taste on motebit cloud *before* asking the user to set anything up:

- `getSyncUrl` falls back to `DEFAULT_RELAY_URL` so a sync-less fresh motebit can reach the relay for a proxy-token (where #169 grants the one-time free credit).
- **Bootstrap is only called on the first message (intent)** — boot no longer fetches a proxy-token, so a purely-local motebit still **never phones home on load**, and free credit is never spent on bounces.
- New `tryFreeCloud` chat callback → `autoInitProxy()`. The no-provider send path shows thinking dots during the brief connect; on success the message just sends; only if the free cloud isn't available (disabled / exhausted / offline) does it fall back to the calm "choose a model in Settings" guide.
- `onProviderReady` already saves the `motebit-cloud` config, so later boots reconnect on the remaining credit.

## Verification

- typecheck 139/139, **15/15 e2e** (chat path uses a stub provider, so the activation branch — which needs a live relay + budget — isn't exercised in the smoke suite), all 111 drift gates.

This is the visible activation moment, so worth a render: with a budget enabled, fresh load → creature + welcome → type → thinking dots → instant answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)