### PR TITLE
ops(relay): enable free first-taste credit — $0.10/motebit, $25/day cap

### DIFF
--- a/services/relay/fly.toml
+++ b/services/relay/fly.toml
@@ -10,6 +10,14 @@ kill_timeout = 5
   NODE_ENV = "production"
   PORT = "3000"
   MOTEBIT_DB_PATH = "/data/motebit.db"
+  # Free "first taste" cloud credit — the activation unlock (see free-credit.ts).
+  # A brand-new motebit gets this one-time balance so it can just talk on motebit
+  # cloud, then meets the upgrade prompt when it runs out. Tunable money knobs —
+  # change here (committed, auditable) and the relay redeploys. Worst-case daily
+  # exposure is bounded by the daily budget regardless of sybil/IP rotation.
+  MOTEBIT_FREE_CREDIT_USD = "0.10"
+  MOTEBIT_FREE_CREDIT_IP_DAILY_CAP = "10"
+  MOTEBIT_FREE_CREDIT_DAILY_BUDGET_USD = "25"
   # Litestream S3 replication (optional — set via `fly secrets set`):
   #   LITESTREAM_REPLICA_BUCKET   — S3 bucket name (required to enable)
   #   LITESTREAM_REPLICA_PATH     — S3 prefix (default: motebit-sync)


### PR DESCRIPTION
## What

Turns ON the activation unlock (engine #169 + ignition #170). Sets the free-credit budget in the relay's `fly.toml [env]`:

```
MOTEBIT_FREE_CREDIT_USD = "0.10"            # per new motebit (≈ several Sonnet messages)
MOTEBIT_FREE_CREDIT_IP_DAILY_CAP = "10"     # casual-abuse cap
MOTEBIT_FREE_CREDIT_DAILY_BUDGET_USD = "25" # hard daily backstop
```

**Merging this deploys `motebit-sync` with free credit live.** Worst-case spend is bounded to **$25/day** regardless of sybil/IP rotation. Per-IP capped at 10 grants/day. One-time per motebit.

**Off switch:** set `MOTEBIT_FREE_CREDIT_USD = "0"` and merge — grants stop immediately on redeploy.

Once this + the web deploy land, the full activation path is live: land → creature + "born" → type → instant answer on the house → upgrade when the taste runs out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)