### PR TITLE
fix(crypto): verifyRequestEnvelope checks freshness by default (agency-reported fail-open)

### DIFF
--- a/.changeset/envelope-freshness-default.md
+++ b/.changeset/envelope-freshness-default.md
@@ -1,0 +1,16 @@
+---
+"@motebit/crypto": minor
+---
+
+`verifyRequestEnvelope` now checks freshness **by default** — closing a fail-open replay window (agency-reported, same-day post-publish).
+
+The bug: freshness ran only when the caller passed `now`. The obvious call — `verifyRequestEnvelope(env, key, { payload, expectedAud })` — silently skipped it, shipping a **forever** replay window to any consumer who didn't know to pass a clock. This was a code-vs-spec drift in the code's direction: `spec/signed-request-envelope-v1.md` §4 already lists the staleness check as Step 2, mandatory for every verifier, with `now = Date.now()` as the default. The code under-delivered the published contract.
+
+Fix (additive API, conforms the code to the spec):
+
+- `now` defaults to `Date.now()` and `windowMs` to 300s, so freshness is enforced even when neither is supplied.
+- New `checkFreshness?: boolean` option (default `true`) — opt out explicitly for re-verifying a _historical_ envelope outside a live request path, mirroring `verifyDelegation`'s `checkExpiry`. A live request-auth verifier MUST NOT disable it (spec §4 foundation law + §10).
+
+**Behavior change to note:** a caller relying on the old "freshness only when `now` is passed" behavior will now reject stale envelopes by default; pass `checkFreshness: false` to restore the old behavior where that is genuinely wanted. Unlike the I/O-free `isRevoked` seam (fail-open by architectural necessity), freshness is a pure clock comparison — there was no reason to leave it off.
+
+Spec sharpening in the same change: §4 foundation law spells out the default-on + opt-out semantics; §10 conformance names freshness explicitly; §5 documents that `aud`'s host part is a stable service identifier (not the transport `Host:`); and `seed-escrow-v1.md` §5 gains a custodian foundation law — at placement, `identity_pubkey_check` MUST equal the registered key of the placing identity, so the field is load-bearing at rest, not only at restore (agency-reported).

--- a/packages/crypto/etc/crypto.api.md
+++ b/packages/crypto/etc/crypto.api.md
@@ -1701,6 +1701,7 @@ export function verifyRelayMetadata(metadata: RelayMetadata, publicKey: Uint8Arr
 export function verifyRequestEnvelope(envelope: SignedRequestEnvelope, registeredPublicKey: Uint8Array, options?: {
     payload?: unknown;
     expectedAud?: string;
+    checkFreshness?: boolean;
     now?: number;
     windowMs?: number;
 }): Promise<boolean>;

--- a/packages/crypto/src/__tests__/signed-request-envelope.test.ts
+++ b/packages/crypto/src/__tests__/signed-request-envelope.test.ts
@@ -4,15 +4,17 @@ import { generateKeypair, signRequestEnvelope, verifyRequestEnvelope } from "../
 const AUD = "app.agency.computer/api/monitors";
 
 describe("signRequestEnvelope / verifyRequestEnvelope", () => {
-  it("round-trips against the signing key", async () => {
+  it("round-trips against the signing key with the default freshness window", async () => {
     const kp = await generateKeypair();
     const env = await signRequestEnvelope(
       { subject: "S", cadence: "daily" },
-      { motebit_id: "mb-1", ts: 1_000, aud: AUD },
+      { motebit_id: "mb-1", ts: Date.now(), aud: AUD },
       kp.privateKey,
     );
     expect(env.suite).toBe("motebit-jcs-ed25519-b64-v1");
     expect(env.payload_digest).toMatch(/^[0-9a-f]{64}$/);
+    // No options → freshness checked by default against Date.now(); a just-signed
+    // envelope is inside the 300s window.
     expect(await verifyRequestEnvelope(env, kp.publicKey)).toBe(true);
   });
 
@@ -24,7 +26,9 @@ describe("signRequestEnvelope / verifyRequestEnvelope", () => {
       { motebit_id: "mb-1", ts: 1_000, aud: AUD },
       kp.privateKey,
     );
-    expect(await verifyRequestEnvelope(env, other.publicKey)).toBe(false);
+    expect(await verifyRequestEnvelope(env, other.publicKey, { checkFreshness: false })).toBe(
+      false,
+    );
   });
 
   it("re-checks the detached payload digest when the payload is supplied", async () => {
@@ -35,11 +39,16 @@ describe("signRequestEnvelope / verifyRequestEnvelope", () => {
       { motebit_id: "mb-1", ts: 1_000, aud: AUD },
       kp.privateKey,
     );
-    expect(await verifyRequestEnvelope(env, kp.publicKey, { payload })).toBe(true);
-    // A different body has a different digest → reject.
-    expect(await verifyRequestEnvelope(env, kp.publicKey, { payload: { subject: "EVIL" } })).toBe(
-      false,
+    expect(await verifyRequestEnvelope(env, kp.publicKey, { payload, checkFreshness: false })).toBe(
+      true,
     );
+    // A different body has a different digest → reject.
+    expect(
+      await verifyRequestEnvelope(env, kp.publicKey, {
+        payload: { subject: "EVIL" },
+        checkFreshness: false,
+      }),
+    ).toBe(false);
   });
 
   it("enforces exact audience match when expectedAud is supplied", async () => {
@@ -49,10 +58,41 @@ describe("signRequestEnvelope / verifyRequestEnvelope", () => {
       { motebit_id: "mb-1", ts: 1_000, aud: AUD },
       kp.privateKey,
     );
-    expect(await verifyRequestEnvelope(env, kp.publicKey, { expectedAud: AUD })).toBe(true);
     expect(
-      await verifyRequestEnvelope(env, kp.publicKey, { expectedAud: "other.host/route" }),
+      await verifyRequestEnvelope(env, kp.publicKey, { expectedAud: AUD, checkFreshness: false }),
+    ).toBe(true);
+    expect(
+      await verifyRequestEnvelope(env, kp.publicKey, {
+        expectedAud: "other.host/route",
+        checkFreshness: false,
+      }),
     ).toBe(false);
+  });
+
+  it("checks freshness BY DEFAULT — a stale envelope is rejected with no options (the foot-gun)", async () => {
+    const kp = await generateKeypair();
+    // ts is ancient relative to Date.now(); the obvious call supplies neither now
+    // nor windowMs. A forever replay window would (wrongly) accept this.
+    const env = await signRequestEnvelope(
+      { x: 1 },
+      { motebit_id: "mb-1", ts: 1_000, aud: AUD },
+      kp.privateKey,
+    );
+    expect(await verifyRequestEnvelope(env, kp.publicKey)).toBe(false);
+    // The same call shape that a consumer would actually write — still fail-closed.
+    expect(
+      await verifyRequestEnvelope(env, kp.publicKey, { payload: { x: 1 }, expectedAud: AUD }),
+    ).toBe(false);
+  });
+
+  it("accepts a stale envelope only when freshness is explicitly disabled", async () => {
+    const kp = await generateKeypair();
+    const env = await signRequestEnvelope(
+      { x: 1 },
+      { motebit_id: "mb-1", ts: 1_000, aud: AUD },
+      kp.privateKey,
+    );
+    expect(await verifyRequestEnvelope(env, kp.publicKey, { checkFreshness: false })).toBe(true);
   });
 
   it("enforces the freshness window when now is supplied", async () => {
@@ -66,6 +106,10 @@ describe("signRequestEnvelope / verifyRequestEnvelope", () => {
     expect(await verifyRequestEnvelope(env, kp.publicKey, { now: 1_000 + 200_000 })).toBe(true);
     // Beyond the window → stale.
     expect(await verifyRequestEnvelope(env, kp.publicKey, { now: 1_000 + 400_000 })).toBe(false);
+    // A wider explicit window admits it again.
+    expect(
+      await verifyRequestEnvelope(env, kp.publicKey, { now: 1_000 + 400_000, windowMs: 600_000 }),
+    ).toBe(true);
   });
 
   it("signs the optional nonce into the body", async () => {
@@ -76,8 +120,10 @@ describe("signRequestEnvelope / verifyRequestEnvelope", () => {
       kp.privateKey,
     );
     expect(env.nonce).toBe("n-123");
-    expect(await verifyRequestEnvelope(env, kp.publicKey)).toBe(true);
+    expect(await verifyRequestEnvelope(env, kp.publicKey, { checkFreshness: false })).toBe(true);
     // Tampering with a signed field (aud) breaks the signature.
-    expect(await verifyRequestEnvelope({ ...env, aud: "x" }, kp.publicKey)).toBe(false);
+    expect(
+      await verifyRequestEnvelope({ ...env, aud: "x" }, kp.publicKey, { checkFreshness: false }),
+    ).toBe(false);
   });
 });

--- a/packages/crypto/src/artifacts.ts
+++ b/packages/crypto/src/artifacts.ts
@@ -1068,22 +1068,36 @@ export async function signRequestEnvelope(
  * caller MUST resolve `registeredPublicKey` from its registry by
  * `envelope.motebit_id`, never from the envelope).
  *
- * Always checks the suite + the signature. Optionally checks, when the
- * corresponding option is supplied: audience (exact-match), freshness
- * (`|now − ts| ≤ windowMs`, default 300s), and the payload digest. Nonce
- * replay-dedup is stateful and stays the consumer's concern. Fail-closed on
- * unknown suite / malformed signature / any supplied-check mismatch.
+ * Always checks the suite + the signature. Freshness (`|now − ts| ≤ windowMs`)
+ * is checked **by default** — `now` defaults to `Date.now()`, `windowMs` to
+ * 300s — because a request-auth envelope verified without a freshness bound is a
+ * forever replay window. Opt out explicitly with `checkFreshness: false` (e.g.
+ * verifying a historical envelope), mirroring `verifyDelegation`'s `checkExpiry`.
+ * Audience (exact-match) and the payload digest are checked when their option is
+ * supplied. Nonce replay-dedup is stateful and stays the consumer's concern.
+ * Fail-closed on unknown suite / malformed signature / staleness / any
+ * supplied-check mismatch.
  */
 export async function verifyRequestEnvelope(
   envelope: SignedRequestEnvelope,
   registeredPublicKey: Uint8Array,
-  options?: { payload?: unknown; expectedAud?: string; now?: number; windowMs?: number },
+  options?: {
+    payload?: unknown;
+    expectedAud?: string;
+    checkFreshness?: boolean;
+    now?: number;
+    windowMs?: number;
+  },
 ): Promise<boolean> {
   if (envelope.suite !== SIGNED_REQUEST_ENVELOPE_SUITE) return false;
   if (options?.expectedAud !== undefined && envelope.aud !== options.expectedAud) return false;
-  if (options?.now !== undefined) {
-    const windowMs = options.windowMs ?? 300_000;
-    if (Math.abs(options.now - envelope.ts) > windowMs) return false;
+  // Freshness is fail-closed by default: a forever replay window is never a safe
+  // default for request auth. Skip only when a consumer explicitly opts out.
+  const checkFreshness = options?.checkFreshness ?? true;
+  if (checkFreshness) {
+    const now = options?.now ?? Date.now();
+    const windowMs = options?.windowMs ?? 300_000;
+    if (Math.abs(now - envelope.ts) > windowMs) return false;
   }
   if (options?.payload !== undefined) {
     const recomputed = await canonicalSha256(options.payload);

--- a/spec/seed-escrow-v1.md
+++ b/spec/seed-escrow-v1.md
@@ -115,6 +115,7 @@ Step 6: The identity is restored; the client re-derives and proceeds
 
 - Step 5 is mandatory. An AEAD success without the pubkey check is not a restore.
 - The custodian MUST accept placement and replacement only from the identity whose seed the payload claims to hold (authenticated placement, §5.1 Step 5).
+- At placement, the custodian MUST verify that the payload's `identity_pubkey_check` equals the registered public key of the identity that authenticated the placement. Without this, an identity can park a payload asserting _another_ identity's key under its own signature — confidentiality is unharmed, but the check field becomes noise exactly where §6's substitution defense needs it meaningful. One equality test at intake makes the field load-bearing at rest, not only at restore.
 - The custodian MUST NOT condition retrieval on anything beyond presentation of the `unlock_hint` — the hint is an unguessable opaque locator, the payload is ciphertext, and the real gate is the authenticator. Retrieval MUST NOT be publicly enumerable.
 - Escrow placement failure MUST NOT block the identity's normal operation. Escrow is durability, never a dependency.
 

--- a/spec/signed-request-envelope-v1.md
+++ b/spec/signed-request-envelope-v1.md
@@ -103,6 +103,7 @@ Step 7: Accept
 
 - The verifier MUST resolve the public key from its registry by `motebit_id`. Verifying against a key carried in or alongside the request defeats the design — possession of the registered key IS the account.
 - Steps 1–5 are mandatory for every verifier. Step 6 is mandatory only for verifiers that advertise replay-once semantics.
+- Freshness (Step 2) is **on by default and fail-closed**: `now` defaults to the wall clock, so a verifier that supplies neither `now` nor `windowMs` still rejects a stale envelope. An implementation MAY expose an explicit opt-out (e.g. `checkFreshness: false`) for re-verifying a _historical_ envelope outside a live request path, but a live request-auth verifier MUST NOT disable Step 2 — a verifier that runs freshness only when a clock is passed in ships a forever replay window to any caller who forgets to pass one.
 - Default freshness window: ±300 seconds. Implementations SHOULD allow ~60s additional skew tolerance in distributed deployments.
 
 ---
@@ -112,6 +113,8 @@ Step 7: Accept
 `aud` is a **free-form string**, deliberately not the `TokenAudience` registry of auth-token@1.0 — request audiences are finer-grained than relay operations and owned by each service.
 
 Convention: `"{host}/{route}"`, e.g. `"app.agency.computer/api/monitors"`. The verifier compares for exact equality, fail-closed. A service MAY use coarser audiences (one per service) at the cost of intra-service replay surface; it MUST NOT accept an envelope whose `aud` it does not recognize as its own.
+
+The host part is a stable **service identifier**, not the transport host. A service spanning environments (e.g. dev and prod against one registry) SHOULD fix one `aud` per route and use it everywhere rather than deriving `aud` from the request's `Host:` header — a reflected host splits one service into per-environment audiences and lets a header rewrite move an envelope between them. The identifier need not resolve in DNS; it must only be agreed, fixed, and exact-matched on both sides.
 
 ---
 
@@ -171,6 +174,6 @@ An implementation conforms to this specification if:
 1. Envelopes contain all required fields with `payload_digest` computed over canonical JSON (§2, §3).
 2. The signature covers `canonicalJson(envelope minus signature)` (§3 Step 3).
 3. Verification resolves the key from the registry, never the request (§4 foundation law).
-4. Verification performs Steps 1–5 in order, fail-closed (§4).
+4. Verification performs Steps 1–5 in order, fail-closed; freshness (Step 2) is enabled by default and a live request-auth verifier MUST NOT skip it (§4).
 5. Audience comparison is exact-match (§5).
 6. Replay-once semantics, where offered, honor `nonce` dedup within the freshness window (§6).


### PR DESCRIPTION
agency consumed `signed-request-envelope@1.0` in production the same day it published and reported a **fail-open replay window** — fixing it here.

## The bug
`verifyRequestEnvelope` ran the freshness check only when the caller passed `now`. The obvious call —
```ts
verifyRequestEnvelope(env, key, { payload, expectedAud })
```
— silently skipped freshness, shipping a **forever replay window** to any consumer who didn't know to pass a clock. agency shipped exactly that for ~4 minutes; their stale-timestamp test caught it. The next consumer might not have that test.

This was a **code-vs-spec drift in the code's direction**: `spec/signed-request-envelope-v1.md` §4 already lists the staleness check as **Step 2, mandatory for every verifier**, with `now = Date.now()` the default. The code under-delivered the published contract — so this conforms the code to the spec rather than changing it.

## The fix (additive API)
- `now` defaults to `Date.now()`, `windowMs` to 300s — freshness enforced even when neither is supplied.
- New `checkFreshness?: boolean` (default `true`); opt out **only** for re-verifying a *historical* envelope outside a live request path — mirrors `verifyDelegation`'s `checkExpiry`. Unlike the I/O-free `isRevoked` seam (fail-open by architectural necessity), freshness is a pure clock comparison: no reason to leave it off.
- 8 envelope tests including the **foot-gun regression** (stale envelope, no options → reject) and the explicit opt-out.

## Spec sharpening (agency-reported)
- signed-request-envelope §4 foundation law (default-on + opt-out semantics), §10 conformance names freshness explicitly, §5 (`aud`'s host is a stable **service identifier**, not the transport `Host:` — a reflected host splits one service across environments).
- seed-escrow §5 custodian foundation law: at placement, `identity_pubkey_check` MUST equal the registered key of the placing identity — makes the field load-bearing at rest, not only at restore (defends §6 substitution where it matters).

## Semver
`@motebit/crypto` **minor** (additive `checkFreshness` option; conforms to the already-published spec). The default-behavior change is called out in the changeset with the `checkFreshness: false` restore path. `@motebit/verifier` gets the patch cascade.

All 115 gates green; crypto typecheck + lint + coverage green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)