### PR TITLE
chore(adoption): doc-count probes, verifier coverage governance, real changeset gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,12 +468,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Check for changeset
-        run: |
-          # Count new changeset files (not README.md or config.json)
-          CHANGESETS=$(git diff --name-only origin/main...HEAD -- '.changeset/*.md' | grep -v README.md | wc -l | tr -d ' ')
-          if [ "$CHANGESETS" -eq "0" ]; then
-            echo "::warning::No changeset found. If this PR affects published packages (@motebit/protocol, @motebit/sdk, @motebit/crypto, @motebit/verifier, create-motebit, motebit), run 'pnpm changeset' and commit the result."
-          else
-            echo "✓ Found $CHANGESETS changeset(s)"
-          fi
+      - name: Require a changeset when a published package's source changed
+        # Fails (exit 1) only when a non-private package's `src/` changed without
+        # a changeset — docs/test/service/CI-only PRs pass. Derives the published
+        # set from package.json (no hardcoded list). See the script header.
+        run: npx tsx scripts/check-changeset-required.ts

--- a/apps/docs/content/docs/operator/architecture.mdx
+++ b/apps/docs/content/docs/operator/architecture.mdx
@@ -169,7 +169,7 @@ Layer N may depend on layers `0..N-1` in production and `0..N` in devDependencie
 
 ## Permissive / BSL boundary
 
-Eleven packages sit on the permissive floor — Apache-2.0, with an explicit patent grant and litigation-termination clause. `check-deps.ts` enforces that permissive-floor packages export only types, enums, branded casts, allowlisted utilities, and deterministic verifiers — never algorithms that would bind a competing implementation to this codebase.
+11 packages sit on the permissive floor — Apache-2.0, with an explicit patent grant and litigation-termination clause. `check-deps.ts` enforces that permissive-floor packages export only types, enums, branded casts, allowlisted utilities, and deterministic verifiers — never algorithms that would bind a competing implementation to this codebase.
 
 | Package                                         | Answers                                                            | Layer |
 | ----------------------------------------------- | ------------------------------------------------------------------ | ----- |

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -6333,7 +6333,7 @@ Layer N may depend on layers `0..N-1` in production and `0..N` in devDependencie
 
 ## Permissive / BSL boundary
 
-Eleven packages sit on the permissive floor — Apache-2.0, with an explicit patent grant and litigation-termination clause. `check-deps.ts` enforces that permissive-floor packages export only types, enums, branded casts, allowlisted utilities, and deterministic verifiers — never algorithms that would bind a competing implementation to this codebase.
+11 packages sit on the permissive floor — Apache-2.0, with an explicit patent grant and litigation-termination clause. `check-deps.ts` enforces that permissive-floor packages export only types, enums, branded casts, allowlisted utilities, and deterministic verifiers — never algorithms that would bind a competing implementation to this codebase.
 
 | Package                                         | Answers                                                            | Layer |
 | ----------------------------------------------- | ------------------------------------------------------------------ | ----- |

--- a/scripts/check-changeset-required.ts
+++ b/scripts/check-changeset-required.ts
@@ -1,0 +1,132 @@
+/**
+ * check-changeset-required — a published-package SOURCE change MUST carry a changeset.
+ *
+ * The release flow (changesets → "Version Packages" PR → publish) only bumps a
+ * package when a changeset names it. A PR that edits a PUBLISHED package's source
+ * without adding a changeset silently ships an unreleased change: the fix lands on
+ * `main` but never reaches npm until something else happens to bump that package
+ * via the patch cascade. This is the PRESENCE half of changeset hygiene; the
+ * companions are `check-changeset-discipline` (quality: non-empty body, migration
+ * section, no mixed bumps) and `check-api-surface` (a public API change needs a
+ * `major`). This gate adds: an internal, non-API published change still needs SOME
+ * changeset.
+ *
+ * Scope is deliberately narrow so it never fires on legitimately changeset-free
+ * PRs (docs, tests, CI, services — none of which publish):
+ *
+ *   A changed file requires a changeset IFF it lives under a PUBLISHED package's
+ *   `src/` tree and is not itself a test. "Published" = a workspace `package.json`
+ *   without `private: true` (the same definition `check-doc-counts` derives) — so
+ *   the set stays correct as packages are added or flipped private, no hardcoded
+ *   list to drift.
+ *
+ * An empty changeset (`---` / `---`) satisfies the gate, so a deliberate
+ * no-release change (e.g. a comment-only edit) is always expressible — the gate
+ * forces the DECISION to be explicit, never the release.
+ *
+ * PR-only (needs a diff against the base), so it runs in the `changeset` CI job,
+ * NOT in `pnpm check`. The base ref defaults to `origin/main` and can be
+ * overridden with `CHANGESET_BASE_REF`.
+ */
+import { execSync } from "node:child_process";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const BASE_REF = process.env.CHANGESET_BASE_REF ?? "origin/main";
+
+/** Directories (relative to ROOT) of every published — non-private — workspace package. */
+function publishedPackageDirs(): string[] {
+  const dirs: string[] = [];
+  for (const parent of ["packages", "apps", "services"]) {
+    let entries: string[];
+    try {
+      entries = readdirSync(resolve(ROOT, parent));
+    } catch {
+      continue;
+    }
+    for (const sub of entries) {
+      if (sub.startsWith(".")) continue;
+      try {
+        const pkg = JSON.parse(
+          readFileSync(resolve(ROOT, parent, sub, "package.json"), "utf-8"),
+        ) as { private?: boolean };
+        if (pkg.private !== true) dirs.push(`${parent}/${sub}`);
+      } catch {
+        // no package.json (e.g. packages/github-action) → not a publishable package
+      }
+    }
+  }
+  return dirs;
+}
+
+function changedFiles(): string[] {
+  const out = execSync(`git diff --name-only ${BASE_REF}...HEAD`, { cwd: ROOT, encoding: "utf-8" });
+  return out
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
+function hasChangeset(files: string[]): boolean {
+  return files.some(
+    (f) => f.startsWith(".changeset/") && f.endsWith(".md") && !f.endsWith("README.md"),
+  );
+}
+
+/** A published-package source file that warrants a release. Excludes tests. */
+function isPublishedSource(file: string, publishedDirs: string[]): boolean {
+  const dir = publishedDirs.find((d) => file.startsWith(`${d}/src/`));
+  if (!dir) return false;
+  if (file.includes("/__tests__/")) return false;
+  if (/\.test\.tsx?$/.test(file)) return false;
+  return /\.(ts|tsx|js|jsx)$/.test(file);
+}
+
+function main(): void {
+  let files: string[];
+  try {
+    files = changedFiles();
+  } catch (err) {
+    process.stdout.write(
+      `check-changeset-required: could not diff against ${BASE_REF} ` +
+        `(${err instanceof Error ? err.message : String(err)}). ` +
+        `Ensure the base ref is fetched (CI uses fetch-depth: 0).\n`,
+    );
+    process.exit(1);
+  }
+
+  const publishedDirs = publishedPackageDirs();
+  const publishedSrcChanges = files.filter((f) => isPublishedSource(f, publishedDirs));
+
+  if (publishedSrcChanges.length === 0) {
+    process.stdout.write(
+      "✓ check-changeset-required: no published-package source changed; a changeset is not required.\n",
+    );
+    return;
+  }
+
+  if (hasChangeset(files)) {
+    process.stdout.write(
+      `✓ check-changeset-required: ${publishedSrcChanges.length} published-package source file(s) changed and a changeset is present.\n`,
+    );
+    return;
+  }
+
+  const touchedPkgs = [
+    ...new Set(
+      publishedSrcChanges.map((f) => publishedDirs.find((d) => f.startsWith(`${d}/src/`))!),
+    ),
+  ].sort();
+  process.stdout.write(
+    "✗ check-changeset-required: published-package source changed without a changeset.\n\n" +
+      `  Published packages touched:\n${touchedPkgs.map((p) => `    - ${p}`).join("\n")}\n\n` +
+      `  Source files:\n${publishedSrcChanges.map((f) => `    - ${f}`).join("\n")}\n\n` +
+      "  Run `pnpm changeset` and commit the result so the change reaches npm.\n" +
+      "  For a deliberate no-release change, add an empty changeset (`---` / `---`).\n",
+  );
+  process.exit(1);
+}
+
+main();

--- a/scripts/check-doc-counts.ts
+++ b/scripts/check-doc-counts.ts
@@ -266,6 +266,11 @@ const DOCS: ReadonlyArray<DocFile> = [
         key: "publishedTotal",
         label: "Versioning section 'the N published packages above'",
       },
+      {
+        regex: /\(\[`services\/`\]\(services\/\)\) — (\d+) services in four roles/,
+        key: "services",
+        label: "Marketplace section — service count",
+      },
     ],
   },
   {
@@ -278,6 +283,11 @@ const DOCS: ReadonlyArray<DocFile> = [
         key: "apps",
         kind: "sum",
         label: "Architecture line — surfaces + supporting apps",
+      },
+      {
+        regex: /supporting apps, (\d+) services/,
+        key: "services",
+        label: "Architecture line — service count",
       },
     ],
   },
@@ -295,6 +305,16 @@ const DOCS: ReadonlyArray<DocFile> = [
         key: "apps",
         kind: "sum",
         label: "Shape banner — surfaces + supporting apps",
+      },
+      {
+        regex: /supporting apps · (\d+) services/,
+        key: "services",
+        label: "Shape banner — service count",
+      },
+      {
+        regex: /(\d+) packages sit on the permissive floor/,
+        key: "publishedApache",
+        label: "License-tier section — permissive-floor (Apache-2.0) count",
       },
     ],
   },

--- a/scripts/money-identity-path.ts
+++ b/scripts/money-identity-path.ts
@@ -98,6 +98,7 @@ export const MONEY_IDENTITY_PATH: ReadonlyMap<string, PathTier> = new Map([
   ["@motebit/crypto-tpm", "identity"],
   ["@motebit/crypto-webauthn", "identity"],
   ["@motebit/verify", "identity"], // canonical motebit-verify aggregator — verification IS the identity path
+  ["@motebit/verifier", "identity"], // dep-thin verification library third parties (agency) consume — verification IS the identity path. Member-by-declaration (NOT a trigger), like crypto
 ]);
 
 /**


### PR DESCRIPTION
Cold-audit **P1/P2 adoption-hygiene** fixes (the lower-priority remainder after #183/#185/#186). Three independent drift/governance hardenings; no published-package source touched (so this PR carries no changeset — and its own new gate agrees).

## 1. `check-doc-counts` — bind two more claim classes to the filesystem

The `services` count was matched **non-capturing** (`(?:\d+) services`) in architecture.mdx + CLAUDE.md — consumed but never validated, so "9 services" was free to re-drift. And the architecture.mdx permissive-floor count was **spelled out** ("Eleven"), which no `(\d+)` probe could see.

- Normalized "Eleven" → "11" (matches the doc's own digit style in the same banner).
- Added 4 capturing probes: `services` ×3 (architecture.mdx, CLAUDE.md, README) + Apache permissive-floor ×1 (architecture.mdx).
- **37 → 41** enforced count claims.

## 2. `@motebit/verifier` → the money/identity coverage registry

The dep-thin verification library third parties (agency) consume was **absent** from `MONEY_IDENTITY_PATH` while its CLI sibling `@motebit/verify` was present. Its coverage (95/81/100/95) already clears the identity floor (85/80/85/85) on **every axis**, so this is governance-only — no test-writing, no graduation entry. Member-by-declaration, like `@motebit/crypto`.

## 3. `check-changeset-required` (new) — make the warning-only `changeset` job real

The `changeset` CI job only emitted a `::warning::` (ignored in practice). Replaced it with a gate that **fails CI** when a non-private package's `src/` changes without a changeset.

- **Scoped** so docs/test/service/CI-only PRs pass (this PR included).
- **Drift-proof**: derives the published set from `package.json` (`private !== true`), no hardcoded list.
- An **empty changeset** (`---`/`---`) satisfies it — forces the release *decision* explicit, never the release.
- It's the non-bypassable CI backstop to the existing (bypassable, `--no-verify`-able) pre-commit hook. Complements `check-changeset-discipline` (quality) + `check-api-surface` (API breaks → major).

## Verification

- All **115** hard gates pass (`pnpm check`); **125/125** gate-effectiveness.
- New gate verified both ways: passes on this docs/scripts PR; fails (exit 1, names the package + files) on a synthetic `packages/crypto/src` change.

## Deliberately not in this PR

- **`@motebit/sdk` functions:37 floor** — sdk is the type/adapter *contract* (mostly types, branded casts, adapter interfaces); forcing a high function-coverage floor would be the test-theater the coverage-graduation doctrine rules out. Left as a documented decision rather than forced into the registry.
- **README integration snippets** — already present and solid (receipt.computer + `@motebit/crypto` `verify()` + the CLI). A snippet-compiles-against-published-API check is a separate, larger docs effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
