### PR TITLE
fix(proxy): classify and observe pre-stream inference failures

### DIFF
--- a/services/proxy/src/__tests__/classify.test.ts
+++ b/services/proxy/src/__tests__/classify.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyProviderHttpFailure,
+  classifyProviderTransportFailure,
+  motebitFailure,
+  parseRetryAfterMs,
+} from "../inference/classify";
+
+// Redacted, table-driven fixtures of the real shapes the proxy sees. Bodies are
+// the small JSON error envelopes providers return on non-2xx — no prompts, no
+// keys, no user content.
+const ANTHROPIC_429 = {
+  type: "error",
+  error: { type: "rate_limit_error", message: "rate limited" },
+};
+const ANTHROPIC_529 = { type: "error", error: { type: "overloaded_error", message: "overloaded" } };
+const ANTHROPIC_500 = { type: "error", error: { type: "api_error", message: "internal" } };
+const ANTHROPIC_401 = {
+  type: "error",
+  error: { type: "authentication_error", message: "bad key" },
+};
+const ANTHROPIC_403_BILLING = {
+  type: "error",
+  error: { type: "billing_error", message: "credits exhausted" },
+};
+const ANTHROPIC_400_CONTEXT = {
+  type: "error",
+  error: {
+    type: "invalid_request_error",
+    message: "prompt is too long: 250000 tokens > 200000 maximum",
+  },
+};
+const ANTHROPIC_400_BAD = {
+  type: "error",
+  error: { type: "invalid_request_error", message: "messages: roles must alternate" },
+};
+
+const NOW = 1_700_000_000_000;
+
+describe("classifyProviderHttpFailure — status → category", () => {
+  const cases: Array<[number, unknown, string]> = [
+    [429, ANTHROPIC_429, "rate_limited"],
+    [529, ANTHROPIC_529, "overloaded"],
+    [500, ANTHROPIC_500, "server_error"],
+    [502, null, "server_error"],
+    [503, null, "server_error"],
+    [401, ANTHROPIC_401, "authentication"],
+    [403, ANTHROPIC_403_BILLING, "provider_billing_exhausted"],
+    [402, null, "provider_billing_exhausted"],
+    [404, null, "model_unavailable"],
+    [413, null, "context_overflow"],
+    [400, ANTHROPIC_400_CONTEXT, "context_overflow"],
+    [400, ANTHROPIC_400_BAD, "malformed_request"],
+    [418, null, "unknown"],
+  ];
+  for (const [status, body, expected] of cases) {
+    it(`status ${status} → ${expected}`, () => {
+      const f = classifyProviderHttpFailure({ provider: "anthropic", status, body, nowMs: NOW });
+      expect(f.source).toBe("provider");
+      expect(f.category).toBe(expected);
+      expect(f.status).toBe(status);
+    });
+  }
+
+  it("captures provider error.type as providerCode", () => {
+    const f = classifyProviderHttpFailure({
+      provider: "anthropic",
+      status: 429,
+      body: ANTHROPIC_429,
+      nowMs: NOW,
+    });
+    expect(f.providerCode).toBe("rate_limit_error");
+  });
+
+  it("classifies on status alone when body is non-JSON / null (raw body never required)", () => {
+    const f = classifyProviderHttpFailure({
+      provider: "anthropic",
+      status: 429,
+      body: null,
+      nowMs: NOW,
+    });
+    expect(f.category).toBe("rate_limited");
+    expect(f.providerCode).toBeUndefined();
+  });
+});
+
+describe("retry-after parsing (delta-seconds AND HTTP-date)", () => {
+  it("parses delta-seconds", () => {
+    expect(parseRetryAfterMs("30", NOW)).toBe(30_000);
+  });
+  it("parses an HTTP-date into a forward delta", () => {
+    const future = new Date(NOW + 45_000).toUTCString();
+    expect(parseRetryAfterMs(future, NOW)).toBe(45_000);
+  });
+  it("clamps a past HTTP-date to 0", () => {
+    const past = new Date(NOW - 60_000).toUTCString();
+    expect(parseRetryAfterMs(past, NOW)).toBe(0);
+  });
+  it("returns undefined for absent/garbage", () => {
+    expect(parseRetryAfterMs(undefined, NOW)).toBeUndefined();
+    expect(parseRetryAfterMs("", NOW)).toBeUndefined();
+    expect(parseRetryAfterMs("soon", NOW)).toBeUndefined();
+  });
+  it("flows through to the failure on a 429", () => {
+    const f = classifyProviderHttpFailure({
+      provider: "anthropic",
+      status: 429,
+      headers: { "retry-after": "12" },
+      body: ANTHROPIC_429,
+      nowMs: NOW,
+    });
+    expect(f.retryAfterMs).toBe(12_000);
+  });
+});
+
+describe("provider request-id header variants", () => {
+  for (const h of ["request-id", "anthropic-request-id", "x-request-id"]) {
+    it(`reads ${h}`, () => {
+      const f = classifyProviderHttpFailure({
+        provider: "anthropic",
+        status: 500,
+        headers: { [h]: "req_abc123" },
+        body: null,
+        nowMs: NOW,
+      });
+      expect(f.providerRequestId).toBe("req_abc123");
+    });
+  }
+  it("falls back to body.request_id when no header present", () => {
+    const f = classifyProviderHttpFailure({
+      provider: "anthropic",
+      status: 500,
+      body: {
+        type: "error",
+        error: { type: "api_error", message: "x" },
+        request_id: "req_from_body",
+      },
+      nowMs: NOW,
+    });
+    expect(f.providerRequestId).toBe("req_from_body");
+  });
+  it("reads headers case-insensitively from a Headers instance", () => {
+    const headers = new Headers({ "Request-Id": "req_hdr" });
+    const f = classifyProviderHttpFailure({
+      provider: "anthropic",
+      status: 500,
+      headers,
+      body: null,
+      nowMs: NOW,
+    });
+    expect(f.providerRequestId).toBe("req_hdr");
+  });
+});
+
+describe("classifyProviderTransportFailure", () => {
+  it("maps abort/timeout error names to timeout", () => {
+    expect(
+      classifyProviderTransportFailure({ provider: "anthropic", errorName: "AbortError" }).category,
+    ).toBe("timeout");
+    expect(
+      classifyProviderTransportFailure({ provider: "anthropic", errorName: "TimeoutError" })
+        .category,
+    ).toBe("timeout");
+  });
+  it("maps other throws to network", () => {
+    const f = classifyProviderTransportFailure({ provider: "anthropic", errorName: "TypeError" });
+    expect(f).toEqual({ source: "network", category: "network", provider: "anthropic" });
+  });
+  it("defaults to network with no error name", () => {
+    expect(classifyProviderTransportFailure({ provider: "anthropic" }).category).toBe("network");
+  });
+});
+
+describe("motebitFailure — motebit-originated, not provider", () => {
+  it("constructs a balance failure", () => {
+    expect(motebitFailure("motebit_balance", "balance_exhausted", 402)).toEqual({
+      source: "motebit_balance",
+      category: "balance_exhausted",
+      status: 402,
+    });
+  });
+  it("constructs a policy failure (jurisdiction)", () => {
+    const f = motebitFailure("motebit_request", "model_unavailable", 451);
+    expect(f.source).toBe("motebit_request");
+    expect(f.provider).toBeUndefined(); // motebit failures carry no provider origin
+  });
+});

--- a/services/proxy/src/__tests__/failure-response.test.ts
+++ b/services/proxy/src/__tests__/failure-response.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { failureResponse, emitProxyFailure } from "../inference/failure-response";
+import {
+  motebitFailure,
+  classifyProviderHttpFailure,
+  classifyProviderTransportFailure,
+} from "../inference/classify";
+
+afterEach(() => vi.restoreAllMocks());
+
+function captureLog(): string[] {
+  const lines: string[] = [];
+  vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  });
+  return lines;
+}
+
+describe("failureResponse — one event + traceable header", () => {
+  it("emits exactly one structured event and stamps X-Motebit-Request-Id", async () => {
+    const lines = captureLog();
+    const res = failureResponse({
+      requestId: "req_test_1",
+      status: 402,
+      bodyObj: { error: "insufficient_balance", balance: 0 },
+      headers: { "Access-Control-Allow-Origin": "https://motebit.com" },
+      mode: "proxy-token",
+      failure: motebitFailure("motebit_balance", "balance_exhausted", 402),
+    });
+
+    expect(lines).toHaveLength(1);
+    expect(res.status).toBe(402);
+    expect(res.headers.get("X-Motebit-Request-Id")).toBe("req_test_1");
+    expect(res.headers.get("Content-Type")).toBe("application/json");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://motebit.com");
+
+    const body = await res.json();
+    expect(body).toEqual({ error: "insufficient_balance", balance: 0 });
+
+    const event = JSON.parse(lines[0]!);
+    expect(event).toMatchObject({
+      event: "proxy.balance_exhausted",
+      schemaVersion: 1,
+      requestId: "req_test_1",
+      source: "motebit_balance",
+      category: "balance_exhausted",
+      status: 402,
+    });
+  });
+
+  it("separates request rejections from model failures (metric hygiene)", () => {
+    // A request never admitted to the model path → request_rejected, NOT a
+    // model failure. A spike in expired tokens must not look like a model spike.
+    const rejectLines = captureLog();
+    failureResponse({
+      requestId: "req_rej",
+      status: 401,
+      bodyObj: { error: "invalid_token" },
+      headers: {},
+      failure: motebitFailure("motebit_request", "authentication", 401),
+    });
+    expect(JSON.parse(rejectLines[0]!).event).toBe("proxy.request_rejected");
+    vi.restoreAllMocks();
+
+    // An OUR-side misconfiguration → internal_failure, NOT request_rejected:
+    // an operator outage must not read as malformed client traffic.
+    const infraLines = captureLog();
+    failureResponse({
+      requestId: "req_infra",
+      status: 501,
+      bodyObj: { error: "provider_not_configured" },
+      headers: {},
+      failure: motebitFailure("motebit_infrastructure", "not_configured", 501),
+    });
+    expect(JSON.parse(infraLines[0]!).event).toBe("proxy.internal_failure");
+    vi.restoreAllMocks();
+
+    // An upstream provider non-2xx → genuine inference failure.
+    const failLines = captureLog();
+    emitProxyFailure({
+      requestId: "req_fail",
+      failure: classifyProviderHttpFailure({
+        provider: "anthropic",
+        status: 429,
+        body: { type: "error", error: { type: "rate_limit_error", message: "x" } },
+        nowMs: 1_700_000_000_000,
+      }),
+    });
+    expect(JSON.parse(failLines[0]!).event).toBe("proxy.inference_failure");
+    vi.restoreAllMocks();
+
+    // A transport throw → also a model-path failure.
+    const txLines = captureLog();
+    emitProxyFailure({
+      requestId: "req_tx",
+      failure: classifyProviderTransportFailure({ provider: "anthropic", errorName: "AbortError" }),
+    });
+    expect(JSON.parse(txLines[0]!).event).toBe("proxy.inference_failure");
+  });
+
+  it("never serializes identity, prompts, provider bodies, or keys", () => {
+    const lines = captureLog();
+    emitProxyFailure({
+      requestId: "req_test_2",
+      model: "claude-sonnet-4-6",
+      mode: "proxy-token",
+      failure: classifyProviderHttpFailure({
+        provider: "anthropic",
+        status: 429,
+        headers: { "retry-after": "30", "request-id": "req_upstream" },
+        body: { type: "error", error: { type: "rate_limit_error", message: "secret-ish detail" } },
+        nowMs: 1_700_000_000_000,
+      }),
+    });
+
+    const raw = lines[0]!;
+    // The classified shape is present...
+    expect(raw).toContain("rate_limited");
+    expect(raw).toContain("req_upstream"); // provider request id IS retained (server telemetry)
+    // ...but nothing identity- or content-bearing leaks.
+    expect(raw).not.toContain("motebitId");
+    expect(raw).not.toContain("mid");
+    expect(raw).not.toContain("secret-ish"); // raw provider message never logged
+    expect(raw).not.toContain("messages");
+    expect(raw).not.toContain("x-api-key");
+
+    const event = JSON.parse(raw);
+    expect(event.providerCode).toBe("rate_limit_error");
+    expect(event.retryAfterMs).toBe(30_000);
+    expect(Object.keys(event)).not.toContain("motebitId");
+  });
+});

--- a/services/proxy/src/__tests__/route.test.ts
+++ b/services/proxy/src/__tests__/route.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as validation from "../validation";
+import type { ProxyTokenPayload } from "../validation";
+
+// Partial-mock the validation module: keep every real function, override only
+// `parseProxyToken` so we can drive the proxy-token balance path without minting
+// a real signed token.
+vi.mock("../validation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../validation")>();
+  return { ...actual, parseProxyToken: vi.fn() };
+});
+
+// Import AFTER the mock is registered.
+import { POST } from "../app/v1/messages/route";
+
+const ORIGIN = "http://localhost:3000";
+
+let logLines: string[];
+beforeEach(() => {
+  process.env.RELAY_PUBLIC_KEY = "test-pubkey";
+  logLines = [];
+  vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    logLines.push(args.map(String).join(" "));
+  });
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+/** All proxy.* failure events emitted this turn (excludes proxy.usage). */
+function failureEvents(): Array<Record<string, unknown>> {
+  return logLines
+    .map((l) => {
+      try {
+        return JSON.parse(l) as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    })
+    .filter((e): e is Record<string, unknown> => {
+      const name = e?.event;
+      return typeof name === "string" && name.startsWith("proxy.") && name !== "proxy.usage";
+    });
+}
+
+function post(headers: Record<string, string>, body: string): Promise<Response> {
+  return POST(
+    new Request("https://proxy.example/api/v1/messages", { method: "POST", headers, body }),
+  );
+}
+
+const BYOK = { origin: ORIGIN, "x-api-key": "sk-byok-test", "content-type": "application/json" };
+
+describe("route POST — failure-event wiring", () => {
+  it("invalid JSON → proxy.request_rejected (400), one event, trace header", async () => {
+    const res = await post(BYOK, "{not valid json");
+    expect(res.status).toBe(400);
+    expect(res.headers.get("X-Motebit-Request-Id")).toBeTruthy();
+    const events = failureEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]!.event).toBe("proxy.request_rejected");
+    expect(events[0]!.source).toBe("motebit_request");
+  });
+
+  it("zero balance → proxy.balance_exhausted (402)", async () => {
+    vi.mocked(validation.parseProxyToken).mockResolvedValue({
+      bal: 0,
+      mid: "m_test",
+      models: [],
+    } as unknown as ProxyTokenPayload);
+    const res = await post(
+      { origin: ORIGIN, "x-proxy-token": "tok", "content-type": "application/json" },
+      JSON.stringify({ model: "auto", messages: [{ role: "user", content: "hi" }] }),
+    );
+    expect(res.status).toBe(402);
+    expect(res.headers.get("X-Motebit-Request-Id")).toBeTruthy();
+    const events = failureEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]!.event).toBe("proxy.balance_exhausted");
+  });
+
+  it("provider 429 → proxy.inference_failure, preserves status + Retry-After, no leakage", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            type: "error",
+            error: { type: "rate_limit_error", message: "secret detail" },
+          }),
+          { status: 429, headers: { "retry-after": "30", "request-id": "req_upstream" } },
+        ),
+      ),
+    );
+    const res = await post(
+      BYOK,
+      JSON.stringify({ model: "claude-sonnet-4-6", messages: [{ role: "user", content: "hi" }] }),
+    );
+    expect(res.status).toBe(429);
+    expect(res.headers.get("X-Motebit-Request-Id")).toBeTruthy();
+    expect(res.headers.get("Retry-After")).toBe("30");
+
+    const events = failureEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]!.event).toBe("proxy.inference_failure");
+    expect(events[0]!.category).toBe("rate_limited");
+    expect(events[0]!.retryAfterMs).toBe(30_000);
+
+    // Telemetry leaks neither identity nor upstream content.
+    const raw = logLines.find((l) => l.includes("proxy.inference_failure"))!;
+    expect(raw).not.toContain("secret detail");
+    expect(raw).not.toContain("sk-byok-test");
+    expect(raw).not.toContain("motebitId");
+  });
+
+  it("operator misconfig (no provider key) → proxy.internal_failure (501), not request_rejected", async () => {
+    // proxy-token path, funded balance, concrete model — but the operator API
+    // key is absent. This is OUR fault, not the client's.
+    const prevKey = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    try {
+      vi.mocked(validation.parseProxyToken).mockResolvedValue({
+        bal: 1_000_000,
+        mid: "m_test",
+        models: [],
+      } as unknown as ProxyTokenPayload);
+      const res = await post(
+        { origin: ORIGIN, "x-proxy-token": "tok", "content-type": "application/json" },
+        JSON.stringify({ model: "claude-sonnet-4-6", messages: [{ role: "user", content: "hi" }] }),
+      );
+      expect(res.status).toBe(501);
+      expect(res.headers.get("X-Motebit-Request-Id")).toBeTruthy();
+      const events = failureEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0]!.event).toBe("proxy.internal_failure");
+      expect(events[0]!.source).toBe("motebit_infrastructure");
+    } finally {
+      if (prevKey != null) process.env.ANTHROPIC_API_KEY = prevKey;
+    }
+  });
+
+  it("provider transport throw → proxy.inference_failure (502 provider_unreachable)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("network down")));
+    const res = await post(
+      BYOK,
+      JSON.stringify({ model: "claude-sonnet-4-6", messages: [{ role: "user", content: "hi" }] }),
+    );
+    expect(res.status).toBe(502);
+    expect(res.headers.get("X-Motebit-Request-Id")).toBeTruthy();
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("provider_unreachable");
+    const events = failureEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]!.event).toBe("proxy.inference_failure");
+    expect(events[0]!.source).toBe("network");
+  });
+});

--- a/services/proxy/src/app/v1/messages/route.ts
+++ b/services/proxy/src/app/v1/messages/route.ts
@@ -23,6 +23,14 @@ import { buildProviderRequest } from "./provider-request";
 // Streaming usage extraction (pure, unit-tested) — normalizes each provider's
 // token-usage shape for the cost calc, incl. OpenAI's cached_tokens split.
 import { extractUsage, type UsageAccumulator } from "./usage";
+// Pre-stream failure classification + the shared one-event-per-failure surface.
+// Observation only (no recovery) — see `inference/classify.ts`.
+import {
+  classifyProviderHttpFailure,
+  classifyProviderTransportFailure,
+  motebitFailure,
+} from "../../../inference/classify";
+import { failureResponse, emitProxyFailure } from "../../../inference/failure-response";
 
 const ALLOWED_ORIGINS = new Set([
   "https://motebit.com",
@@ -38,6 +46,10 @@ function corsHeaders(origin: string): Record<string, string> {
     "Access-Control-Allow-Origin": origin,
     "Access-Control-Allow-Methods": "POST, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type, x-api-key, x-proxy-token, anthropic-version",
+    // Expose custom response headers so the browser client can read them
+    // cross-origin: the per-turn trace id (failures), routing reason (success),
+    // and the upstream retry guidance forwarded on a provider 429.
+    "Access-Control-Expose-Headers": "X-Motebit-Request-Id, X-Motebit-Routing-Reason, Retry-After",
     "Access-Control-Max-Age": "86400",
   };
 }
@@ -138,6 +150,9 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   const cors = corsHeaders(origin);
+  // Per-turn trace id, hoisted so every failure path can stamp it on both the
+  // structured event and the `X-Motebit-Request-Id` response header.
+  const requestId = crypto.randomUUID();
 
   // --- Authentication ---
   const proxyTokenStr = request.headers.get("x-proxy-token");
@@ -151,40 +166,54 @@ export async function POST(request: Request): Promise<Response> {
   } else if (proxyTokenStr) {
     const relayPubKey = process.env.RELAY_PUBLIC_KEY;
     if (!relayPubKey) {
-      return new Response(
-        JSON.stringify({
-          error: "server_error",
-          message: "Proxy token verification not configured",
-        }),
-        { status: 500, headers: { ...cors, "Content-Type": "application/json" } },
-      );
+      return failureResponse({
+        requestId,
+        status: 500,
+        bodyObj: { error: "server_error", message: "Proxy token verification not configured" },
+        headers: cors,
+        failure: motebitFailure("motebit_infrastructure", "not_configured", 500),
+      });
     }
 
     tokenPayload = await parseProxyToken(proxyTokenStr, relayPubKey);
     if (!tokenPayload) {
-      return new Response(
-        JSON.stringify({ error: "invalid_token", message: "Invalid or expired proxy token" }),
-        { status: 401, headers: { ...cors, "Content-Type": "application/json" } },
-      );
+      return failureResponse({
+        requestId,
+        status: 401,
+        bodyObj: { error: "invalid_token", message: "Invalid or expired proxy token" },
+        headers: cors,
+        failure: motebitFailure("motebit_request", "authentication", 401),
+      });
     }
 
     if (tokenPayload.bal <= 0) {
-      return new Response(
-        JSON.stringify({
+      // Balance reached zero at the proxy. WHY (free-preview burned through vs
+      // never-granted vs funded-then-drained) is not knowable here — the proxy
+      // has no balance history. The relay's `free_credit.grant_decision` event
+      // + ledger carry that causal attribution in its own trust domain.
+      return failureResponse({
+        requestId,
+        status: 402,
+        bodyObj: {
           error: "insufficient_balance",
           message: "Deposit funds to use cloud AI.",
           balance: 0,
-        }),
-        { status: 402, headers: { ...cors, "Content-Type": "application/json" } },
-      );
+        },
+        headers: cors,
+        mode: "proxy-token",
+        failure: motebitFailure("motebit_balance", "balance_exhausted", 402),
+      });
     }
 
     authMode = "proxy-token";
   } else {
-    return new Response(
-      JSON.stringify({ error: "unauthorized", message: "Provide a proxy token or API key." }),
-      { status: 401, headers: { ...cors, "Content-Type": "application/json" } },
-    );
+    return failureResponse({
+      requestId,
+      status: 401,
+      bodyObj: { error: "unauthorized", message: "Provide a proxy token or API key." },
+      headers: cors,
+      failure: motebitFailure("motebit_request", "authentication", 401),
+    });
   }
 
   const isBYOK = authMode === "byok";
@@ -193,9 +222,13 @@ export async function POST(request: Request): Promise<Response> {
   // --- Parse body ---
   const raw = await request.text();
   if (raw.length > limits.maxBody) {
-    return new Response(JSON.stringify({ error: "request_too_large" }), {
+    return failureResponse({
+      requestId,
       status: 413,
-      headers: { ...cors, "Content-Type": "application/json" },
+      bodyObj: { error: "request_too_large" },
+      headers: cors,
+      mode: authMode,
+      failure: motebitFailure("motebit_request", "malformed_request", 413),
     });
   }
 
@@ -203,18 +236,26 @@ export async function POST(request: Request): Promise<Response> {
   try {
     body = JSON.parse(raw) as Record<string, unknown>;
   } catch {
-    return new Response(JSON.stringify({ error: "invalid_json" }), {
+    return failureResponse({
+      requestId,
       status: 400,
-      headers: { ...cors, "Content-Type": "application/json" },
+      bodyObj: { error: "invalid_json" },
+      headers: cors,
+      mode: authMode,
+      failure: motebitFailure("motebit_request", "malformed_request", 400),
     });
   }
 
   // --- Validate and resolve model ---
   let resolvedModel = body.model as string | undefined;
   if (!resolvedModel) {
-    return new Response(JSON.stringify({ error: "invalid_model", message: "Model is required" }), {
+    return failureResponse({
+      requestId,
       status: 400,
-      headers: { ...cors, "Content-Type": "application/json" },
+      bodyObj: { error: "invalid_model", message: "Model is required" },
+      headers: cors,
+      mode: authMode,
+      failure: motebitFailure("motebit_request", "malformed_request", 400),
     });
   }
 
@@ -320,13 +361,15 @@ export async function POST(request: Request): Promise<Response> {
       tokenPayload.models.length > 0 &&
       !tokenPayload.models.includes(resolvedModel)
     ) {
-      return new Response(
-        JSON.stringify({
-          error: "invalid_model",
-          message: `Allowed: ${tokenPayload.models.join(", ")}`,
-        }),
-        { status: 400, headers: { ...cors, "Content-Type": "application/json" } },
-      );
+      return failureResponse({
+        requestId,
+        status: 400,
+        bodyObj: { error: "invalid_model", message: `Allowed: ${tokenPayload.models.join(", ")}` },
+        headers: cors,
+        model: resolvedModel,
+        mode: "proxy-token",
+        failure: motebitFailure("motebit_request", "model_unavailable", 400),
+      });
     }
 
     // Motebit-cloud jurisdiction admission predicate. Lifts the previously-
@@ -337,13 +380,18 @@ export async function POST(request: Request): Promise<Response> {
     // this filter (the user's own key, the user's own choice; sovereignty
     // doctrine stays orthogonal to tier policy).
     if (resolvedModel !== "auto" && !isModelAllowedInMotebitCloud(resolvedModel)) {
-      return new Response(
-        JSON.stringify({
+      return failureResponse({
+        requestId,
+        status: 451,
+        bodyObj: {
           error: "jurisdiction_not_permitted",
           message: `${resolvedModel} is not available in motebit-cloud routing. Use BYOK to call this model with your own API key.`,
-        }),
-        { status: 451, headers: { ...cors, "Content-Type": "application/json" } },
-      );
+        },
+        headers: cors,
+        model: resolvedModel,
+        mode: "proxy-token",
+        failure: motebitFailure("motebit_request", "model_unavailable", 451),
+      });
     }
   }
 
@@ -356,46 +404,68 @@ export async function POST(request: Request): Promise<Response> {
     apiKey = clientApiKey;
   } else {
     if (!provider) {
-      return new Response(
-        JSON.stringify({
-          error: "invalid_model",
-          message: `Model not supported: ${resolvedModel}`,
-        }),
-        { status: 400, headers: { ...cors, "Content-Type": "application/json" } },
-      );
+      return failureResponse({
+        requestId,
+        status: 400,
+        bodyObj: { error: "invalid_model", message: `Model not supported: ${resolvedModel}` },
+        headers: cors,
+        model: resolvedModel,
+        mode: authMode,
+        failure: motebitFailure("motebit_request", "model_unavailable", 400),
+      });
     }
     apiKey = getProviderApiKey(provider);
     if (!apiKey) {
-      return new Response(
-        JSON.stringify({
+      return failureResponse({
+        requestId,
+        status: 501,
+        bodyObj: {
           error: "provider_not_configured",
           message: `${provider} is not configured on this proxy`,
-        }),
-        { status: 501, headers: { ...cors, "Content-Type": "application/json" } },
-      );
+        },
+        headers: cors,
+        model: resolvedModel,
+        mode: authMode,
+        failure: motebitFailure("motebit_infrastructure", "not_configured", 501),
+      });
     }
   }
 
   if (!apiKey) {
-    return new Response(
-      JSON.stringify({ error: "server_error", message: "No API key available" }),
-      { status: 500, headers: { ...cors, "Content-Type": "application/json" } },
-    );
+    return failureResponse({
+      requestId,
+      status: 500,
+      bodyObj: { error: "server_error", message: "No API key available" },
+      headers: cors,
+      model: resolvedModel,
+      mode: authMode,
+      failure: motebitFailure("motebit_infrastructure", "not_configured", 500),
+    });
   }
 
   // --- Validate messages ---
   const messages = body.messages as Array<{ role: string; content: string }> | undefined;
   if (!Array.isArray(messages) || messages.length === 0) {
-    return new Response(JSON.stringify({ error: "invalid_messages" }), {
+    return failureResponse({
+      requestId,
       status: 400,
-      headers: { ...cors, "Content-Type": "application/json" },
+      bodyObj: { error: "invalid_messages" },
+      headers: cors,
+      model: resolvedModel,
+      mode: authMode,
+      failure: motebitFailure("motebit_request", "malformed_request", 400),
     });
   }
   if (messages.length > limits.maxMsgs) {
-    return new Response(
-      JSON.stringify({ error: "too_many_messages", message: `Max ${limits.maxMsgs} messages` }),
-      { status: 400, headers: { ...cors, "Content-Type": "application/json" } },
-    );
+    return failureResponse({
+      requestId,
+      status: 400,
+      bodyObj: { error: "too_many_messages", message: `Max ${limits.maxMsgs} messages` },
+      headers: cors,
+      model: resolvedModel,
+      mode: authMode,
+      failure: motebitFailure("motebit_request", "malformed_request", 400),
+    });
   }
 
   // --- Build and send provider request ---
@@ -407,13 +477,71 @@ export async function POST(request: Request): Promise<Response> {
     body,
     limits.maxTokens,
   );
-  const requestId = crypto.randomUUID();
 
-  const providerRes = await fetch(providerReq.url, {
-    method: "POST",
-    headers: providerReq.headers,
-    body: providerReq.body,
-  });
+  let providerRes: Response;
+  try {
+    providerRes = await fetch(providerReq.url, {
+      method: "POST",
+      headers: providerReq.headers,
+      body: providerReq.body,
+    });
+  } catch (err) {
+    // Transport failure: fetch threw before any HTTP response (DNS, connection
+    // refused, abort, read timeout). Currently this would surface as an opaque
+    // edge-runtime error; classify it as a network/timeout failure instead.
+    const failure = classifyProviderTransportFailure({
+      provider: resolvedProvider,
+      errorName: err instanceof Error ? err.name : undefined,
+    });
+    return failureResponse({
+      requestId,
+      status: 502,
+      bodyObj: {
+        error: "provider_unreachable",
+        message: "Upstream provider could not be reached.",
+      },
+      headers: cors,
+      model: resolvedModel,
+      mode: authMode,
+      failure,
+    });
+  }
+
+  // Pre-stream upstream failure: classify + emit one event, then preserve the
+  // provider's own body/status pass-through (adding the trace header). This is
+  // the recovery-safe boundary — no client bytes sent, no debit taken yet.
+  if (!providerRes.ok) {
+    let parsedBody: unknown = null;
+    let bodyText = "";
+    try {
+      bodyText = await providerRes.text();
+      parsedBody = bodyText === "" ? null : JSON.parse(bodyText);
+    } catch {
+      parsedBody = null; // non-JSON error body — classify on status alone; never logged
+    }
+    const failure = classifyProviderHttpFailure({
+      provider: resolvedProvider,
+      status: providerRes.status,
+      headers: providerRes.headers,
+      body: parsedBody,
+      nowMs: Date.now(),
+    });
+    emitProxyFailure({ requestId, model: resolvedModel, mode: authMode, failure });
+    // Forward ONLY the safe operational header from upstream — the client may
+    // still want the provider's retry guidance until in-proxy recovery (PR3)
+    // exists. The rest of the upstream header set is deliberately not relayed.
+    const retryAfter = providerRes.headers.get("Retry-After");
+    return new Response(bodyText, {
+      status: providerRes.status,
+      headers: {
+        ...cors,
+        "Content-Type": providerRes.headers.get("Content-Type") ?? "application/json",
+        "Cache-Control": "no-cache",
+        "X-Motebit-Request-Id": requestId,
+        ...(retryAfter != null ? { "Retry-After": retryAfter } : {}),
+      },
+    });
+  }
 
   // --- Stream response and extract usage for debit ---
   if (authMode === "proxy-token" && tokenPayload && providerRes.ok && providerRes.body) {

--- a/services/proxy/src/inference/classify.ts
+++ b/services/proxy/src/inference/classify.ts
@@ -1,0 +1,214 @@
+// Pre-stream inference-failure classification — OBSERVATION ONLY.
+//
+// This module answers "what happened" for a failed inference turn. It never
+// decides "what to do" — no retries, no backoff, no failover. Recovery policy
+// (a `RecoveryDecision` layer) is a deliberately separate, later PR; keeping
+// classification pure keeps the observation honest and unit-testable.
+//
+// SCOPE BOUNDARY (PR1): this classifies failures observable BEFORE the response
+// stream begins — an upstream provider HTTP non-2xx, or a transport throw
+// before any HTTP response. It does NOT classify a 200 response that later
+// refuses (`stop_reason: "refusal"`) or a mid-stream interruption; those live
+// behind a future `classifyStreamTermination()` boundary and are out of scope.
+//
+// Edge-runtime-safe: pure functions, no Node APIs. `nowMs` is injected so the
+// `Retry-After` HTTP-date path is deterministic in tests.
+
+// Where the failure originated. This drives the event NAME (failure-response.ts)
+// so the four operational questions stay un-contaminated:
+//   request rejected? · no balance? · OUR infra failed? · the model path failed?
+export type FailureSource =
+  | "motebit_request" // client input/policy rejected (auth, validation, jurisdiction, allowlist)
+  | "motebit_balance" // the user's virtual-account balance reached zero
+  | "motebit_infrastructure" // OUR misconfiguration/outage (missing keys, unconfigured provider)
+  | "provider" // upstream provider returned a non-2xx
+  | "network"; // transport failed before any HTTP response
+
+/** What kind of failure it was. Closed set; `unknown` is the honest fallback. */
+export type FailureCategory =
+  // source: motebit_balance
+  | "balance_exhausted"
+  // source: motebit_request
+  | "authentication" // 401/403 (motebit token, or provider auth)
+  | "model_unavailable" // 451 jurisdiction / 404 not_found / token allowlist
+  | "malformed_request" // 400 bad request / invalid json / invalid messages / too large
+  // source: motebit_infrastructure
+  | "not_configured" // missing relay key / operator API key / unconfigured provider
+  // source: provider
+  | "rate_limited" // 429
+  | "overloaded" // 529
+  | "server_error" // 500 / 502 / 503
+  | "context_overflow" // 413, or 400 with a context-window signal
+  | "provider_billing_exhausted" // operator-key billing/credit exhaustion
+  // source: network
+  | "timeout"
+  | "network"
+  | "unknown";
+
+export interface ProxyFailure {
+  source: FailureSource;
+  category: FailureCategory;
+  /** Provider origin label when known (e.g. "anthropic"). */
+  provider?: string;
+  /** HTTP status; absent for transport failures. */
+  status?: number;
+  /** Upstream `error.type` (e.g. "rate_limit_error"). Never the raw body. */
+  providerCode?: string;
+  /** `retry-after` parsed (delta-seconds OR HTTP-date) → milliseconds. */
+  retryAfterMs?: number;
+  /** Upstream request id, for server-side tracing. Never user content. */
+  providerRequestId?: string;
+}
+
+// ── header + body helpers ────────────────────────────────────────────────
+
+type HeaderBag = Headers | Record<string, string> | undefined;
+
+function headerGet(headers: HeaderBag, name: string): string | undefined {
+  if (!headers) return undefined;
+  if (headers instanceof Headers) return headers.get(name) ?? undefined;
+  const lower = name.toLowerCase();
+  for (const [k, v] of Object.entries(headers)) {
+    if (k.toLowerCase() === lower) return v;
+  }
+  return undefined;
+}
+
+/**
+ * Parse `Retry-After`: either an integer count of delta-seconds, or an
+ * HTTP-date (RFC 7231 §7.1.3). Returns milliseconds to wait, clamped at ≥ 0,
+ * or undefined when absent/unparseable. `nowMs` is injected for determinism.
+ */
+export function parseRetryAfterMs(raw: string | undefined, nowMs: number): number | undefined {
+  if (raw == null) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === "") return undefined;
+  if (/^\d+$/.test(trimmed)) {
+    const secs = Number(trimmed);
+    return Number.isFinite(secs) ? secs * 1000 : undefined;
+  }
+  const dateMs = Date.parse(trimmed);
+  if (Number.isFinite(dateMs)) {
+    const delta = dateMs - nowMs;
+    return delta > 0 ? delta : 0;
+  }
+  return undefined;
+}
+
+// Anthropic returns `request-id`; other proxies/CDNs vary. Order = preference.
+const REQUEST_ID_HEADERS = ["request-id", "anthropic-request-id", "x-request-id"];
+
+function extractProviderRequestId(headers: HeaderBag, body: unknown): string | undefined {
+  for (const h of REQUEST_ID_HEADERS) {
+    const v = headerGet(headers, h);
+    if (v) return v;
+  }
+  const r = asRecord(body);
+  const fromBody = r?.request_id;
+  return typeof fromBody === "string" ? fromBody : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value != null && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
+/** Pull `error.type` (or top-level `type`) from a parsed provider error body. */
+function extractProviderErrorType(body: unknown): string | undefined {
+  const r = asRecord(body);
+  if (!r) return undefined;
+  const err = asRecord(r.error);
+  const t = err?.type ?? r.type;
+  return typeof t === "string" ? t : undefined;
+}
+
+/** Heuristic: does a 400 body signal a context-window overflow vs a generic bad request? */
+function isContextWindowError(body: unknown): boolean {
+  const r = asRecord(body);
+  const err = asRecord(r?.error);
+  const msg = typeof err?.message === "string" ? err.message.toLowerCase() : "";
+  if (msg === "") return false;
+  return (
+    msg.includes("prompt is too long") ||
+    (msg.includes("context") && (msg.includes("window") || msg.includes("token"))) ||
+    msg.includes("max_tokens") ||
+    msg.includes("too many tokens")
+  );
+}
+
+// ── classifiers ───────────────────────────────────────────────────────────
+
+/**
+ * Classify an upstream provider HTTP non-2xx response. The caller reads the
+ * (small) error body and passes the PARSED JSON (or null) — the raw body is
+ * never retained or logged here.
+ */
+export function classifyProviderHttpFailure(input: {
+  provider: string;
+  status: number;
+  headers?: HeaderBag;
+  body?: unknown;
+  nowMs: number;
+}): ProxyFailure {
+  const { provider, status, headers, body, nowMs } = input;
+  const providerCode = extractProviderErrorType(body);
+  const base: ProxyFailure = {
+    source: "provider",
+    category: "unknown",
+    provider,
+    status,
+    providerCode,
+    retryAfterMs: parseRetryAfterMs(headerGet(headers, "retry-after"), nowMs),
+    providerRequestId: extractProviderRequestId(headers, body),
+  };
+
+  switch (status) {
+    case 429:
+      return { ...base, category: "rate_limited" };
+    case 529:
+      return { ...base, category: "overloaded" };
+    case 500:
+    case 502:
+    case 503:
+      return { ...base, category: "server_error" };
+    case 402:
+      return { ...base, category: "provider_billing_exhausted" };
+    case 401:
+    case 403:
+      return {
+        ...base,
+        category:
+          providerCode === "billing_error" ? "provider_billing_exhausted" : "authentication",
+      };
+    case 404:
+      return { ...base, category: "model_unavailable" };
+    case 413:
+      return { ...base, category: "context_overflow" };
+    case 400:
+      return {
+        ...base,
+        category: isContextWindowError(body) ? "context_overflow" : "malformed_request",
+      };
+    default:
+      return base;
+  }
+}
+
+/** Classify a transport failure: `fetch` threw before any HTTP response. */
+export function classifyProviderTransportFailure(input: {
+  provider: string;
+  errorName?: string; // e.g. "AbortError", "TimeoutError", "TypeError"
+}): ProxyFailure {
+  const name = (input.errorName ?? "").toLowerCase();
+  const category: FailureCategory =
+    name.includes("abort") || name.includes("timeout") ? "timeout" : "network";
+  return { source: "network", category, provider: input.provider };
+}
+
+/** Construct a motebit-originated failure (request / balance / infrastructure). */
+export function motebitFailure(
+  source: "motebit_request" | "motebit_balance" | "motebit_infrastructure",
+  category: FailureCategory,
+  status: number,
+): ProxyFailure {
+  return { source, category, status };
+}

--- a/services/proxy/src/inference/failure-response.ts
+++ b/services/proxy/src/inference/failure-response.ts
@@ -1,0 +1,97 @@
+// Shared failure surface for the edge proxy: emit exactly one structured
+// observability event and attach a traceable request id to the response.
+//
+// Privacy invariant: the event NEVER carries raw provider bodies, prompts,
+// API keys, user content, or `motebitId`. The activation/money causal join
+// lives in the relay (its own trust domain, keyed on `motebitId`); the proxy
+// stream stays identity-free so it can ship to centralized infra safely.
+// Correlate a user-reported incident via the `X-Motebit-Request-Id` header.
+
+import type { FailureSource, ProxyFailure } from "./classify";
+
+/**
+ * The event name is derived from the failure SOURCE so the reliability metric
+ * stays clean — four un-contaminated operational questions:
+ *   - `proxy.request_rejected`  — client never admitted (auth, validation, policy)
+ *   - `proxy.balance_exhausted` — economic admission boundary (activation signal)
+ *   - `proxy.internal_failure`  — OUR misconfiguration/outage (missing keys, etc.)
+ *   - `proxy.inference_failure` — the model path actually failed (provider / transport)
+ * An operator outage must NOT read as malformed client traffic, and vice versa.
+ */
+function eventNameForSource(source: FailureSource): string {
+  switch (source) {
+    case "motebit_request":
+      return "proxy.request_rejected";
+    case "motebit_balance":
+      return "proxy.balance_exhausted";
+    case "motebit_infrastructure":
+      return "proxy.internal_failure";
+    case "provider":
+    case "network":
+      return "proxy.inference_failure";
+  }
+}
+
+/**
+ * Emit exactly one structured proxy-failure event. The event name is chosen by
+ * source (rejection / balance / inference), so this is deliberately NOT named
+ * for inference — a caller must not assume every invocation is a model failure.
+ * No identity, no body, no prompts.
+ */
+export function emitProxyFailure(args: {
+  requestId: string;
+  model?: string;
+  mode?: "proxy-token" | "byok";
+  failure: ProxyFailure;
+}): void {
+  const { requestId, model, mode, failure } = args;
+  // Mirrors the existing `proxy.usage` console event shape (route.ts) — the
+  // proxy's established structured-log channel for the edge runtime.
+  console.log(
+    JSON.stringify({
+      event: eventNameForSource(failure.source),
+      schemaVersion: 1,
+      requestId,
+      model,
+      mode,
+      source: failure.source,
+      category: failure.category,
+      provider: failure.provider,
+      status: failure.status,
+      providerCode: failure.providerCode,
+      retryAfterMs: failure.retryAfterMs,
+      providerRequestId: failure.providerRequestId,
+    }),
+  );
+}
+
+/**
+ * Build a JSON failure Response for a motebit-constructed body: logs one event
+ * and attaches `X-Motebit-Request-Id`, preserving the given status. Use the
+ * raw `emitProxyFailure` + a manual Response when passing an upstream body
+ * through unmodified (so the provider's body/Content-Type are preserved).
+ */
+export function failureResponse(args: {
+  requestId: string;
+  status: number;
+  bodyObj: Record<string, unknown>;
+  headers: Record<string, string>;
+  model?: string;
+  mode?: "proxy-token" | "byok";
+  failure: ProxyFailure;
+}): Response {
+  emitProxyFailure({
+    requestId: args.requestId,
+    model: args.model,
+    mode: args.mode,
+    failure: args.failure,
+  });
+  return new Response(JSON.stringify(args.bodyObj), {
+    status: args.status,
+    headers: {
+      ...args.headers,
+      "Content-Type": "application/json",
+      "X-Motebit-Request-Id": args.requestId,
+    },
+  });
+}

--- a/services/proxy/vitest.config.ts
+++ b/services/proxy/vitest.config.ts
@@ -1,12 +1,15 @@
 import { defineMotebitTest } from "../../vitest.shared.js";
 
-// proxy only unit-tests the validation module; everything else is the
-// Next.js edge proxy handlers exercised via E2E deploy smoke tests.
+// proxy unit-tests the pure modules; the Next.js edge handler (route.ts) is
+// glue exercised via E2E deploy smoke tests, but its failure-classification
+// and one-event-per-failure surface are pure and tested here.
 export default defineMotebitTest({
   coverageInclude: [
     "src/validation.ts",
     "src/app/v1/messages/provider-request.ts",
     "src/app/v1/messages/usage.ts",
+    "src/inference/classify.ts",
+    "src/inference/failure-response.ts",
   ],
   thresholds: { statements: 70, branches: 60, functions: 65, lines: 70 },
 });

--- a/services/relay/src/free-credit.ts
+++ b/services/relay/src/free-credit.ts
@@ -110,7 +110,16 @@ export function grantFreeCreditIfEligible(
       .get(day) as { grants: number } | undefined;
     const spent = (grantsRow?.grants ?? 0) * cfg.amountMicro;
     if (spent + cfg.amountMicro > cfg.dailyBudgetMicro) {
-      logger.warn("free-credit.daily_budget_reached", { spent, day });
+      // Activation signal: a NEW motebit got zero credit because the global
+      // give-away budget is drained — it hits the setup wall on message one.
+      logger.warn("free_credit.grant_decision", {
+        schemaVersion: 1,
+        outcome: "denied",
+        reason: "daily_budget",
+        motebitId,
+        spent,
+        day,
+      });
       return { granted: false, reason: "daily_budget" };
     }
 
@@ -119,6 +128,15 @@ export function grantFreeCreditIfEligible(
       .prepare("SELECT count FROM relay_free_grants WHERE ip = ? AND day = ?")
       .get(ip, day) as { count: number } | undefined;
     if ((ipRow?.count ?? 0) >= cfg.ipDailyCap) {
+      // Activation signal: shared/NAT IPs exhausting the per-IP grant cap.
+      // Previously silent — now the cap is observable.
+      logger.warn("free_credit.grant_decision", {
+        schemaVersion: 1,
+        outcome: "denied",
+        reason: "ip_cap",
+        motebitId,
+        day,
+      });
       return { granted: false, reason: "ip_cap" };
     }
 
@@ -137,13 +155,32 @@ export function grantFreeCreditIfEligible(
        ON CONFLICT(ip, day) DO UPDATE SET count = count + 1`,
     ).run(ip, day);
 
-    logger.info("free-credit.granted", { motebitId, amountMicro: cfg.amountMicro, ip, day });
+    // `motebitId` is the in-service join key (relay is identity's home; consistent
+    // with `account.debit`). Raw `ip` is deliberately NOT logged — the per-IP cap
+    // counter lives in `relay_free_grants`; activation telemetry doesn't need the
+    // network identifier.
+    logger.info("free_credit.grant_decision", {
+      schemaVersion: 1,
+      outcome: "granted",
+      reason: "granted",
+      motebitId,
+      grantedMicro: cfg.amountMicro,
+      day,
+    });
     return { granted: true, amountMicro: cfg.amountMicro };
   } catch (err) {
-    logger.warn("free-credit.error", {
+    logger.warn("free_credit.grant_decision", {
+      schemaVersion: 1,
+      outcome: "error",
+      reason: "internal_error",
       motebitId,
       error: err instanceof Error ? err.message : String(err),
     });
     return { granted: false, reason: "error" };
   }
+  // NOTE: `already_granted` and `disabled` are intentionally NOT logged — they
+  // fire on every returning user's token mint (`subscriptions.ts`), so logging
+  // them would flood the channel and drown the activation signal. The four
+  // decisive outcomes above (granted / daily_budget / ip_cap / internal_error)
+  // are what answer "are new users getting credit, and if not, why".
 }


### PR DESCRIPTION
## What

Observability foundation for the cloud-inference path: classify every pre-stream failure and emit it as one structured event, so the funnel's failure modes become measurable. **Observation only** — no retries, failover, recovery policy, protocol types, or credential pools (those are later PRs).

## Four un-contaminated event families

Failure events are named by *source*, so an operator outage or a malformed-client spike can no longer masquerade as a model-reliability regression:

| Event | Question it answers |
|---|---|
| `proxy.request_rejected` | Was the request rejected? (auth, validation, jurisdiction) |
| `proxy.balance_exhausted` | Was there no balance? (activation signal) |
| `proxy.internal_failure` | Did **our** infra fail? (missing keys, unconfigured provider) |
| `proxy.inference_failure` | Did the model path fail? (provider non-2xx / transport) |

## Changes

- New proxy-private module `services/proxy/src/inference/` — `classifyProviderHttpFailure` / `classifyProviderTransportFailure` / `motebitFailure` + `emitProxyFailure`. Consumed at every early-return failure site in the edge route. Each failure emits exactly one event (no `motebitId`, body, prompt, or key) and carries `X-Motebit-Request-Id` for incident tracing.
- `Retry-After` preserved from upstream 429s and exposed via CORS.
- **Behavior change (not purely additive):** a provider transport exception — which previously escaped as an unhandled edge-runtime error — now returns a traced `502 provider_unreachable`.
- Relay: normalize free-credit grant decisions into one `free_credit.grant_decision` event (`granted` / `daily_budget` / `ip_cap` / `internal_error`; the high-volume `already_granted` / `disabled` steady-state paths stay unlogged), dropping raw IP. This + `account.debit(balanceAfter)` + the ledger free-credit reference make the activation cause (zero-grant vs preview-exhausted vs funded-drained) a relay-side, in-trust-domain join; **proxy telemetry stays identity-free aggregate**.

## Tests

Classifier + helper unit tests, and route-boundary wiring tests across all four failure families (one event + trace header per branch; no leakage). Proxy 209 tests, `classify.ts` 98% coverage. All 119 drift defenses pass.

## Follow-ups (separate PRs)

- **PR2** — warm free-preview wall copy + evidence-based `FREE_CREDIT_USD` / daily-budget bump (sized from this PR's telemetry, not a guess).
- Fire-and-forget `debitRelay(...).catch(() => {})` can silently lose debits — separate revenue-integrity ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
