### PR TITLE
fix(web): correct the cloud-balance wall copy

### DIFF
--- a/apps/web/src/__tests__/chat-rendering.test.ts
+++ b/apps/web/src/__tests__/chat-rendering.test.ts
@@ -66,10 +66,43 @@ beforeAll(() => {
 
 // Dynamic import so the stubs are in place first
 let renderMarkdown: (raw: string) => string;
+let formatErrorMessage: (msg: string) => string;
 
 beforeAll(async () => {
   const mod = await import("../ui/chat");
   renderMarkdown = mod.renderMarkdown;
+  formatErrorMessage = mod.formatErrorMessage;
+});
+
+// ─── formatErrorMessage — the cloud-inference failure wall ─────────────
+
+describe("formatErrorMessage", () => {
+  // The bounced-user bug: a motebit-cloud user hitting the proxy's own 402
+  // (`insufficient_balance`) must NOT be told to add credits at an Anthropic
+  // console account they don't have.
+  it("cloud balance wall (insufficient_balance) → fund/BYOK, NOT console.anthropic.com", () => {
+    const out = formatErrorMessage('Anthropic API error 402: {"error":"insufficient_balance"}');
+    expect(out).toContain("Motebit Cloud has no balance");
+    expect(out).toContain("fund your droplet");
+    expect(out).not.toContain("console.anthropic.com");
+  });
+
+  it("BYOK provider billing 402 still points at console.anthropic.com", () => {
+    const out = formatErrorMessage('Anthropic API error 402: {"error":{"type":"billing_error"}}');
+    expect(out).toContain("console.anthropic.com");
+    expect(out).not.toContain("Motebit Cloud has no balance");
+  });
+
+  it("cloud-balance case wins even though the string also contains 402", () => {
+    // The thrown string contains both "402" and "insufficient_balance"; the
+    // cloud case is matched first so the wrong console copy never shows.
+    const out = formatErrorMessage('Anthropic API error 402: {"error":"insufficient_balance"}');
+    expect(out).not.toContain("No API credits");
+  });
+
+  it("unrelated errors fall through to the generic message", () => {
+    expect(formatErrorMessage("boom")).toContain("Something went wrong");
+  });
 });
 
 // ─── stripInternalTags (exercised through renderMarkdown) ─────────────

--- a/apps/web/src/ui/chat.ts
+++ b/apps/web/src/ui/chat.ts
@@ -475,7 +475,7 @@ const SETTINGS_LINK = `<a href="#" class="chat-action-link" data-action="open-se
 const RELOAD_LINK = `<a href="#" class="chat-action-link" data-action="reload">`;
 const IDENTITY_LINK = `<a href="#" class="chat-action-link" data-action="open-identity">`;
 
-function formatErrorMessage(msg: string): string {
+export function formatErrorMessage(msg: string): string {
   // Rate limit — distinguish proxy free-tier from API rate limit
   if (msg.includes("rate_limited") || msg.includes("429")) {
     if (msg.includes("free") || msg.includes("daily")) {
@@ -487,8 +487,19 @@ function formatErrorMessage(msg: string): string {
   if (msg.includes("401") || msg.includes("authentication_error")) {
     return `Invalid API key. ${SETTINGS_LINK}Check your key in Settings</a>.`;
   }
-  // No credits / billing
-  if (msg.includes("402") || msg.includes("billing") || msg.includes("insufficient")) {
+  // Motebit-cloud balance exhausted — the proxy's OWN 402 (`insufficient_balance`),
+  // matched BEFORE the generic provider-billing 402 below. A cloud user has no
+  // Anthropic console account, so "add credits at console.anthropic.com" is the
+  // wrong instruction for them — they bring their own key (kept on-device) or
+  // fund the droplet. The proxy can't distinguish free-preview-exhausted from
+  // funded-then-drained (no balance history), so the copy is neutral truth that
+  // serves both populations. See docs/doctrine — PR2 of the inference-reliability arc.
+  if (msg.includes("insufficient_balance")) {
+    return `Motebit Cloud has no balance available. ${SETTINGS_LINK}Add your own model key</a> — kept on this device — or fund your droplet to continue.`;
+  }
+  // No credits / billing — a BYOK provider's own account is out (e.g. Anthropic
+  // console). Distinct from the motebit-cloud balance wall handled just above.
+  if (msg.includes("402") || msg.includes("billing")) {
     return `No API credits. Add credits at <a href="https://console.anthropic.com" target="_blank" rel="noopener" class="chat-action-link">console.anthropic.com</a>, or ${SETTINGS_LINK}use a different key</a>.`;
   }
   // Overloaded


### PR DESCRIPTION
## What

Corrects the cloud-inference balance-wall copy. A motebit-cloud user who exhausts their balance hits the proxy's own `402 insufficient_balance`, which `formatErrorMessage` rendered as **"No API credits. Add credits at console.anthropic.com"** — the wrong instruction, because a cloud user has no Anthropic console account. That misdirection (on top of the tiny free credit) is a direct funnel break: the exact user who bounced to ChatGPT.

## Change

- New case matching the proxy's stable `insufficient_balance` token, **before** the generic provider-billing 402, → neutral truth that serves both free-preview-exhausted and funded-then-drained users (the proxy can't distinguish them):
  > Motebit Cloud has no balance available. **Add your own model key** — kept on this device — or fund your droplet to continue.
- The generic provider-billing 402 (BYOK, e.g. Anthropic console) keeps its `console.anthropic.com` copy.
- `formatErrorMessage` exported + 4 focused tests (cloud vs BYOK 402, match ordering, fallthrough). 30 chat tests pass.

## Scope

- Sibling-audited: that copy exists only in web — no desktop/mobile fan-out.
- **No live env change.** `MOTEBIT_FREE_CREDIT_USD` / daily-budget stay as-is until PR #194's `proxy.*` + `free_credit.grant_decision` telemetry sizes them from evidence.

Companion to #194 (failure observability); independent — can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
