### PR TITLE
feat(ai-core): instrument time-to-first-token on the chat turn

### DIFF
--- a/apps/web/src/ui/chat.ts
+++ b/apps/web/src/ui/chat.ts
@@ -880,6 +880,17 @@ export function initChat(ctx: WebContext, callbacks: ChatCallbacks): ChatAPI {
               costEl.textContent = `${chunk.result.totalTokens.toLocaleString()} tokens`;
               bubble.appendChild(costEl);
             }
+            // TTFT instrumentation: one content-free latency line per turn —
+            // where the "feels weak" wait actually goes (context pipeline vs model).
+            // Console-only (no UI), but emitted in every environment on purpose so
+            // the breakdown is readable from a live session. See @motebit/ai-core
+            // TurnLatency. A dashboard/aggregate is a deliberate later step.
+            if (chunk.result.latency) {
+              const l = chunk.result.latency;
+              console.debug(
+                `[ttft] ${l.ttft_ms}ms (pipeline ${l.context_pipeline_ms}ms · provider ${l.provider_ttft_ms}ms · embed ${l.embed_ms} · retrieve ${l.memory_retrieve_ms} · events ${l.event_query_ms} · pinned ${l.pinned_ms})`,
+              );
+            }
             break;
           }
         }

--- a/packages/ai-core/src/__tests__/loop.test.ts
+++ b/packages/ai-core/src/__tests__/loop.test.ts
@@ -7,6 +7,7 @@ vi.mock("@motebit/memory-graph", async () => {
 });
 
 import { runTurn, runTurnStreaming } from "../loop";
+import { withStageTimeout } from "../core";
 import type { MotebitLoopDependencies, AgenticChunk, LoopMemoryGovernor } from "../loop";
 import type { SensitivityCleared } from "@motebit/sdk";
 import { AnthropicProvider } from "../index";
@@ -126,6 +127,24 @@ describe("runTurn", () => {
     expect(result.stateAfter).toBeDefined();
     expect(result.cues).toBeDefined();
     expect(result.cues.hover_distance).toBeGreaterThan(0);
+  });
+
+  it("attaches a content-free TTFT latency breakdown to the result", async () => {
+    mockFetchSuccess("A plain streamed reply.");
+
+    const deps = makeDeps();
+    const result = await runTurn(deps, "hello there");
+
+    expect(result.latency).toBeDefined();
+    const l = result.latency!;
+    // Every field is a non-negative duration (ms).
+    for (const v of Object.values(l)) {
+      expect(typeof v).toBe("number");
+      expect(v).toBeGreaterThanOrEqual(0);
+    }
+    // The split is exact by construction: ttft = pipeline + provider segment.
+    expect(l.ttft_ms).toBe(l.context_pipeline_ms + l.provider_ttft_ms);
+    expect(l.ttft_ms).toBeGreaterThanOrEqual(l.context_pipeline_ms);
   });
 
   it("handles API error gracefully", async () => {
@@ -1908,5 +1927,24 @@ describe("synthesizeClosingFallback — runtime guarantee of visible closing tex
       expect(out.length).toBeGreaterThan(0);
       expect(out.trim()).not.toBe("");
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withStageTimeout — duration sink (TTFT instrumentation primitive)
+// ---------------------------------------------------------------------------
+
+describe("withStageTimeout — onDuration", () => {
+  it("reports a non-negative elapsed time on the success path", async () => {
+    let recorded = -1;
+    const value = await withStageTimeout("test_stage", 1000, Promise.resolve("ok"), (ms) => {
+      recorded = ms;
+    });
+    expect(value).toBe("ok");
+    expect(recorded).toBeGreaterThanOrEqual(0);
+  });
+
+  it("still resolves normally when no sink is provided (back-compat)", async () => {
+    await expect(withStageTimeout("test_stage", 1000, Promise.resolve(42))).resolves.toBe(42);
   });
 });

--- a/packages/ai-core/src/core.ts
+++ b/packages/ai-core/src/core.ts
@@ -93,7 +93,14 @@ export async function withStageTimeout<T>(
   stage: string,
   ms: number,
   promise: Promise<T>,
+  /**
+   * Optional duration sink — called with the wall-clock ms the stage took,
+   * on both the success and timeout paths. Used for TTFT instrumentation
+   * (single source for per-stage timing); never affects control flow.
+   */
+  onDuration?: (elapsedMs: number) => void,
 ): Promise<T> {
+  const start = Date.now();
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_, reject) => {
     timer = setTimeout(() => reject(new StageTimeoutError(stage, ms)), ms);
@@ -102,6 +109,7 @@ export async function withStageTimeout<T>(
     return await Promise.race([promise, timeout]);
   } finally {
     if (timer) clearTimeout(timer);
+    if (onDuration) onDuration(Date.now() - start);
   }
 }
 

--- a/packages/ai-core/src/index.ts
+++ b/packages/ai-core/src/index.ts
@@ -15,6 +15,7 @@ export { runTurn, runTurnStreaming, projectProviderClearance } from "./loop.js";
 export type {
   MotebitLoopDependencies,
   TurnResult,
+  TurnLatency,
   TurnOptions,
   AgenticChunk,
   LoopMemoryGovernor,

--- a/packages/ai-core/src/loop.ts
+++ b/packages/ai-core/src/loop.ts
@@ -468,6 +468,28 @@ export interface MotebitLoopDependencies {
   onPixelOmissionEmitted?: (reason: import("@motebit/sdk").PixelOmittedReason) => void;
 }
 
+/**
+ * Per-turn latency breakdown, all in milliseconds. OBSERVATION ONLY — entirely
+ * content-free (durations, no message or memory text), safe to log and aggregate.
+ *
+ * The headline is `ttft_ms` (turn entry → first streamed text token). It splits
+ * into `context_pipeline_ms` (motebit's pre-model overhead: event query + embed +
+ * memory retrieval + context assembly) and `provider_ttft_ms` (first model call →
+ * first streamed text). For a normal no-tool chat turn `provider_ttft_ms` is the
+ * model's own first-token time; on a tool-first turn it includes the tool
+ * round-trips that preceded text (and `ttft_ms` still reflects the true wait).
+ * Present only on a turn that streamed text (first iteration).
+ */
+export interface TurnLatency {
+  ttft_ms: number;
+  context_pipeline_ms: number;
+  provider_ttft_ms: number;
+  event_query_ms: number;
+  embed_ms: number;
+  pinned_ms: number;
+  memory_retrieve_ms: number;
+}
+
 export interface TurnResult {
   response: string;
   memoriesFormed: MemoryNode[];
@@ -476,6 +498,8 @@ export interface TurnResult {
   cues: BehaviorCues;
   /** Total token usage across all LLM calls in this turn, if available. */
   totalTokens?: number;
+  /** Per-turn latency breakdown. Absent on legacy literals / text-free turns. */
+  latency?: TurnLatency;
   /** Number of agentic loop iterations used in this turn. */
   iterations: number;
   /** Number of tool calls that executed successfully. */
@@ -786,6 +810,19 @@ export async function* runTurnStreaming(
 ): AsyncGenerator<AgenticChunk> {
   const { motebitId, eventStore, memoryGraph, stateEngine, behaviorEngine, provider } = deps;
 
+  // TTFT instrumentation — content-free wall-clock stamps. `turnStart` anchors
+  // every delta; per-stage durations come from `withStageTimeout`'s sink (one
+  // source); `providerCallStart`/`firstTokenAt` bracket the model segment. See
+  // `TurnLatency`. Observation only — never affects control flow.
+  const turnStart = Date.now();
+  let eventQueryMs = 0;
+  let embedMs = 0;
+  let pinnedMs = 0;
+  let memoryRetrieveMs = 0;
+  let providerCallStart: number | undefined;
+  let contextPipelineMs: number | undefined;
+  let firstTokenAt: number | undefined;
+
   // 1. Query recent events, embed user message, and fetch pinned memories in parallel.
   // These are independent — no reason to await sequentially.
   //
@@ -800,16 +837,25 @@ export async function* runTurnStreaming(
       "event_query",
       STAGE_TIMEOUTS_MS.event_query,
       eventStore.query({ motebit_id: motebitId, limit: 10 }),
+      (ms) => {
+        eventQueryMs = ms;
+      },
     ),
     withStageTimeout(
       "embed_user_message",
       STAGE_TIMEOUTS_MS.embed_user_message,
       embedText(userMessage),
+      (ms) => {
+        embedMs = ms;
+      },
     ),
     withStageTimeout(
       "pinned_memories",
       STAGE_TIMEOUTS_MS.pinned_memories,
       memoryGraph.getPinnedMemories(),
+      (ms) => {
+        pinnedMs = ms;
+      },
     ),
   ]);
 
@@ -825,6 +871,9 @@ export async function* runTurnStreaming(
       strengthenCoRetrieved: true,
       sensitivityFilter: CONTEXT_SAFE_SENSITIVITY,
     }),
+    (ms) => {
+      memoryRetrieveMs = ms;
+    },
   );
 
   // Merge: pinned first (cap 5), then similarity (deduplicated)
@@ -947,8 +996,15 @@ export async function* runTurnStreaming(
     // original prompt would waste context and confuse turn structure.
 
     let aiResponse;
+    // TTFT: the first model call ends the context pipeline; the first streamed
+    // text token (anywhere in the turn) is time-to-first-token.
+    if (iteration === 1) {
+      providerCallStart = Date.now();
+      contextPipelineMs = providerCallStart - turnStart;
+    }
     for await (const chunk of provider.generateStream(contextPack)) {
       if (chunk.type === "text") {
+        if (firstTokenAt === undefined) firstTokenAt = Date.now();
         yield { type: "text", text: chunk.text };
       } else {
         aiResponse = chunk.response;
@@ -1708,6 +1764,21 @@ export async function* runTurnStreaming(
   const stateAfter = stateEngine.getState();
   const cues = behaviorEngine.compute(stateAfter);
 
+  // TTFT: only when the turn actually streamed text (both stamps set). A
+  // text-free turn (tool-only / empty) has no honest time-to-first-token.
+  const latency: TurnLatency | undefined =
+    firstTokenAt !== undefined && providerCallStart !== undefined
+      ? {
+          ttft_ms: firstTokenAt - turnStart,
+          context_pipeline_ms: contextPipelineMs ?? providerCallStart - turnStart,
+          provider_ttft_ms: firstTokenAt - providerCallStart,
+          event_query_ms: eventQueryMs,
+          embed_ms: embedMs,
+          pinned_ms: pinnedMs,
+          memory_retrieve_ms: memoryRetrieveMs,
+        }
+      : undefined;
+
   yield {
     type: "result",
     result: {
@@ -1722,6 +1793,7 @@ export async function* runTurnStreaming(
       toolCallsDenied,
       toolCallsFailed,
       ...(turnCtx && turnCtx.costAccumulated > 0 ? { totalTokens: turnCtx.costAccumulated } : {}),
+      ...(latency ? { latency } : {}),
     },
   };
 }


### PR DESCRIPTION
## What

Makes the **"weak model UX"** half of the original complaint measurable — the half the funnel work (PR #194 / #195) didn't touch. When a strong model (Sonnet 4.6) *feels* slow, it's usually the wrapper, not the model. This instruments where the wait actually goes.

Adds a content-free per-turn `TurnLatency` on `TurnResult`:

| Field | Meaning |
|---|---|
| `ttft_ms` | turn entry → first streamed text token (the headline) |
| `context_pipeline_ms` | our pre-model overhead: event query + embed + memory retrieval + assembly |
| `provider_ttft_ms` | first model call → first streamed text |
| `embed_ms` / `memory_retrieve_ms` / `event_query_ms` / `pinned_ms` | per-stage |

The split is exact by construction: `ttft_ms = context_pipeline_ms + provider_ttft_ms`.

## How

- `withStageTimeout` gains a non-breaking optional `onDuration` sink — one source for per-stage timing.
- `runTurnStreaming` stamps turn entry, the first model call, and the first text token; `latency` is attached to the result chunk (present only when the turn streamed text). Ring-1 → web/desktop/mobile inherit it.
- The web result handler logs one `[ttft]` line per turn (console-only, every environment, so it's readable from a live session). No UI change.

## Scope

- **Observation only** — no behavior change, no content logged (durations only).
- Tests: latency split is exact + the `withStageTimeout` duration sink fires. ai-core 513 tests, web chat 26, all 119 drift defenses pass.

## Why now

`context_pipeline_ms` vs `provider_ttft_ms` tells us the fix: if the pipeline dominates, the embed→retrieval serial chain is the dead air (local/cached embeddings, overlap the cached-prompt connection with retrieval); if the provider segment dominates, it's network/cold-cache (cache warming, fewer hops). Same evidence-first move as #194 — measure before changing.

Third in the inference-reliability series; independent of #194 / #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
