### PR TITLE
fix(relay): redact raw user text from synced memory_audit / memory_consolidated

### DIFF
--- a/apps/web/src/ui/chat.ts
+++ b/apps/web/src/ui/chat.ts
@@ -891,11 +891,11 @@ export function initChat(ctx: WebContext, callbacks: ChatCallbacks): ChatAPI {
               costEl.textContent = `${chunk.result.totalTokens.toLocaleString()} tokens`;
               bubble.appendChild(costEl);
             }
-            // TTFT instrumentation: one content-free latency line per turn —
-            // where the "feels weak" wait actually goes (context pipeline vs model).
-            // Console-only (no UI), but emitted in every environment on purpose so
-            // the breakdown is readable from a live session. See @motebit/ai-core
-            // TurnLatency. A dashboard/aggregate is a deliberate later step.
+            // TTFT instrumentation: one content-free latency line per turn — the
+            // time-to-first-token split (context pipeline vs provider). Console-only
+            // (no UI), emitted in every environment so the breakdown is readable from
+            // a live session. See @motebit/ai-core TurnLatency. Aggregation is a
+            // deliberate later step.
             if (chunk.result.latency) {
               const l = chunk.result.latency;
               console.debug(

--- a/services/relay/src/__tests__/sync-redaction-ingress.test.ts
+++ b/services/relay/src/__tests__/sync-redaction-ingress.test.ts
@@ -13,7 +13,12 @@ import type { SyncRelay } from "../index.js";
 import type { EventLogEntry } from "@motebit/sdk";
 import { EventType } from "@motebit/sdk";
 import { AUTH_HEADER, createTestRelay } from "./test-helpers.js";
-import { redactSensitiveEvents, redactMemoryFormedPayload } from "../redaction.js";
+import {
+  redactSensitiveEvents,
+  redactMemoryFormedPayload,
+  redactMemoryAuditPayload,
+  redactMemoryConsolidatedPayload,
+} from "../redaction.js";
 
 const MOTEBIT_ID = "redaction-test-mote";
 
@@ -143,6 +148,43 @@ describe("sync ingress redaction (HTTP push)", () => {
     expect(frame.event.payload.redacted).toBe(true);
   });
 
+  it("strips raw user text from a memory_audit event at ingress", async () => {
+    // memory_audit fires when the model MISSED tagging a pattern — so its raw
+    // fields are disproportionately the sensitive content that escaped tagging.
+    const event = makeMemoryFormedEvent(
+      {
+        turn_message: "my SSN is 123-45-6789 and I take lisinopril",
+        missed_patterns: ['personal_fact: "SSN is 123-45-6789"'],
+      },
+      { event_type: EventType.MemoryAudit },
+    );
+    await pushEvents(relay, [event]);
+    const stored = storedPayload(relay, event.event_id);
+    expect(stored.turn_message).toBeUndefined();
+    expect(stored.missed_patterns).toBeUndefined();
+    expect(stored.redacted).toBe(true);
+  });
+
+  it("redacts the free-text reason from memory_consolidated, keeping structure", async () => {
+    const event = makeMemoryFormedEvent(
+      {
+        action: "merge",
+        existing_node_id: "n-1",
+        new_node_id: "n-2",
+        reason: "user said their diagnosis is X",
+        superseded_valid_until: 5000,
+      },
+      { event_type: EventType.MemoryConsolidated },
+    );
+    await pushEvents(relay, [event]);
+    const stored = storedPayload(relay, event.event_id);
+    expect(stored.reason).toBe("[REDACTED]");
+    expect(stored.action).toBe("merge");
+    expect(stored.existing_node_id).toBe("n-1");
+    expect(stored.new_node_id).toBe("n-2");
+    expect(stored.superseded_valid_until).toBe(5000);
+  });
+
   it("receipt idempotency survives redaction (duplicate receipt still detected)", async () => {
     const receipt = { receipt_id: "r-1", signature: "sig-abc" };
     const first = makeMemoryFormedEvent({
@@ -192,6 +234,34 @@ describe("redactMemoryFormedPayload unit", () => {
     const [m, o] = redactSensitiveEvents([memory, other]);
     expect(m!.payload.content).toBe("[REDACTED]");
     expect(o!.payload).toEqual(other.payload);
+  });
+
+  it("redactMemoryAuditPayload strips both raw fields, is idempotent, passes encrypted", () => {
+    const out = redactMemoryAuditPayload({
+      turn_message: "raw user text",
+      missed_patterns: ['goal: "x"'],
+    });
+    expect(out).not.toBeNull();
+    expect(out!.turn_message).toBeUndefined();
+    expect(out!.missed_patterns).toBeUndefined();
+    expect(out!.redacted).toBe(true);
+    expect(redactMemoryAuditPayload(out!)).toBeNull(); // idempotent
+    expect(redactMemoryAuditPayload({ _encrypted: true, _data: "ct" })).toBeNull();
+    expect(redactMemoryAuditPayload({})).toBeNull(); // nothing to strip
+  });
+
+  it("redactMemoryConsolidatedPayload redacts reason, preserves structure, idempotent", () => {
+    const out = redactMemoryConsolidatedPayload({
+      action: "supersede",
+      existing_node_id: "n1",
+      new_node_id: null,
+      reason: "sensitive rationale",
+    });
+    expect(out!.reason).toBe("[REDACTED]");
+    expect(out!.action).toBe("supersede");
+    expect(out!.existing_node_id).toBe("n1");
+    expect(redactMemoryConsolidatedPayload(out!)).toBeNull(); // idempotent (redacted flag)
+    expect(redactMemoryConsolidatedPayload({ action: "reject" })).toBeNull(); // no reason
   });
 
   it("strips the owner-local mutation_manifest from a synced consolidation receipt", () => {

--- a/services/relay/src/migrations.ts
+++ b/services/relay/src/migrations.ts
@@ -8,7 +8,11 @@
 
 import type { DatabaseDriver } from "@motebit/persistence";
 import { createLogger } from "./logger.js";
-import { redactMemoryFormedPayload } from "./redaction.js";
+import {
+  redactMemoryFormedPayload,
+  redactMemoryAuditPayload,
+  redactMemoryConsolidatedPayload,
+} from "./redaction.js";
 
 const logger = createLogger({ service: "migrations" });
 
@@ -1583,6 +1587,51 @@ export const relayMigrations: Migration[] = [
       }
       if (redacted > 0) {
         logger.info("migration.backfill_historical_memory_deletions", { redacted });
+      }
+    },
+  },
+  {
+    version: 36,
+    name: "scrub_unredacted_memory_audit_consolidated",
+    up: (db) => {
+      // Sibling of the version-34 memory_formed scrub: before the redaction.ts
+      // arms for these landed, the sync push paths appended `memory_audit` and
+      // `memory_consolidated` events RAW — `memory_audit` carrying the user's
+      // turn text + missed-pattern excerpts (exactly the content that escaped
+      // sensitivity tagging), `memory_consolidated` carrying free-text `reason`
+      // that may quote memory content. Rewrite historical rows to the shape the
+      // ingress redactor now produces. Driver-agnostic JS parse; same guards as
+      // version 34 (events table created at boot before relay migrations run).
+      const hasEvents = db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'events'")
+        .get() as { name: string } | undefined;
+      if (!hasEvents) return;
+      const update = db.prepare("UPDATE events SET payload = ? WHERE event_id = ?");
+      let scrubbed = 0;
+      const scrub = (
+        eventType: string,
+        redact: (p: Record<string, unknown>) => Record<string, unknown> | null,
+      ): void => {
+        const rows = db
+          .prepare("SELECT event_id, payload FROM events WHERE event_type = ?")
+          .all(eventType) as { event_id: string; payload: string }[];
+        for (const row of rows) {
+          let payload: Record<string, unknown>;
+          try {
+            payload = JSON.parse(row.payload) as Record<string, unknown>;
+          } catch {
+            continue; // unparseable — leave untouched rather than destroy
+          }
+          const redacted = redact(payload);
+          if (!redacted) continue;
+          update.run(JSON.stringify(redacted), row.event_id);
+          scrubbed++;
+        }
+      };
+      scrub("memory_audit", redactMemoryAuditPayload);
+      scrub("memory_consolidated", redactMemoryConsolidatedPayload);
+      if (scrubbed > 0) {
+        logger.info("migration.scrub_unredacted_memory_audit_consolidated", { scrubbed });
       }
     },
   },

--- a/services/relay/src/redaction.ts
+++ b/services/relay/src/redaction.ts
@@ -63,9 +63,51 @@ export function stripConsolidationManifest(
 }
 
 /**
- * Map a batch of events, redacting `memory_formed` content above the
- * sync-safe ceiling and stripping the owner-local consolidation mutation
- * manifest. Other events pass through byte-identical.
+ * Strip the raw user text from a `memory_audit` payload. This event fires
+ * precisely when the model FAILED to tag a memory-worthy pattern, so its
+ * `turn_message` (up to 200 chars of the raw user message) and `missed_patterns`
+ * (raw `<label>: "<excerpt>"` slices of that same text) are disproportionately
+ * likely to be exactly the medical/financial/secret content that escaped
+ * classification — and the payload carries NO `sensitivity` field to gate on.
+ * The event is a LOCAL reflection signal (revisit missed tagging on-device); no
+ * peer or device consumes the excerpts at the relay. So both fields are stripped
+ * at ingress, fail-closed. Returns the stripped payload, or `null` when there is
+ * nothing to strip.
+ */
+export function redactMemoryAuditPayload(
+  payload: Record<string, unknown>,
+): Record<string, unknown> | null {
+  if (payload._encrypted === true) return null;
+  if (payload.redacted === true) return null;
+  if (!("turn_message" in payload) && !("missed_patterns" in payload)) return null;
+  const { turn_message: _t, missed_patterns: _m, ...rest } = payload;
+  return { ...rest, redacted: true };
+}
+
+/**
+ * Redact the free-text `reason` from a `memory_consolidated` payload. The
+ * rationale is decider-authored free text that MAY quote or derive memory
+ * content of any sensitivity, with no `sensitivity` field to gate on. The
+ * structural fields (`action`, `existing_node_id`, `new_node_id`,
+ * `superseded_valid_until`) are what a peer device needs to apply the
+ * consolidation, so they are preserved; only `reason` is stripped. Returns the
+ * redacted payload, or `null` when there is nothing to do.
+ */
+export function redactMemoryConsolidatedPayload(
+  payload: Record<string, unknown>,
+): Record<string, unknown> | null {
+  if (payload._encrypted === true) return null;
+  if (payload.redacted === true) return null;
+  if (!("reason" in payload)) return null;
+  return { ...payload, reason: "[REDACTED]", redacted: true };
+}
+
+/**
+ * Map a batch of events, redacting memory content above the sync-safe ceiling
+ * (`memory_formed`), stripping the owner-local consolidation mutation manifest
+ * (`consolidation_receipt_signed`), and stripping the raw user text carried by
+ * `memory_audit` / `memory_consolidated` (free text with no `sensitivity` field
+ * and no relay-side consumer). Other events pass through byte-identical.
  */
 export function redactSensitiveEvents(events: EventLogEntry[]): EventLogEntry[] {
   return events.map((e) => {
@@ -78,6 +120,14 @@ export function redactSensitiveEvents(events: EventLogEntry[]): EventLogEntry[] 
     if (e.event_type === EventType.ConsolidationReceiptSigned) {
       const stripped = stripConsolidationManifest(payload);
       return stripped ? { ...e, payload: stripped } : e;
+    }
+    if (e.event_type === EventType.MemoryAudit) {
+      const redacted = redactMemoryAuditPayload(payload);
+      return redacted ? { ...e, payload: redacted } : e;
+    }
+    if (e.event_type === EventType.MemoryConsolidated) {
+      const redacted = redactMemoryConsolidatedPayload(payload);
+      return redacted ? { ...e, payload: redacted } : e;
     }
     return e;
   });


### PR DESCRIPTION
## What

Closes a **fail-closed-privacy leak** found by the repo audit (verified against the code): the relay ingress redactor stripped only `memory_formed` content + the consolidation manifest, so **`memory_audit` and `memory_consolidated` reached the relay — and fanned out to peer devices — verbatim.**

`memory_audit` is the worst case: it fires precisely when the model **failed** to tag a memory-worthy pattern, so its `turn_message` (raw user message) + `missed_patterns` (raw excerpts of it) are disproportionately the **medical/financial/secret** content that escaped classification — and the payload carries no `sensitivity` field to gate on. This violates the core invariant that medical/financial/secret never persist at the relay. It's the same sync-redaction gap class as the felt-interior manifest fix (third recurrence).

## Changes

- `redactMemoryAuditPayload` — strips `turn_message` + `missed_patterns` at ingress (local audit signal; no relay/peer consumer).
- `redactMemoryConsolidatedPayload` — redacts the free-text `reason`; preserves the structural fields peers need (`action`, node ids, `superseded_valid_until`).
- Both wired into `redactSensitiveEvents` (HTTP + WS ingress push paths).
- **Migration v36** scrubs already-leaked historical rows, mirroring the v34 `memory_formed` scrub (driver-agnostic; encrypted / already-redacted guards). Not just stop-the-bleed — cleans what already landed.
- Tests: ingress strips both event types; unit tests for strip / idempotency / encrypted passthrough / structure preservation.

Also folds in a pending comment cleanup (`apps/web/src/ui/chat.ts`): drops the colloquial "feels weak" phrasing from the TTFT instrumentation comment.

## Verification

17 redaction + 50 migration tests pass; relay typecheck + lint clean; **all 119 drift gates green** (pre-push).

## Follow-up (NOT in this PR)

Conversation/message sync (`data-sync.ts` title/summary/content) has **no relay-side sensitivity floor** — relies entirely on client-side encryption being present. Flagged MEDIUM by the audit; a separate code path, deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
