### PR TITLE
fix(relay): route pre-settlement dispute escrow by role, not by filer

### DIFF
--- a/services/relay/src/__tests__/dispute-clawback.test.ts
+++ b/services/relay/src/__tests__/dispute-clawback.test.ts
@@ -180,3 +180,149 @@ describe("Dispute claw-back (post-settlement, no mint)", () => {
     expect(bal(relay, DELEGATOR)).toBe(0);
   });
 });
+
+/**
+ * Pre-settlement distribution — the worker-filed inversion fix.
+ *
+ * A dispute filed BEFORE any relay settlement has no settlement row, so
+ * `executeFundAction` takes Case A: it distributes the still-held escrow
+ * (`amount_locked`) with no claw-back. Worker/delegator are NOT in the ledger,
+ * so they must be recovered from the dispute parties + the `filer_role` captured
+ * at filing. Before the 2026-06 fix, Case A credited `filed_by`/`respondent`
+ * directly — correct only when the DELEGATOR filed. On a WORKER-filed dispute
+ * `filed_by` = worker and `respondent` = delegator, so `release_to_worker` paid
+ * the delegator and `refund_to_delegator` paid the worker — escrow to the LOSING
+ * party every time. (`reconcileLedger` cannot catch this; it's a routing bug,
+ * not a conservation bug — the right total reaches the wrong account.)
+ *
+ * These tests seed a resolved pre-settlement dispute past the appeal window,
+ * vary the filer, and assert the escrow lands in the correct account.
+ */
+const ESCROW = 1_000_000;
+
+interface PreSeedOpts {
+  fundAction: "refund_to_delegator" | "release_to_worker" | "split";
+  splitRatio: number;
+  resolution: "upheld" | "overturned" | "split";
+  filerRole: "worker" | "delegator";
+  taskId: string;
+  disputeId: string;
+}
+
+function seedPreSettlementDispute(relay: SyncRelay, o: PreSeedOpts): void {
+  const db = relay.moteDb.db;
+  const now = Date.now();
+
+  // filed_by is whoever filed; respondent is the counterparty. NO settlement
+  // row → executeFundAction takes the pre-settlement escrow path.
+  const filedBy = o.filerRole === "worker" ? WORKER : DELEGATOR;
+  const respondent = o.filerRole === "worker" ? DELEGATOR : WORKER;
+
+  db.prepare(
+    `INSERT INTO relay_disputes
+     (dispute_id, task_id, allocation_id, filed_by, respondent, category, description, state, amount_locked, filing_fee, filed_at, evidence_deadline, resolved_at, filer_role)
+     VALUES (?, ?, ?, ?, ?, 'quality', 'dispute', 'resolved', ?, 0, ?, ?, ?, ?)`,
+  ).run(
+    o.disputeId,
+    o.taskId,
+    `alloc-${o.taskId}`,
+    filedBy,
+    respondent,
+    ESCROW,
+    now - 26 * 3600_000,
+    now - 25 * 3600_000,
+    now - 25 * 3600_000,
+    o.filerRole,
+  );
+
+  db.prepare(
+    `INSERT INTO relay_dispute_resolutions
+     (resolution_id, dispute_id, round, resolution, rationale, fund_action, split_ratio, adjudicator, resolved_at, signature)
+     VALUES (?, ?, 1, ?, 'r', ?, ?, 'op', ?, 'sig')`,
+  ).run(
+    `res-${o.disputeId}`,
+    o.disputeId,
+    o.resolution,
+    o.fundAction,
+    o.splitRatio,
+    now - 25 * 3600_000,
+  );
+}
+
+describe("Dispute pre-settlement distribution (worker-filed inversion fix)", () => {
+  let relay: SyncRelay;
+  beforeEach(async () => {
+    relay = await createTestRelay();
+  });
+  afterEach(async () => {
+    await relay.close();
+  });
+
+  it("worker-filed + upheld pays the WORKER (was paying the delegator pre-fix)", async () => {
+    // Worker files, wins (upheld) → release_to_worker. The escrow must reach
+    // the worker (= filed_by here), NOT the respondent.
+    seedPreSettlementDispute(relay, {
+      fundAction: "release_to_worker",
+      splitRatio: 1.0,
+      resolution: "upheld",
+      filerRole: "worker",
+      taskId: "task-pre-wf-up",
+      disputeId: "dsp-pre-wf-up",
+    });
+    await finalize(relay, "dsp-pre-wf-up");
+
+    expect(bal(relay, WORKER)).toBe(ESCROW);
+    expect(bal(relay, DELEGATOR)).toBe(0);
+  });
+
+  it("worker-filed + overturned refunds the DELEGATOR (was paying the worker pre-fix)", async () => {
+    // Worker files, loses (overturned) → refund_to_delegator. The escrow must
+    // reach the delegator (= respondent here), NOT the filer.
+    seedPreSettlementDispute(relay, {
+      fundAction: "refund_to_delegator",
+      splitRatio: 0.0,
+      resolution: "overturned",
+      filerRole: "worker",
+      taskId: "task-pre-wf-ov",
+      disputeId: "dsp-pre-wf-ov",
+    });
+    await finalize(relay, "dsp-pre-wf-ov");
+
+    expect(bal(relay, DELEGATOR)).toBe(ESCROW);
+    expect(bal(relay, WORKER)).toBe(0);
+  });
+
+  it("delegator-filed + upheld refunds the DELEGATOR — common path unchanged", async () => {
+    // The pre-existing (and majority) case: delegator files and wins. Behavior
+    // must be byte-identical to before the fix — escrow back to the delegator.
+    seedPreSettlementDispute(relay, {
+      fundAction: "refund_to_delegator",
+      splitRatio: 0.0,
+      resolution: "upheld",
+      filerRole: "delegator",
+      taskId: "task-pre-df-up",
+      disputeId: "dsp-pre-df-up",
+    });
+    await finalize(relay, "dsp-pre-df-up");
+
+    expect(bal(relay, DELEGATOR)).toBe(ESCROW);
+    expect(bal(relay, WORKER)).toBe(0);
+  });
+
+  it("worker-filed + split divides escrow worker/delegator by ratio, not filer/respondent", async () => {
+    seedPreSettlementDispute(relay, {
+      fundAction: "split",
+      splitRatio: 0.5,
+      resolution: "split",
+      filerRole: "worker",
+      taskId: "task-pre-wf-sp",
+      disputeId: "dsp-pre-wf-sp",
+    });
+    await finalize(relay, "dsp-pre-wf-sp");
+
+    const workerShare = Math.floor(ESCROW * 0.5);
+    expect(bal(relay, WORKER)).toBe(workerShare);
+    expect(bal(relay, DELEGATOR)).toBe(ESCROW - workerShare);
+    expect(bal(relay, WORKER) + bal(relay, DELEGATOR)).toBe(ESCROW);
+  });
+});

--- a/services/relay/src/__tests__/disputes.test.ts
+++ b/services/relay/src/__tests__/disputes.test.ts
@@ -839,7 +839,14 @@ describe("Dispute: fund execution integrity", () => {
     relay = await createTestRelay({ enableDeviceAuth: false });
     await registerAgent(relay, "del-fund");
     await registerAgent(relay, "wrk-fund");
-    createAllocation(relay, "alloc-fund", "task-fund", "del-fund");
+    // The allocation's motebit_id IS the worker (it's the agent the escrow pays
+    // out to). So `wrk-fund` owns the allocation; `del-fund` is the delegator,
+    // and a dispute it files is `filer_role=delegator`. (Pre-fix this fixture
+    // assigned the allocation to `del-fund`, inverting the roles — which only
+    // passed because executeFundAction's Case A inverted them a SECOND time via
+    // filed_by/respondent; the two cancelled. The fix removes that inversion, so
+    // the fixture now has to name roles honestly.)
+    createAllocation(relay, "alloc-fund", "task-fund", "wrk-fund");
   });
 
   afterEach(async () => {
@@ -939,7 +946,7 @@ describe("Dispute: fund execution integrity", () => {
     expect(delTxn?.amount).toBe(30000);
   });
 
-  it("release_to_worker credits the respondent", async () => {
+  it("release_to_worker credits the worker (= the allocation owner, not the filer)", async () => {
     const openRes = await openDispute(relay, "alloc-fund", "del-fund", "wrk-fund", "task-fund");
     const { dispute_id } = (await openRes.json()) as { dispute_id: string };
 

--- a/services/relay/src/__tests__/federation-appeal.test.ts
+++ b/services/relay/src/__tests__/federation-appeal.test.ts
@@ -422,7 +422,11 @@ describe("Federation appeal: round-1 resolved → /appeal → round-2 → final"
     expect(resolutionRows[1]).toEqual({ round: 2, resolution: "overturned" });
 
     // §7.1 + §7.3 + §8.4: fund_action executes on transition to `final`.
-    // round-2 verdict was `overturned` → split_ratio = 0.0 (delegator wins).
+    // `del-fa` OWNS the allocation, so it is the worker and (having filed) the
+    // worker-filer; the relay is the respondent = delegator. Round-2 `overturned`
+    // means the worker-filer LOSES on appeal → mapFundAction(overturned, worker)
+    // = refund_to_delegator, split_ratio 0.0 → the full escrow refunds the
+    // delegator (the relay here), NOT the losing filer.
     const stateFinal = relay.moteDb.db
       .prepare("SELECT state, resolution, split_ratio FROM relay_disputes WHERE dispute_id = ?")
       .get(disputeId) as { state: string; resolution: string; split_ratio: number };
@@ -430,13 +434,22 @@ describe("Federation appeal: round-1 resolved → /appeal → round-2 → final"
     expect(stateFinal.resolution).toBe("overturned");
     expect(stateFinal.split_ratio).toBe(0.0);
 
-    // Delegator received the refund (split_ratio=0 → all to delegator)
-    const delTxn = relay.moteDb.db
+    // The delegator (= respondent = relay) received the refund; the worker-filer
+    // who lost the appeal received nothing. (Pre-fix, Case A credited `filed_by`
+    // — the losing filer — paying the escrow to exactly the wrong party.)
+    const refundTxn = relay.moteDb.db
+      .prepare(
+        "SELECT amount FROM relay_transactions WHERE motebit_id = ? AND type = 'settlement_credit' AND reference_id = ?",
+      )
+      .get(relayMotebitId, disputeId) as { amount: number } | undefined;
+    expect(refundTxn?.amount).toBe(100000);
+
+    const loserTxn = relay.moteDb.db
       .prepare(
         "SELECT amount FROM relay_transactions WHERE motebit_id = ? AND type = 'settlement_credit' AND reference_id = ?",
       )
       .get("del-fa", disputeId) as { amount: number } | undefined;
-    expect(delTxn?.amount).toBe(100000);
+    expect(loserTxn).toBeUndefined();
   });
 });
 

--- a/services/relay/src/disputes.ts
+++ b/services/relay/src/disputes.ts
@@ -1962,61 +1962,59 @@ function executeFundAction(
     return;
   }
 
-  // ── Case A: PRE-SETTLEMENT. Escrow (amount_locked) still held; release it. ──
+  // ── Case A: PRE-SETTLEMENT. Escrow (amount_locked) still held; distribute it. ──
   // The delegator was debited amount_locked at submission and the worker was
   // never paid (no settlement row), so the funds sit in escrow — distribute
-  // them per fund_action with no claw-back. Uses the dispute parties; the
-  // (resolution, filer_role) → fund_action mapping already encodes direction.
+  // them with no claw-back.
+  //
+  // No settlement row means worker/delegator are NOT in the ledger and must be
+  // recovered from the dispute parties. `filed_by`/`respondent` are filer and
+  // counterparty — they map to delegator/worker ONLY when the delegator filed;
+  // a worker-filed dispute INVERTS them. (This is the exact hazard Case B's
+  // comment warns about; pre-fix this path credited `filed_by`/`respondent`
+  // directly and so paid escrow to the losing party on every worker-filed
+  // dispute.) So resolve the roles explicitly from the filer_role captured at
+  // filing, then divide by split_ratio exactly as Case B divides the net:
+  // refund→0.0, release→1.0, split→0.5. filer_role NULL (pre-migration-21
+  // disputes, always emitted as the v1 `split` shape) falls back to the v1
+  // assumption filer=delegator / respondent=worker, which the ternary preserves
+  // (worker = respondent whenever the role is not "worker").
   const filedBy = dispute.filed_by as string;
   const respondent = dispute.respondent as string;
+  const filerRole = (dispute.filer_role as FilerRole | null) ?? null;
+  const worker = filerRole === "worker" ? filedBy : respondent;
+  const delegator = filerRole === "worker" ? respondent : filedBy;
+  const workerShare = Math.floor(amountLocked * splitRatio);
+  const delegatorShare = amountLocked - workerShare;
 
-  switch (fundAction) {
-    case "refund_to_delegator": {
-      creditAccountCanonical(
-        db,
-        filedBy,
-        amountLocked,
-        "settlement_credit",
-        disputeId,
-        `Dispute refund: ${disputeId}`,
-      );
-      break;
-    }
-    case "release_to_worker": {
-      creditAccountCanonical(
-        db,
-        respondent,
-        amountLocked,
-        "settlement_credit",
-        disputeId,
-        `Dispute release: ${disputeId}`,
-      );
-      break;
-    }
-    case "split": {
-      const workerAmount = Math.floor(amountLocked * splitRatio);
-      const delegatorAmount = amountLocked - workerAmount;
-      if (workerAmount > 0) {
-        creditAccountCanonical(
-          db,
-          respondent,
-          workerAmount,
-          "settlement_credit",
-          disputeId,
-          `Dispute split (worker): ${disputeId}`,
-        );
-      }
-      if (delegatorAmount > 0) {
-        creditAccountCanonical(
-          db,
-          filedBy,
-          delegatorAmount,
-          "settlement_credit",
-          disputeId,
-          `Dispute split (delegator): ${disputeId}`,
-        );
-      }
-      break;
-    }
+  if (workerShare > 0) {
+    creditAccountCanonical(
+      db,
+      worker,
+      workerShare,
+      "settlement_credit",
+      disputeId,
+      `Dispute release (${fundAction}): ${disputeId}`,
+    );
   }
+  if (delegatorShare > 0) {
+    creditAccountCanonical(
+      db,
+      delegator,
+      delegatorShare,
+      "settlement_credit",
+      disputeId,
+      `Dispute refund (${fundAction}): ${disputeId}`,
+    );
+  }
+  logger.info("dispute.fund_action.pre_settlement", {
+    disputeId,
+    fundAction,
+    filerRole,
+    worker,
+    delegator,
+    amountLocked,
+    workerShare,
+    delegatorShare,
+  });
 }


### PR DESCRIPTION
## What

Closes the **#2 money/ledger bug** from the repo audit (verified end-to-end against code + spec): `executeFundAction`'s **Case A (pre-settlement dispute)** distributed the still-held escrow to the dispute's `filed_by`/`respondent` directly — `refund_to_delegator` → `filed_by`, `release_to_worker` → `respondent`. That mapping is correct **only when the delegator filed**.

On a **worker-filed** pre-settlement dispute, `filed_by` is the worker and `respondent` is the delegator, so the escrow paid the **losing party** every time: `release_to_worker` paid the delegator, `refund_to_delegator` paid the worker. `reconcileLedger` cannot catch this — the right *total* reaches the *wrong account* (a routing bug, not a conservation bug).

Reachable: `disputes.ts` sets `filer_role = "worker"` whenever the filer owns the allocation (`req.filed_by === allocation.motebit_id`), and a worker can file pre-settlement.

## The fix is already spec-mandated

`spec/dispute-v1.md` §7.4 already states the worker/delegator identities are **"NOT the dispute's `filed_by`/`respondent` (which are filer/counterparty and do not map to worker/delegator for a worker-filed dispute)"** — and the post-settlement **Case B** already follows it (off the settlement row). The old Case A was a spec violation. No spec change needed.

Case A now mirrors Case B: resolve `worker`/`delegator` from the `filer_role` captured at filing, then divide `amount_locked` by `split_ratio` (`refund` 0.0 / `release` 1.0 / `split` 0.5). `filer_role` NULL (pre-migration-21) falls back to the v1 `filer=delegator` assumption, which the ternary preserves.

**Behavior delta is surgical:** delegator-filed and legacy disputes are byte-identical; only worker-filed payouts change.

## Tests

Two pre-existing suites passed only because **two inversions cancelled** — the fixtures mislabeled the allocation owner (which IS the worker) as `del-fund`/`del-fa` while asserting textbook-correct payouts, and the old Case A inverted a second time. `federation-appeal` even commented *"filer loses on appeal"* then asserted the filer got paid. Fixed both fixtures to name roles honestly:
- `disputes.test.ts` fund-integrity → an honest **delegator-filed** case (assertions unchanged, now pass for the right reason).
- `federation-appeal.test.ts` overturned case → an honest **worker-filer who loses** and is correctly **not** paid (the delegator is refunded).

Added 4 pre-settlement regression tests in `dispute-clawback.test.ts`: worker-filed upheld/overturned/split + a delegator-filed control proving the common path is unchanged.

Full relay suite (1348 passed, 6 pre-existing skips) + all 119 drift gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
