### PR TITLE
fix(relay): fail-closed sensitivity floor for conversation/message/plan sync

### DIFF
--- a/packages/encryption/src/__tests__/index.test.ts
+++ b/packages/encryption/src/__tests__/index.test.ts
@@ -35,6 +35,8 @@ import {
   publicKeyToDidKey,
   hexPublicKeyToDidKey,
   bytesToHex,
+  ENCRYPTED_FIELD_PREFIX,
+  isEncryptedField,
 } from "../index";
 
 // ---------------------------------------------------------------------------
@@ -1452,5 +1454,36 @@ describe("canonicalJson", () => {
     expect(canonicalJson("hello")).toBe('"hello"');
     expect(canonicalJson(42)).toBe("42");
     expect(canonicalJson(true)).toBe("true");
+  });
+});
+
+describe("field-level encryption marker", () => {
+  it("the canonical prefix is the field adapters' marker (NUL-led, not human text)", () => {
+    expect(ENCRYPTED_FIELD_PREFIX).toBe("\0ENC:");
+  });
+
+  it("isEncryptedField detects prefixed ciphertext, rejects plaintext/null/non-strings", () => {
+    expect(isEncryptedField(ENCRYPTED_FIELD_PREFIX + "anything")).toBe(true);
+    expect(isEncryptedField("plaintext")).toBe(false);
+    expect(isEncryptedField("[REDACTED]")).toBe(false);
+    expect(isEncryptedField("")).toBe(false);
+    expect(isEncryptedField(null)).toBe(false);
+    expect(isEncryptedField(undefined)).toBe(false);
+    expect(isEncryptedField(42)).toBe(false);
+  });
+
+  it("round-trips: a value the field encryptor produces is detected as encrypted", async () => {
+    // Mirrors the adapters' encryptString packing so the marker contract is
+    // pinned at the source, not just asserted as a literal.
+    const key = generateKey();
+    const e = await encrypt(new TextEncoder().encode("secret"), key);
+    const packed =
+      ENCRYPTED_FIELD_PREFIX +
+      JSON.stringify({
+        c: bytesToHex(e.ciphertext),
+        n: bytesToHex(e.nonce),
+        t: bytesToHex(e.tag),
+      });
+    expect(isEncryptedField(packed)).toBe(true);
   });
 });

--- a/packages/encryption/src/index.ts
+++ b/packages/encryption/src/index.ts
@@ -186,6 +186,38 @@ export interface EncryptedPayload {
 }
 
 /**
+ * Marker prefix for a FIELD-LEVEL encrypted string on the sync wire.
+ *
+ * The conversation/plan sync adapters (`@motebit/sync-engine`) encrypt
+ * individual free-text fields (message `content`, conversation `title`/
+ * `summary`, plan `title`, step `description`/`prompt`/`result_summary`/
+ * `error_message`, `tool_calls`) in place: the value becomes
+ * `"\0ENC:" + base64-packed {c,n,t}`. A leading NUL keeps the marker out of
+ * any legitimate human text. This differs from the event-store envelope
+ * (`{_encrypted: true, _data}`) — sync encryption is per-field so the relay
+ * can still index by id/timestamp without the key.
+ *
+ * This is a **cross-package wire sentinel**: the client side (encrypt/decrypt
+ * adapters) and the relay side (the ingress sensitivity floor in
+ * `services/relay/src/data-sync-redaction.ts`, which passes ciphertext through
+ * and fail-closed redacts plaintext) must agree on it byte-for-byte. It lives
+ * here, in the package that owns the encryption envelope, so both sides import
+ * one source of truth rather than each re-declaring it (they used to, and it
+ * was already drifting toward two private copies).
+ */
+export const ENCRYPTED_FIELD_PREFIX = "\0ENC:";
+
+/**
+ * True when `value` is a field-level encrypted string (carries
+ * `ENCRYPTED_FIELD_PREFIX`). Opaque ciphertext the holder of the sync key
+ * guards — the relay must pass it through untouched. A plaintext string
+ * (no prefix) is, at the relay boundary, unprotected content.
+ */
+export function isEncryptedField(value: unknown): value is string {
+  return typeof value === "string" && value.startsWith(ENCRYPTED_FIELD_PREFIX);
+}
+
+/**
  * Legacy unsigned deletion certificate. Pre-dates the
  * `DeletionCertificate` discriminated union in `@motebit/protocol`,
  * which carries `kind`, `suite`, and signatures (subject / operator /

--- a/packages/sync-engine/src/encrypted-conversation-adapter.ts
+++ b/packages/sync-engine/src/encrypted-conversation-adapter.ts
@@ -8,7 +8,12 @@
  */
 
 import type { SyncConversation, SyncConversationMessage } from "@motebit/sdk";
-import { encrypt, decrypt, type EncryptedPayload } from "@motebit/encryption";
+import {
+  encrypt,
+  decrypt,
+  type EncryptedPayload,
+  ENCRYPTED_FIELD_PREFIX as ENCRYPTED_PREFIX,
+} from "@motebit/encryption";
 import type { ConversationSyncRemoteAdapter } from "./conversation-sync.js";
 
 export interface EncryptedConversationAdapterConfig {
@@ -41,9 +46,6 @@ function fromBase64(str: string): Uint8Array {
   }
   return bytes;
 }
-
-/** Marker prefix for encrypted strings — allows graceful handling of mixed encrypted/plaintext data. */
-const ENCRYPTED_PREFIX = "\0ENC:";
 
 async function encryptString(value: string | null, key: Uint8Array): Promise<string | null> {
   if (value == null || value === "") return value;

--- a/packages/sync-engine/src/encrypted-plan-adapter.ts
+++ b/packages/sync-engine/src/encrypted-plan-adapter.ts
@@ -8,7 +8,12 @@
  */
 
 import type { SyncPlan, SyncPlanStep } from "@motebit/sdk";
-import { encrypt, decrypt, type EncryptedPayload } from "@motebit/encryption";
+import {
+  encrypt,
+  decrypt,
+  type EncryptedPayload,
+  ENCRYPTED_FIELD_PREFIX as ENCRYPTED_PREFIX,
+} from "@motebit/encryption";
 import type { PlanSyncRemoteAdapter } from "./plan-sync.js";
 
 export interface EncryptedPlanAdapterConfig {
@@ -41,9 +46,6 @@ function fromBase64(str: string): Uint8Array {
   }
   return bytes;
 }
-
-/** Marker prefix for encrypted strings — allows graceful handling of mixed encrypted/plaintext data. */
-const ENCRYPTED_PREFIX = "\0ENC:";
 
 async function encryptString(value: string | null, key: Uint8Array): Promise<string | null> {
   if (value == null || value === "") return value;

--- a/services/relay/src/__tests__/conversation-sync.test.ts
+++ b/services/relay/src/__tests__/conversation-sync.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { SyncRelay } from "../index.js";
 import type { SyncConversation, SyncConversationMessage } from "@motebit/sdk";
 import { AUTH_HEADER, createTestRelay } from "./test-helpers.js";
@@ -6,6 +6,13 @@ import { AUTH_HEADER, createTestRelay } from "./test-helpers.js";
 // === Helpers ===
 
 const MOTEBIT_ID = "test-mote";
+
+// Field-level encryption marker (canonical: @motebit/encryption ENCRYPTED_FIELD_PREFIX).
+// The relay floor passes prefixed values through opaquely — production ALWAYS
+// encrypts conversation/message content before push, so these mechanics tests
+// use encrypted-shaped sentinels for any field they round-trip.
+const ENC = "\0ENC:";
+const enc = (s: string): string => ENC + s;
 
 function makeConversation(
   motebitId: string,
@@ -189,8 +196,8 @@ describe("Conversation Sync Endpoints", () => {
   it("GET /sync/:id/messages filters by since timestamp", async () => {
     const convId = "conv-filter-test";
     const messages = [
-      makeMessage(convId, MOTEBIT_ID, { content: "Old", created_at: 1000 }),
-      makeMessage(convId, MOTEBIT_ID, { content: "New", created_at: 5000 }),
+      makeMessage(convId, MOTEBIT_ID, { content: enc("Old"), created_at: 1000 }),
+      makeMessage(convId, MOTEBIT_ID, { content: enc("New"), created_at: 5000 }),
     ];
     await relay.app.request(`/sync/${MOTEBIT_ID}/messages`, {
       method: "POST",
@@ -206,7 +213,8 @@ describe("Conversation Sync Endpoints", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { messages: SyncConversationMessage[] };
     expect(body.messages).toHaveLength(1);
-    expect(body.messages[0]!.content).toBe("New");
+    // Encrypted content passes the floor through byte-identical.
+    expect(body.messages[0]!.content).toBe(enc("New"));
   });
 
   it("GET /sync/:id/messages returns 400 when conversation_id missing", async () => {
@@ -244,15 +252,15 @@ describe("Conversation Sync Endpoints", () => {
     const old = makeConversation(MOTEBIT_ID, {
       conversation_id: convId,
       last_active_at: 1000,
-      title: "Old title",
-      summary: "Old summary",
+      title: enc("Old title"),
+      summary: enc("Old summary"),
       message_count: 5,
     });
     const newer = makeConversation(MOTEBIT_ID, {
       conversation_id: convId,
       last_active_at: 2000,
-      title: "New title",
-      summary: "New summary",
+      title: enc("New title"),
+      summary: enc("New summary"),
       message_count: 3, // lower — but MAX should keep 5
     });
 
@@ -275,8 +283,8 @@ describe("Conversation Sync Endpoints", () => {
     const body = (await res.json()) as { conversations: SyncConversation[] };
     const conv = body.conversations.find((c) => c.conversation_id === convId);
     expect(conv).toBeDefined();
-    expect(conv!.title).toBe("New title");
-    expect(conv!.summary).toBe("New summary");
+    expect(conv!.title).toBe(enc("New title"));
+    expect(conv!.summary).toBe(enc("New summary"));
     expect(conv!.message_count).toBe(5); // MAX of 5 and 3
   });
 
@@ -352,5 +360,111 @@ describe("Conversation Sync Endpoints", () => {
       body: JSON.stringify({}),
     });
     expect(res.status).toBe(400);
+  });
+});
+
+// === Sensitivity floor (fail-closed: plaintext content never persists) ===
+
+describe("Conversation sync sensitivity floor", () => {
+  let relay: SyncRelay;
+  beforeEach(async () => {
+    relay = await createTestRelay({ enableDeviceAuth: false });
+  });
+  afterEach(async () => {
+    await relay.close();
+  });
+
+  async function pushConversations(convs: SyncConversation[], deviceId = "device-a") {
+    return relay.app.request(`/sync/${MOTEBIT_ID}/conversations`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-device-id": deviceId, ...AUTH_HEADER },
+      body: JSON.stringify({ conversations: convs }),
+    });
+  }
+  async function pushMessages(msgs: SyncConversationMessage[], deviceId = "device-a") {
+    return relay.app.request(`/sync/${MOTEBIT_ID}/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-device-id": deviceId, ...AUTH_HEADER },
+      body: JSON.stringify({ messages: msgs }),
+    });
+  }
+  function pulledConversation(id: string): SyncConversation | undefined {
+    const row = relay.moteDb.db
+      .prepare("SELECT * FROM sync_conversations WHERE conversation_id = ?")
+      .get(id) as SyncConversation | undefined;
+    return row;
+  }
+  function pulledMessage(id: string): SyncConversationMessage | undefined {
+    return relay.moteDb.db
+      .prepare("SELECT * FROM sync_conversation_messages WHERE message_id = ?")
+      .get(id) as SyncConversationMessage | undefined;
+  }
+
+  it("redacts plaintext conversation title + summary at ingress", async () => {
+    const conv = makeConversation(MOTEBIT_ID, {
+      title: "Dinner with Dr. Reyes about the diagnosis",
+      summary: "discussed the MRI results",
+    });
+    await pushConversations([conv]);
+    const stored = pulledConversation(conv.conversation_id)!;
+    expect(stored.title).toBe("[REDACTED]");
+    expect(stored.summary).toBe("[REDACTED]");
+  });
+
+  it("passes encrypted conversation fields through byte-identical", async () => {
+    const conv = makeConversation(MOTEBIT_ID, {
+      title: enc("ciphertext-title"),
+      summary: enc("ciphertext-summary"),
+    });
+    await pushConversations([conv]);
+    const stored = pulledConversation(conv.conversation_id)!;
+    expect(stored.title).toBe(enc("ciphertext-title"));
+    expect(stored.summary).toBe(enc("ciphertext-summary"));
+  });
+
+  it("leaves null/empty conversation fields untouched", async () => {
+    const conv = makeConversation(MOTEBIT_ID, { title: null, summary: "" });
+    await pushConversations([conv]);
+    const stored = pulledConversation(conv.conversation_id)!;
+    expect(stored.title).toBeNull();
+    expect(stored.summary).toBe("");
+  });
+
+  it("redacts plaintext message content + tool_calls at ingress", async () => {
+    const msg = makeMessage("conv-floor", MOTEBIT_ID, {
+      content: "my account number is 1234567890",
+      tool_calls: '[{"name":"transfer","args":{"to":"acct-x"}}]',
+    });
+    await pushMessages([msg]);
+    const stored = pulledMessage(msg.message_id)!;
+    expect(stored.content).toBe("[REDACTED]");
+    expect(stored.tool_calls).toBe("[REDACTED]");
+  });
+
+  it("passes encrypted message content through byte-identical", async () => {
+    const msg = makeMessage("conv-floor-enc", MOTEBIT_ID, {
+      content: enc("ciphertext-body"),
+      tool_calls: null,
+    });
+    await pushMessages([msg]);
+    const stored = pulledMessage(msg.message_id)!;
+    expect(stored.content).toBe(enc("ciphertext-body"));
+    expect(stored.tool_calls).toBeNull();
+  });
+
+  it("floors plaintext message content in the fan-out frame to peers", async () => {
+    const peerWs = { send: vi.fn(), close: vi.fn(), readyState: 1 };
+    relay.connections.set(MOTEBIT_ID, [{ ws: peerWs as never, deviceId: "device-b" }]);
+
+    const msg = makeMessage("conv-fanout", MOTEBIT_ID, { content: "leaked secret to peer" });
+    await pushMessages([msg], "device-a");
+
+    expect(peerWs.send).toHaveBeenCalledTimes(1);
+    const frame = JSON.parse(peerWs.send.mock.calls[0]![0] as string) as {
+      type: string;
+      message: SyncConversationMessage;
+    };
+    expect(frame.type).toBe("conversation_message");
+    expect(frame.message.content).toBe("[REDACTED]");
   });
 });

--- a/services/relay/src/__tests__/data-sync-redaction.test.ts
+++ b/services/relay/src/__tests__/data-sync-redaction.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for the conversation/message/plan sync sensitivity floor.
+ *
+ * The floor is a key-acceptance decision: every free-text field the client
+ * adapters encrypt MUST arrive encrypted (carrying ENCRYPTED_FIELD_PREFIX); a
+ * plaintext value in those fields is unprotected content and is replaced with
+ * [REDACTED] at relay ingress. null/empty pass through; ciphertext passes
+ * through byte-identical.
+ */
+import { describe, it, expect } from "vitest";
+import type {
+  SyncConversation,
+  SyncConversationMessage,
+  SyncPlan,
+  SyncPlanStep,
+} from "@motebit/sdk";
+import { ENCRYPTED_FIELD_PREFIX } from "@motebit/encryption";
+import {
+  floorSyncConversation,
+  floorSyncMessage,
+  floorSyncPlan,
+  floorSyncPlanStep,
+} from "../data-sync-redaction.js";
+
+const enc = (s: string): string => ENCRYPTED_FIELD_PREFIX + s;
+const REDACTED = "[REDACTED]";
+
+const baseConv = (o: Partial<SyncConversation>): SyncConversation =>
+  ({
+    conversation_id: "c1",
+    motebit_id: "m1",
+    started_at: 1,
+    last_active_at: 2,
+    title: null,
+    summary: null,
+    message_count: 0,
+    ...o,
+  }) as SyncConversation;
+
+const baseMsg = (o: Partial<SyncConversationMessage>): SyncConversationMessage =>
+  ({
+    message_id: "msg1",
+    conversation_id: "c1",
+    motebit_id: "m1",
+    role: "user",
+    content: "",
+    tool_calls: null,
+    tool_call_id: null,
+    created_at: 1,
+    token_estimate: 0,
+    ...o,
+  }) as SyncConversationMessage;
+
+const basePlan = (o: Partial<SyncPlan>): SyncPlan =>
+  ({
+    plan_id: "p1",
+    goal_id: "g1",
+    motebit_id: "m1",
+    title: "",
+    status: "active",
+    created_at: 1,
+    updated_at: 2,
+    current_step_index: 0,
+    total_steps: 1,
+    proposal_id: null,
+    collaborative: 0,
+    ...o,
+  }) as SyncPlan;
+
+const baseStep = (o: Partial<SyncPlanStep>): SyncPlanStep =>
+  ({
+    step_id: "s1",
+    plan_id: "p1",
+    motebit_id: "m1",
+    ordinal: 0,
+    description: "",
+    prompt: "",
+    depends_on: "[]",
+    optional: false,
+    status: "pending",
+    required_capabilities: null,
+    delegation_task_id: null,
+    assigned_motebit_id: null,
+    result_summary: null,
+    error_message: null,
+    tool_calls_made: 0,
+    started_at: null,
+    completed_at: null,
+    retry_count: 0,
+    updated_at: 2,
+    ...o,
+  }) as SyncPlanStep;
+
+describe("floorSyncConversation", () => {
+  it("redacts plaintext title + summary", () => {
+    const out = floorSyncConversation(
+      baseConv({ title: "secret title", summary: "secret summary" }),
+    );
+    expect(out.title).toBe(REDACTED);
+    expect(out.summary).toBe(REDACTED);
+  });
+  it("passes ciphertext through, leaves null/empty", () => {
+    const out = floorSyncConversation(baseConv({ title: enc("ct"), summary: null }));
+    expect(out.title).toBe(enc("ct"));
+    expect(out.summary).toBeNull();
+    expect(floorSyncConversation(baseConv({ summary: "" })).summary).toBe("");
+  });
+  it("does not touch structural fields", () => {
+    const out = floorSyncConversation(baseConv({ title: "x", message_count: 7 }));
+    expect(out.conversation_id).toBe("c1");
+    expect(out.message_count).toBe(7);
+  });
+  it("is idempotent on ciphertext (re-floor is a no-op)", () => {
+    const once = floorSyncConversation(baseConv({ title: enc("ct") }));
+    expect(floorSyncConversation(once).title).toBe(enc("ct"));
+  });
+});
+
+describe("floorSyncMessage", () => {
+  it("redacts plaintext content + tool_calls", () => {
+    const out = floorSyncMessage(baseMsg({ content: "plaintext body", tool_calls: '{"x":1}' }));
+    expect(out.content).toBe(REDACTED);
+    expect(out.tool_calls).toBe(REDACTED);
+  });
+  it("passes ciphertext content through; null tool_calls stays null", () => {
+    const out = floorSyncMessage(baseMsg({ content: enc("ct"), tool_calls: null }));
+    expect(out.content).toBe(enc("ct"));
+    expect(out.tool_calls).toBeNull();
+  });
+  it("keeps role + ids", () => {
+    const out = floorSyncMessage(baseMsg({ content: "x", role: "assistant" }));
+    expect(out.role).toBe("assistant");
+    expect(out.message_id).toBe("msg1");
+  });
+});
+
+describe("floorSyncPlan", () => {
+  it("redacts plaintext title, passes ciphertext", () => {
+    expect(floorSyncPlan(basePlan({ title: "do the thing" })).title).toBe(REDACTED);
+    expect(floorSyncPlan(basePlan({ title: enc("ct") })).title).toBe(enc("ct"));
+    expect(floorSyncPlan(basePlan({ title: "" })).title).toBe("");
+  });
+});
+
+describe("floorSyncPlanStep", () => {
+  it("redacts all four plaintext free-text fields", () => {
+    const out = floorSyncPlanStep(
+      baseStep({
+        description: "plaintext desc",
+        prompt: "plaintext prompt",
+        result_summary: "plaintext result",
+        error_message: "plaintext error",
+      }),
+    );
+    expect(out.description).toBe(REDACTED);
+    expect(out.prompt).toBe(REDACTED);
+    expect(out.result_summary).toBe(REDACTED);
+    expect(out.error_message).toBe(REDACTED);
+  });
+  it("passes ciphertext through, leaves null optionals", () => {
+    const out = floorSyncPlanStep(
+      baseStep({
+        description: enc("d"),
+        prompt: enc("p"),
+        result_summary: null,
+        error_message: null,
+      }),
+    );
+    expect(out.description).toBe(enc("d"));
+    expect(out.prompt).toBe(enc("p"));
+    expect(out.result_summary).toBeNull();
+    expect(out.error_message).toBeNull();
+  });
+  it("does not regress structural fields", () => {
+    const out = floorSyncPlanStep(baseStep({ description: "x", ordinal: 3 }));
+    expect(out.ordinal).toBe(3);
+    expect(out.status).toBe("pending"); // default status preserved
+    expect(out.step_id).toBe("s1");
+  });
+});

--- a/services/relay/src/__tests__/index.test.ts
+++ b/services/relay/src/__tests__/index.test.ts
@@ -779,7 +779,10 @@ describe("Sync Relay — admin API endpoints", () => {
             motebit_id: MOTEBIT_ID,
             started_at: 1000,
             last_active_at: 2000,
-            title: "Test Chat",
+            // Production always encrypts conversation fields before push; the
+            // relay floor redacts any PLAINTEXT title. Use a ciphertext-shaped
+            // value (\0ENC: marker) so it passes the floor through byte-identical.
+            title: "\0ENC:Test Chat",
             summary: null,
             message_count: 5,
           },
@@ -799,7 +802,7 @@ describe("Sync Relay — admin API endpoints", () => {
     expect(body.motebit_id).toBe(MOTEBIT_ID);
     expect(body.conversations).toHaveLength(1);
     expect(body.conversations[0]!.conversation_id).toBe("conv-1");
-    expect(body.conversations[0]!.title).toBe("Test Chat");
+    expect(body.conversations[0]!.title).toBe("\0ENC:Test Chat");
   });
 
   it("GET /api/v1/conversations/:motebitId/:id/messages returns messages", async () => {
@@ -1594,7 +1597,8 @@ describe("Sync Relay — agent protocol", () => {
       plan_id: "plan-sync-1",
       goal_id: "goal-1",
       motebit_id: MOTEBIT_ID,
-      title: "Test plan",
+      // Encrypted-shaped (\0ENC: marker) — the relay floor redacts plaintext.
+      title: "\0ENC:Test plan",
       status: "active",
       created_at: 1000,
       updated_at: 5000,
@@ -1619,7 +1623,7 @@ describe("Sync Relay — agent protocol", () => {
     const pullBody = (await pullRes.json()) as { plans: Array<{ plan_id: string; title: string }> };
     expect(pullBody.plans).toHaveLength(1);
     expect(pullBody.plans[0]!.plan_id).toBe("plan-sync-1");
-    expect(pullBody.plans[0]!.title).toBe("Test plan");
+    expect(pullBody.plans[0]!.title).toBe("\0ENC:Test plan");
   });
 
   it("POST/GET /sync/:id/plan-steps pushes and pulls steps", async () => {
@@ -1628,14 +1632,15 @@ describe("Sync Relay — agent protocol", () => {
       plan_id: "plan-sync-1",
       motebit_id: MOTEBIT_ID,
       ordinal: 0,
-      description: "Test step",
-      prompt: "Do the thing",
+      // Encrypted-shaped free-text (\0ENC: marker) — the relay floor redacts plaintext.
+      description: "\0ENC:Test step",
+      prompt: "\0ENC:Do the thing",
       depends_on: "[]",
       optional: false,
       status: "completed",
       required_capabilities: null,
       delegation_task_id: null,
-      result_summary: "Done!",
+      result_summary: "\0ENC:Done!",
       error_message: null,
       tool_calls_made: 2,
       started_at: 2000,
@@ -1662,7 +1667,7 @@ describe("Sync Relay — agent protocol", () => {
     expect(pullBody.steps).toHaveLength(1);
     expect(pullBody.steps[0]!.step_id).toBe("step-sync-1");
     expect(pullBody.steps[0]!.status).toBe("completed");
-    expect(pullBody.steps[0]!.result_summary).toBe("Done!");
+    expect(pullBody.steps[0]!.result_summary).toBe("\0ENC:Done!");
   });
 
   it("plan sync enforces step status monotonicity on relay", async () => {

--- a/services/relay/src/__tests__/migrations.test.ts
+++ b/services/relay/src/__tests__/migrations.test.ts
@@ -5,7 +5,12 @@
  * partial failure rollback, duplicate version detection.
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { SqlJsDriver, type DatabaseDriver } from "@motebit/persistence";
+import {
+  SqlJsDriver,
+  createMotebitDatabase,
+  type DatabaseDriver,
+  type MotebitDatabase,
+} from "@motebit/persistence";
 import { runMigrations, getSchemaVersion, relayMigrations, type Migration } from "../migrations.js";
 
 let db: DatabaseDriver;
@@ -372,5 +377,131 @@ describe("migration 35 — backfill_historical_memory_deletions", () => {
 
   it("is a no-op (no throw) when the events table doesn't exist yet", () => {
     expect(() => m35.up(db)).not.toThrow();
+  });
+});
+
+describe("migration 37 — scrub_unredacted_conversation_sync_content", () => {
+  const m37 = relayMigrations.find((m) => m.version === 37)!;
+  const ENC = "\0ENC:"; // ENCRYPTED_FIELD_PREFIX
+
+  // Encrypted field markers begin with a NUL byte. sql.js (the other describes'
+  // driver) truncates TEXT at an embedded NUL on insert, so it cannot store a
+  // ciphertext sentinel faithfully; production runs on the native better-sqlite3
+  // driver (CLAUDE.md rule 13), which preserves it. Use the native driver here so
+  // the "ciphertext preserved" assertions reflect production storage.
+  let ndb: MotebitDatabase;
+  let db: DatabaseDriver;
+  beforeEach(() => {
+    ndb = createMotebitDatabase(":memory:");
+    db = ndb.db;
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  function createSyncTables() {
+    db.exec(`CREATE TABLE sync_conversations (
+      conversation_id TEXT PRIMARY KEY, motebit_id TEXT, started_at INTEGER,
+      last_active_at INTEGER, title TEXT, summary TEXT, message_count INTEGER
+    )`);
+    db.exec(`CREATE TABLE sync_conversation_messages (
+      message_id TEXT PRIMARY KEY, conversation_id TEXT, motebit_id TEXT, role TEXT,
+      content TEXT, tool_calls TEXT, tool_call_id TEXT, created_at INTEGER, token_estimate INTEGER
+    )`);
+    db.exec(`CREATE TABLE sync_plans (
+      plan_id TEXT PRIMARY KEY, goal_id TEXT, motebit_id TEXT, title TEXT, status TEXT,
+      created_at INTEGER, updated_at INTEGER, current_step_index INTEGER, total_steps INTEGER
+    )`);
+    db.exec(`CREATE TABLE sync_plan_steps (
+      step_id TEXT PRIMARY KEY, plan_id TEXT, motebit_id TEXT, ordinal INTEGER,
+      description TEXT, prompt TEXT, depends_on TEXT, optional INTEGER, status TEXT,
+      required_capabilities TEXT, delegation_task_id TEXT, result_summary TEXT,
+      error_message TEXT, tool_calls_made INTEGER, started_at INTEGER, completed_at INTEGER,
+      retry_count INTEGER, updated_at INTEGER
+    )`);
+  }
+
+  it("redacts plaintext free-text across all four sync tables, keeping ciphertext + structure", () => {
+    createSyncTables();
+    db.prepare(
+      "INSERT INTO sync_conversations (conversation_id, title, summary, message_count) VALUES (?, ?, ?, ?)",
+    ).run("c-plain", "secret title", "secret summary", 9);
+    db.prepare(
+      "INSERT INTO sync_conversations (conversation_id, title, summary) VALUES (?, ?, ?)",
+    ).run("c-enc", ENC + "ct-title", null);
+    db.prepare(
+      "INSERT INTO sync_conversation_messages (message_id, content, tool_calls) VALUES (?, ?, ?)",
+    ).run("m-plain", "my SSN is 123", '{"args":1}');
+    db.prepare(
+      "INSERT INTO sync_conversation_messages (message_id, content, tool_calls) VALUES (?, ?, ?)",
+    ).run("m-enc", ENC + "ct-body", null);
+    db.prepare("INSERT INTO sync_plans (plan_id, title) VALUES (?, ?)").run(
+      "p-plain",
+      "plan secret",
+    );
+    db.prepare(
+      "INSERT INTO sync_plan_steps (step_id, description, prompt, result_summary, error_message) VALUES (?, ?, ?, ?, ?)",
+    ).run("s-plain", "desc", "prompt", "result", "error");
+
+    m37.up(db);
+
+    const conv = db
+      .prepare(
+        "SELECT title, summary, message_count FROM sync_conversations WHERE conversation_id = ?",
+      )
+      .get("c-plain") as {
+      title: string;
+      summary: string;
+      message_count: number;
+    };
+    expect(conv.title).toBe("[REDACTED]");
+    expect(conv.summary).toBe("[REDACTED]");
+    expect(conv.message_count).toBe(9); // structural field untouched
+
+    const convEnc = db
+      .prepare("SELECT title, summary FROM sync_conversations WHERE conversation_id = ?")
+      .get("c-enc") as {
+      title: string;
+      summary: string | null;
+    };
+    expect(convEnc.title).toBe(ENC + "ct-title"); // ciphertext preserved
+    expect(convEnc.summary).toBeNull();
+
+    const msg = db
+      .prepare("SELECT content, tool_calls FROM sync_conversation_messages WHERE message_id = ?")
+      .get("m-plain") as {
+      content: string;
+      tool_calls: string;
+    };
+    expect(msg.content).toBe("[REDACTED]");
+    expect(msg.tool_calls).toBe("[REDACTED]");
+    const msgEnc = db
+      .prepare("SELECT content FROM sync_conversation_messages WHERE message_id = ?")
+      .get("m-enc") as {
+      content: string;
+    };
+    expect(msgEnc.content).toBe(ENC + "ct-body");
+
+    expect(
+      (
+        db.prepare("SELECT title FROM sync_plans WHERE plan_id = ?").get("p-plain") as {
+          title: string;
+        }
+      ).title,
+    ).toBe("[REDACTED]");
+
+    const step = db
+      .prepare(
+        "SELECT description, prompt, result_summary, error_message FROM sync_plan_steps WHERE step_id = ?",
+      )
+      .get("s-plain") as Record<string, string>;
+    expect(step.description).toBe("[REDACTED]");
+    expect(step.prompt).toBe("[REDACTED]");
+    expect(step.result_summary).toBe("[REDACTED]");
+    expect(step.error_message).toBe("[REDACTED]");
+  });
+
+  it("is a no-op (no throw) when the sync tables don't exist yet", () => {
+    expect(() => m37.up(db)).not.toThrow();
   });
 });

--- a/services/relay/src/data-sync-redaction.ts
+++ b/services/relay/src/data-sync-redaction.ts
@@ -1,0 +1,87 @@
+/**
+ * Sensitivity floor for synced conversation / message / plan data.
+ *
+ * The conversation, message, and plan sync tables hold free-text the user
+ * generated — message bodies, conversation titles/summaries, plan step prompts
+ * and results. The client encrypts every one of these fields BEFORE pushing
+ * (the `EncryptedConversation`/`EncryptedPlan` sync adapters in
+ * `@motebit/sync-engine`, keyed by a per-motebit key the relay never holds), so
+ * in normal operation the relay only ever sees opaque ciphertext carrying the
+ * `ENCRYPTED_FIELD_PREFIX` marker.
+ *
+ * Until now that was a CONVENTION enforced only on the client. A misconfigured,
+ * downgraded, or hostile pusher could POST plaintext bodies and the relay would
+ * persist them and fan them out to peer devices verbatim — the same fail-closed
+ * gap (sync pushes content with no relay-side floor) the memory-event redactor
+ * (`redaction.ts`) closes for `memory_formed`. Unlike memory, conversation
+ * content carries NO `sensitivity` field to gate on, so the floor is a pure
+ * key-acceptance decision: a field that is not encrypted is, at this boundary,
+ * unprotected content and must not land at the relay.
+ *
+ * The floor therefore runs at INGRESS — inside the storage helpers (so storage
+ * is unconditionally safe for any caller) AND on each fan-out object (so peers
+ * never receive plaintext) — on both sync surfaces (HTTP push in `data-sync.ts`,
+ * WebSocket push in `websocket.ts`). Encrypted fields pass through untouched;
+ * a plaintext content field is replaced with `[REDACTED]`. Idempotent:
+ * re-flooring an already-floored or encrypted value is a no-op. The set of
+ * floored fields is exactly the set the client adapters encrypt.
+ */
+
+import type {
+  SyncConversation,
+  SyncConversationMessage,
+  SyncPlan,
+  SyncPlanStep,
+} from "@motebit/sdk";
+import { isEncryptedField } from "@motebit/encryption";
+
+const REDACTED = "[REDACTED]";
+
+/**
+ * Floor a nullable free-text field: null/empty and encrypted values pass
+ * through; any other (plaintext) value becomes `[REDACTED]`.
+ */
+function floorOptional(value: string | null): string | null {
+  if (value == null || value === "") return value;
+  if (isEncryptedField(value)) return value;
+  return REDACTED;
+}
+
+/** Floor a required (non-null) free-text field. */
+function floorRequired(value: string): string {
+  if (value === "" || isEncryptedField(value)) return value;
+  return REDACTED;
+}
+
+export function floorSyncConversation(conv: SyncConversation): SyncConversation {
+  return {
+    ...conv,
+    title: floorOptional(conv.title),
+    summary: floorOptional(conv.summary),
+  };
+}
+
+export function floorSyncMessage(msg: SyncConversationMessage): SyncConversationMessage {
+  return {
+    ...msg,
+    content: floorRequired(msg.content),
+    tool_calls: floorOptional(msg.tool_calls),
+  };
+}
+
+export function floorSyncPlan(plan: SyncPlan): SyncPlan {
+  return {
+    ...plan,
+    title: floorRequired(plan.title),
+  };
+}
+
+export function floorSyncPlanStep(step: SyncPlanStep): SyncPlanStep {
+  return {
+    ...step,
+    description: floorRequired(step.description),
+    prompt: floorRequired(step.prompt),
+    result_summary: floorOptional(step.result_summary),
+    error_message: floorOptional(step.error_message),
+  };
+}

--- a/services/relay/src/data-sync.ts
+++ b/services/relay/src/data-sync.ts
@@ -14,6 +14,12 @@ import type {
 import { asMotebitId } from "@motebit/sdk";
 import type { DatabaseDriver } from "@motebit/persistence";
 import type { ConnectedDevice } from "./index.js";
+import {
+  floorSyncConversation,
+  floorSyncMessage,
+  floorSyncPlan,
+  floorSyncPlanStep,
+} from "./data-sync-redaction.js";
 
 export interface DataSyncDeps {
   db: DatabaseDriver;
@@ -117,7 +123,10 @@ export function createDataSyncTables(db: DatabaseDriver): void {
 
 // === Conversation Sync Helpers ===
 
-export function upsertSyncConversation(db: DatabaseDriver, conv: SyncConversation): void {
+export function upsertSyncConversation(db: DatabaseDriver, raw: SyncConversation): void {
+  // Fail-closed floor: plaintext free-text fields never persist (the client
+  // encrypts them; see data-sync-redaction.ts). Storage is safe for any caller.
+  const conv = floorSyncConversation(raw);
   db.prepare(
     `INSERT INTO sync_conversations (conversation_id, motebit_id, started_at, last_active_at, title, summary, message_count)
        VALUES (?, ?, ?, ?, ?, ?, ?)
@@ -137,7 +146,8 @@ export function upsertSyncConversation(db: DatabaseDriver, conv: SyncConversatio
   );
 }
 
-export function upsertSyncMessage(db: DatabaseDriver, msg: SyncConversationMessage): void {
+export function upsertSyncMessage(db: DatabaseDriver, raw: SyncConversationMessage): void {
+  const msg = floorSyncMessage(raw);
   db.prepare(
     `INSERT OR IGNORE INTO sync_conversation_messages
        (message_id, conversation_id, motebit_id, role, content, tool_calls, tool_call_id, created_at, token_estimate)
@@ -166,7 +176,8 @@ const STEP_STATUS_ORDER: Record<string, number> = {
   skipped: 2,
 };
 
-function upsertSyncPlan(db: DatabaseDriver, plan: SyncPlan): void {
+function upsertSyncPlan(db: DatabaseDriver, raw: SyncPlan): void {
+  const plan = floorSyncPlan(raw);
   db.prepare(
     `INSERT INTO sync_plans (plan_id, goal_id, motebit_id, title, status, created_at, updated_at, current_step_index, total_steps, proposal_id, collaborative)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -193,7 +204,8 @@ function upsertSyncPlan(db: DatabaseDriver, plan: SyncPlan): void {
   );
 }
 
-function upsertSyncPlanStep(db: DatabaseDriver, step: SyncPlanStep): void {
+function upsertSyncPlanStep(db: DatabaseDriver, raw: SyncPlanStep): void {
+  const step = floorSyncPlanStep(raw);
   // Check existing status for monotonicity
   const existing = db
     .prepare(`SELECT status, updated_at FROM sync_plan_steps WHERE step_id = ?`)
@@ -262,7 +274,10 @@ export function registerDataSyncRoutes(deps: DataSyncDeps): void {
     const peers = connections.get(motebitId);
     if (peers) {
       for (const conv of body.conversations) {
-        const payload = JSON.stringify({ type: "conversation", conversation: conv });
+        const payload = JSON.stringify({
+          type: "conversation",
+          conversation: floorSyncConversation(conv),
+        });
         for (const peer of peers) {
           if (peer.deviceId !== senderDeviceId) {
             peer.ws.send(payload);
@@ -306,7 +321,10 @@ export function registerDataSyncRoutes(deps: DataSyncDeps): void {
     const peers = connections.get(motebitId);
     if (peers) {
       for (const msg of body.messages) {
-        const payload = JSON.stringify({ type: "conversation_message", message: msg });
+        const payload = JSON.stringify({
+          type: "conversation_message",
+          message: floorSyncMessage(msg),
+        });
         for (const peer of peers) {
           if (peer.deviceId !== senderDeviceId) {
             peer.ws.send(payload);
@@ -357,7 +375,7 @@ export function registerDataSyncRoutes(deps: DataSyncDeps): void {
     const peers = connections.get(motebitId);
     if (peers) {
       for (const plan of body.plans) {
-        const payload = JSON.stringify({ type: "plan", plan });
+        const payload = JSON.stringify({ type: "plan", plan: floorSyncPlan(plan) });
         for (const peer of peers) {
           if (peer.deviceId !== senderDeviceId) {
             peer.ws.send(payload);
@@ -399,7 +417,7 @@ export function registerDataSyncRoutes(deps: DataSyncDeps): void {
     const peers = connections.get(motebitId);
     if (peers) {
       for (const step of body.steps) {
-        const payload = JSON.stringify({ type: "plan_step", step });
+        const payload = JSON.stringify({ type: "plan_step", step: floorSyncPlanStep(step) });
         for (const peer of peers) {
           if (peer.deviceId !== senderDeviceId) {
             peer.ws.send(payload);

--- a/services/relay/src/migrations.ts
+++ b/services/relay/src/migrations.ts
@@ -7,6 +7,7 @@
  */
 
 import type { DatabaseDriver } from "@motebit/persistence";
+import { isEncryptedField } from "@motebit/encryption";
 import { createLogger } from "./logger.js";
 import { redactMemoryFormedPayload } from "./redaction.js";
 
@@ -1583,6 +1584,130 @@ export const relayMigrations: Migration[] = [
       }
       if (redacted > 0) {
         logger.info("migration.backfill_historical_memory_deletions", { redacted });
+      }
+    },
+  },
+  {
+    // NOTE: version 36 is reserved for the in-flight memory_audit/consolidated
+    // scrub (PR privacy/redact-memory-audit-ingress). This migration is v37 to
+    // avoid a duplicate-version collision; since runMigrations skips
+    // version <= MAX(applied), v36 MUST land before v37 in deploy order or its
+    // scrub is skipped. Flagged in the PR.
+    version: 37,
+    name: "scrub_unredacted_conversation_sync_content",
+    up: (db) => {
+      // Sibling of the v34 memory_formed scrub, for the conversation / message /
+      // plan sync tables. Before the data-sync ingress floor
+      // (data-sync-redaction.ts) landed, the sync push paths persisted these
+      // free-text fields verbatim — a client that pushed plaintext (no
+      // field-level encryption) left it live at the relay, contradicting the
+      // E2E-encrypted-content posture. Rewrite historical rows to the shape the
+      // floor now produces: any plaintext value (non-empty, not marked with
+      // ENCRYPTED_FIELD_PREFIX) becomes [REDACTED]; ciphertext is left untouched.
+      // Driver-agnostic; idempotent (an already-[REDACTED] value re-scrubs to the
+      // same [REDACTED]). The sync_* tables are created at boot
+      // (createDataSyncTables) before relay migrations run; guard for harnesses
+      // running relayMigrations on a bare driver.
+      const REDACTED = "[REDACTED]";
+      const scrubField = (value: unknown): string | undefined => {
+        // undefined ⇒ keep column as-is; string ⇒ the replacement to write.
+        if (typeof value !== "string" || value === "") return undefined; // NULL / empty
+        if (isEncryptedField(value)) return undefined; // opaque ciphertext — keep
+        return REDACTED; // plaintext (incl. a prior [REDACTED]) — floor it
+      };
+      const tableExists = (name: string): boolean =>
+        (db
+          .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+          .get(name) as { name: string } | undefined) != null;
+      let scrubbed = 0;
+
+      if (tableExists("sync_conversations")) {
+        const rows = db
+          .prepare("SELECT conversation_id, title, summary FROM sync_conversations")
+          .all() as { conversation_id: string; title: string | null; summary: string | null }[];
+        const update = db.prepare(
+          "UPDATE sync_conversations SET title = ?, summary = ? WHERE conversation_id = ?",
+        );
+        for (const r of rows) {
+          const t = scrubField(r.title);
+          const s = scrubField(r.summary);
+          if (t === undefined && s === undefined) continue;
+          update.run(t ?? r.title, s ?? r.summary, r.conversation_id);
+          scrubbed++;
+        }
+      }
+
+      if (tableExists("sync_conversation_messages")) {
+        const rows = db
+          .prepare("SELECT message_id, content, tool_calls FROM sync_conversation_messages")
+          .all() as { message_id: string; content: string | null; tool_calls: string | null }[];
+        const update = db.prepare(
+          "UPDATE sync_conversation_messages SET content = ?, tool_calls = ? WHERE message_id = ?",
+        );
+        for (const r of rows) {
+          const content = scrubField(r.content);
+          const toolCalls = scrubField(r.tool_calls);
+          if (content === undefined && toolCalls === undefined) continue;
+          update.run(content ?? r.content, toolCalls ?? r.tool_calls, r.message_id);
+          scrubbed++;
+        }
+      }
+
+      if (tableExists("sync_plans")) {
+        const rows = db.prepare("SELECT plan_id, title FROM sync_plans").all() as {
+          plan_id: string;
+          title: string | null;
+        }[];
+        const update = db.prepare("UPDATE sync_plans SET title = ? WHERE plan_id = ?");
+        for (const r of rows) {
+          const t = scrubField(r.title);
+          if (t === undefined) continue;
+          update.run(t, r.plan_id);
+          scrubbed++;
+        }
+      }
+
+      if (tableExists("sync_plan_steps")) {
+        const rows = db
+          .prepare(
+            "SELECT step_id, description, prompt, result_summary, error_message FROM sync_plan_steps",
+          )
+          .all() as {
+          step_id: string;
+          description: string | null;
+          prompt: string | null;
+          result_summary: string | null;
+          error_message: string | null;
+        }[];
+        const update = db.prepare(
+          "UPDATE sync_plan_steps SET description = ?, prompt = ?, result_summary = ?, error_message = ? WHERE step_id = ?",
+        );
+        for (const r of rows) {
+          const description = scrubField(r.description);
+          const prompt = scrubField(r.prompt);
+          const resultSummary = scrubField(r.result_summary);
+          const errorMessage = scrubField(r.error_message);
+          if (
+            description === undefined &&
+            prompt === undefined &&
+            resultSummary === undefined &&
+            errorMessage === undefined
+          ) {
+            continue;
+          }
+          update.run(
+            description ?? r.description,
+            prompt ?? r.prompt,
+            resultSummary ?? r.result_summary,
+            errorMessage ?? r.error_message,
+            r.step_id,
+          );
+          scrubbed++;
+        }
+      }
+
+      if (scrubbed > 0) {
+        logger.info("migration.scrub_unredacted_conversation_sync_content", { scrubbed });
       }
     },
   },

--- a/services/relay/src/websocket.ts
+++ b/services/relay/src/websocket.ts
@@ -17,6 +17,7 @@ import type { EventLogEntry, SyncConversation, SyncConversationMessage } from "@
 import { AgentTaskStatus, asMotebitId } from "@motebit/sdk";
 import type { FixedWindowLimiter } from "./rate-limiter.js";
 import { upsertSyncConversation, upsertSyncMessage } from "./data-sync.js";
+import { floorSyncConversation, floorSyncMessage } from "./data-sync-redaction.js";
 import { redactSensitiveEvents } from "./redaction.js";
 import { propagateDeletionForEvent } from "./deletion-propagation.js";
 import type { TaskQueueEntry } from "./tasks.js";
@@ -428,7 +429,10 @@ export function registerWebSocketRoutes(deps: WebSocketDeps): void {
               const peers = connections.get(motebitId);
               if (peers) {
                 for (const conv of msg.conversations) {
-                  const payload = JSON.stringify({ type: "conversation", conversation: conv });
+                  const payload = JSON.stringify({
+                    type: "conversation",
+                    conversation: floorSyncConversation(conv),
+                  });
                   for (const peer of peers) {
                     if (peer.ws !== ws && peer.ws.readyState === 1) {
                       peer.ws.send(payload);
@@ -448,7 +452,10 @@ export function registerWebSocketRoutes(deps: WebSocketDeps): void {
               const peers = connections.get(motebitId);
               if (peers) {
                 for (const m of msg.messages) {
-                  const payload = JSON.stringify({ type: "conversation_message", message: m });
+                  const payload = JSON.stringify({
+                    type: "conversation_message",
+                    message: floorSyncMessage(m),
+                  });
                   for (const peer of peers) {
                     if (peer.ws !== ws && peer.ws.readyState === 1) {
                       peer.ws.send(payload);


### PR DESCRIPTION
## What

Closes the **MEDIUM privacy gap** flagged (as still-open) by PR #197: the relay's conversation/message/plan **data-sync** path — `services/relay/src/data-sync.ts` (HTTP) and `websocket.ts` (`push_conversations`/`push_messages`) — stored user free-text (message bodies, conversation `title`/`summary`, plan `title`, step `description`/`prompt`/`result_summary`/`error_message`, `tool_calls`) with **no relay-side floor**. The client `EncryptedConversation`/`EncryptedPlan` adapters encrypt these fields before push, but that was a convention enforced only client-side: a misconfigured, downgraded, or hostile pusher could POST plaintext and the relay would **persist it and fan it out to peer devices verbatim** — the same fail-closed gap the `memory_formed` redactor closes.

## How

Conversation content carries no `sensitivity` field, so the floor is a pure **key-acceptance decision**: a free-text field not carrying the encryption marker is, at the relay boundary, unprotected content.

- New `data-sync-redaction.ts` (`floorSync{Conversation,Message,Plan,PlanStep}`): encrypted fields (`ENCRYPTED_FIELD_PREFIX`) pass through byte-identical; plaintext → `[REDACTED]`. The floored set is exactly the set the client adapters encrypt.
- Enforced at **ingress** on both surfaces: inside the storage helpers (storage unconditionally safe for any caller) **and** on every fan-out object (peers never receive plaintext). `websocket.ts` push paths were a second, independent leak point — both covered.
- **Canonical sentinel**: `"\0ENC:"` was a private const **duplicated in both sync-engine adapters** (already drifting). Promoted to `ENCRYPTED_FIELD_PREFIX` + `isEncryptedField` in `@motebit/encryption` (owns the envelope); both adapters and the relay floor + scrub import one source — a cross-package wire sentinel can no longer drift.
- **Migration v37** scrubs already-leaked historical plaintext across all four sync tables (mirrors the v34 `memory_formed` scrub; encrypted/empty rows untouched; idempotent).

## ⚠️ Merge/deploy ordering

This migration is **v37** because **#197** (memory_audit) already claims **v36**. `runMigrations` is a high-water mark (skips `version <= MAX(applied)`), so **#197 must merge/deploy before this PR** — otherwise its v36 scrub is silently skipped. The ingress floor itself has no migration dependency.

## Tests

- Floor unit tests for all four types (plaintext→redacted / ciphertext-passthrough / null-empty / structure preserved).
- Relay ingress + WS fan-out tests (plaintext redacted at the boundary and in the peer frame; ciphertext passes through).
- v37 scrub test on the **native better-sqlite3** driver — sql.js truncates the NUL-led marker, production is native (CLAUDE.md rule 13).
- `ENCRYPTED_FIELD_PREFIX` / `isEncryptedField` contract test.
- Updated mechanics tests that round-tripped plaintext to use ciphertext-shaped values (production always encrypts).

Full relay suite (1363) + sync-engine (187) + encryption (243) + all 119 drift gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
