### PR TITLE
fix(proxy/relay): stop silently dropping cloud-usage debits; make them idempotent

### DIFF
--- a/services/proxy/src/app/v1/messages/__tests__/debit-relay.test.ts
+++ b/services/proxy/src/app/v1/messages/__tests__/debit-relay.test.ts
@@ -1,0 +1,131 @@
+/**
+ * debitRelay — retry + reconciliation behavior.
+ *
+ * The relay debit endpoint is idempotent on reference_id, so debitRelay retries
+ * transient failures with backoff (using the same reference, which cannot
+ * double-charge) and, only after exhausting them, emits a structured
+ * `proxy.debit_failed` event so a dropped debit is reconcilable from logs
+ * instead of silently lost (the old `void fetch(...).catch(() => {})` behavior).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { debitRelay, DEBIT_MAX_ATTEMPTS } from "../route";
+
+const REF = "req-abc";
+const MID = "mote-1";
+const AMOUNT = 12_345;
+
+let errLines: string[];
+
+beforeEach(() => {
+  process.env.RELAY_PROXY_SECRET = "secret";
+  process.env.RELAY_API_URL = "https://relay.test";
+  errLines = [];
+  vi.spyOn(console, "error").mockImplementation((...a: unknown[]) => {
+    errLines.push(a.map(String).join(" "));
+  });
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  delete process.env.RELAY_PROXY_SECRET;
+  delete process.env.RELAY_API_URL;
+});
+
+function mockFetch(
+  ...responses: Array<{ ok: boolean; status: number } | Error>
+): ReturnType<typeof vi.fn> {
+  let i = 0;
+  const fn = vi.fn(() => {
+    const r = responses[Math.min(i, responses.length - 1)];
+    i++;
+    if (r instanceof Error) return Promise.reject(r);
+    return Promise.resolve(r as Response);
+  });
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+function debitFailedEvents(): Array<Record<string, unknown>> {
+  return errLines
+    .map((l) => {
+      try {
+        return JSON.parse(l) as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    })
+    .filter((e): e is Record<string, unknown> => e?.event === "proxy.debit_failed");
+}
+
+describe("debitRelay", () => {
+  it("no-ops without a relay secret (no fetch, no failure event)", async () => {
+    delete process.env.RELAY_PROXY_SECRET;
+    const fetchFn = mockFetch({ ok: true, status: 200 });
+    await debitRelay(MID, AMOUNT, REF);
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(debitFailedEvents()).toHaveLength(0);
+  });
+
+  it("no-ops for a non-positive amount", async () => {
+    const fetchFn = mockFetch({ ok: true, status: 200 });
+    await debitRelay(MID, 0, REF);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("succeeds on the first attempt — one call, no retry, no failure event", async () => {
+    const fetchFn = mockFetch({ ok: true, status: 200 });
+    const p = debitRelay(MID, AMOUNT, REF);
+    await vi.runAllTimersAsync();
+    await p;
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(debitFailedEvents()).toHaveLength(0);
+  });
+
+  it("retries a transient 5xx and succeeds without a failure event", async () => {
+    const fetchFn = mockFetch({ ok: false, status: 503 }, { ok: true, status: 200 });
+    const p = debitRelay(MID, AMOUNT, REF);
+    await vi.runAllTimersAsync();
+    await p;
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(debitFailedEvents()).toHaveLength(0);
+  });
+
+  it("retries a network error and succeeds", async () => {
+    const fetchFn = mockFetch(new Error("ECONNRESET"), { ok: true, status: 200 });
+    const p = debitRelay(MID, AMOUNT, REF);
+    await vi.runAllTimersAsync();
+    await p;
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(debitFailedEvents()).toHaveLength(0);
+  });
+
+  it("exhausts retries on persistent 5xx and emits a reconcilable proxy.debit_failed", async () => {
+    const fetchFn = mockFetch({ ok: false, status: 500 });
+    const p = debitRelay(MID, AMOUNT, REF);
+    await vi.runAllTimersAsync();
+    await p;
+    expect(fetchFn).toHaveBeenCalledTimes(DEBIT_MAX_ATTEMPTS);
+    const events = debitFailedEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      event: "proxy.debit_failed",
+      motebitId: MID,
+      amountMicro: AMOUNT,
+      requestId: REF,
+      error: "HTTP 500",
+    });
+  });
+
+  it("fails fast on a 4xx (no retry) but still records the dropped debit", async () => {
+    const fetchFn = mockFetch({ ok: false, status: 401 });
+    const p = debitRelay(MID, AMOUNT, REF);
+    await vi.runAllTimersAsync();
+    await p;
+    expect(fetchFn).toHaveBeenCalledTimes(1); // 4xx not retried
+    const events = debitFailedEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]!.error).toBe("HTTP 401");
+  });
+});

--- a/services/proxy/src/app/v1/messages/route.ts
+++ b/services/proxy/src/app/v1/messages/route.ts
@@ -94,21 +94,67 @@ Message: ${message.slice(0, 500)}`,
   }
 }
 
-/** Fire-and-forget debit call to the relay. */
-function debitRelay(motebitId: string, amountMicro: number, referenceId: string): void {
+/** @internal — exported only for unit tests. */
+export const DEBIT_MAX_ATTEMPTS = 3;
+
+/**
+ * Debit the relay for actual compute cost.
+ *
+ * Runs AFTER the response stream is returned to the client (in the stream pump's
+ * `finally`), so it never delays the user — but it must NOT silently drop
+ * revenue, which the old `void fetch(...).catch(() => {})` did on any network
+ * error, AND on every non-2xx (a 500/401 resolves the promise, so `.catch` never
+ * fired). The relay debit endpoint is idempotent on `reference_id`, so transient
+ * failures (network blip, relay restart, 5xx) are retried with backoff using the
+ * same reference — a retry after a missed 200 cannot double-charge. A 4xx is a
+ * permanent error (bad secret / bad amount) and is not retried. On exhaustion we
+ * emit a structured `proxy.debit_failed` event so the dropped debit is
+ * reconcilable from logs rather than vanishing.
+ */
+export async function debitRelay(
+  motebitId: string,
+  amountMicro: number,
+  referenceId: string,
+): Promise<void> {
   const relayUrl = process.env.RELAY_API_URL ?? "https://relay.motebit.com";
   const secret = process.env.RELAY_PROXY_SECRET;
   if (!secret || amountMicro <= 0) return;
 
-  void fetch(`${relayUrl}/api/v1/agents/${motebitId}/debit`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json", "x-relay-secret": secret },
-    body: JSON.stringify({
-      amount: amountMicro,
-      reference_id: referenceId,
-      description: "Cloud AI usage",
+  let lastError = "";
+  for (let attempt = 1; attempt <= DEBIT_MAX_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(`${relayUrl}/api/v1/agents/${motebitId}/debit`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-relay-secret": secret },
+        body: JSON.stringify({
+          amount: amountMicro,
+          reference_id: referenceId,
+          description: "Cloud AI usage",
+        }),
+      });
+      if (res.ok) return;
+      lastError = `HTTP ${res.status}`;
+      // 4xx won't change on retry (bad secret, malformed amount) — fail fast.
+      if (res.status >= 400 && res.status < 500) break;
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+    }
+    if (attempt < DEBIT_MAX_ATTEMPTS) {
+      await new Promise((resolve) => setTimeout(resolve, attempt * 250));
+    }
+  }
+
+  // Exhausted retries — do NOT swallow. This event is the reconciliation trail
+  // for a debit the relay never recorded (lost revenue if not recovered).
+  console.error(
+    JSON.stringify({
+      event: "proxy.debit_failed",
+      requestId: referenceId,
+      motebitId,
+      amountMicro,
+      error: lastError,
     }),
-  }).catch(() => {});
+  );
 }
 
 // ── Provider API adapters ───────────────────────────────────────────────
@@ -598,7 +644,10 @@ export async function POST(request: Request): Promise<Response> {
             motebitId: mid,
           }),
         );
-        if (cost > 0) debitRelay(mid, cost, requestId);
+        // Awaited so retries complete before the pump task ends; the client
+        // already holds the full response (writer.close() above), so this never
+        // delays the user.
+        if (cost > 0) await debitRelay(mid, cost, requestId);
       }
     })();
 

--- a/services/relay/src/__tests__/debit-endpoint.test.ts
+++ b/services/relay/src/__tests__/debit-endpoint.test.ts
@@ -196,4 +196,79 @@ describe("POST /api/v1/agents/:motebitId/debit", () => {
     expect(b3.success).toBe(false);
     expect(b3.balance).toBe(0);
   });
+
+  // ── Idempotency on reference_id ──────────────────────────────────────────
+  // The proxy debits fire-and-forget after serving the response and retries a
+  // failed debit with the SAME reference_id. The endpoint must apply it once.
+
+  it("is idempotent on reference_id — a retried debit does not double-charge", async () => {
+    await deposit(relay, motebitId, 0.1); // 100,000 micro
+
+    const first = await debitRequest(
+      relay,
+      motebitId,
+      { amount: 30_000, reference_id: "ref-retry" },
+      RELAY_SECRET,
+    );
+    const b1 = (await first.json()) as { success: boolean; balance: number; idempotent?: boolean };
+    expect(b1.success).toBe(true);
+    expect(b1.balance).toBe(70_000);
+    expect(b1.idempotent).toBeUndefined();
+
+    // Same reference_id again (a retry) — must NOT debit a second time.
+    const retry = await debitRequest(
+      relay,
+      motebitId,
+      { amount: 30_000, reference_id: "ref-retry" },
+      RELAY_SECRET,
+    );
+    expect(retry.status).toBe(200);
+    const b2 = (await retry.json()) as { success: boolean; balance: number; idempotent?: boolean };
+    expect(b2.success).toBe(true);
+    expect(b2.idempotent).toBe(true);
+    expect(b2.balance).toBe(70_000); // unchanged — no second charge
+  });
+
+  it("idempotent replay reports success even if the balance later dropped to zero", async () => {
+    await deposit(relay, motebitId, 0.05); // 50,000 micro
+    // Original debit recorded under ref-A.
+    await debitRequest(relay, motebitId, { amount: 30_000, reference_id: "ref-A" }, RELAY_SECRET);
+    // A different request spends the rest.
+    await debitRequest(relay, motebitId, { amount: 20_000, reference_id: "ref-B" }, RELAY_SECRET);
+
+    // Retry of ref-A: already recorded, so a no-op replay — success, no debit,
+    // not the insufficient-balance path even though spendable is now 0.
+    const retry = await debitRequest(
+      relay,
+      motebitId,
+      { amount: 30_000, reference_id: "ref-A" },
+      RELAY_SECRET,
+    );
+    const body = (await retry.json()) as {
+      success: boolean;
+      balance: number;
+      idempotent?: boolean;
+    };
+    expect(body.success).toBe(true);
+    expect(body.idempotent).toBe(true);
+    expect(body.balance).toBe(0);
+  });
+
+  it("distinct reference_ids both apply (idempotency does not over-dedupe)", async () => {
+    await deposit(relay, motebitId, 0.1); // 100,000 micro
+    const r1 = await debitRequest(
+      relay,
+      motebitId,
+      { amount: 10_000, reference_id: "ref-x" },
+      RELAY_SECRET,
+    );
+    expect(((await r1.json()) as { balance: number }).balance).toBe(90_000);
+    const r2 = await debitRequest(
+      relay,
+      motebitId,
+      { amount: 10_000, reference_id: "ref-y" },
+      RELAY_SECRET,
+    );
+    expect(((await r2.json()) as { balance: number }).balance).toBe(80_000);
+  });
 });

--- a/services/relay/src/account-store-sqlite.ts
+++ b/services/relay/src/account-store-sqlite.ts
@@ -270,6 +270,21 @@ export class SqliteAccountStore implements AccountStore {
     return row !== undefined;
   }
 
+  /**
+   * True when a `fee` debit with this reference already exists. The cloud proxy
+   * uses the per-request id as `reference_id` and retries a failed debit with
+   * the SAME reference, so the debit endpoint dedupes on this to make retries
+   * idempotent (re-applying would double-charge the user).
+   */
+  hasFeeWithReference(motebitId: string, referenceId: string): boolean {
+    const row = this.db
+      .prepare(
+        "SELECT 1 FROM relay_transactions WHERE motebit_id = ? AND reference_id = ? AND type = 'fee' LIMIT 1",
+      )
+      .get(motebitId, referenceId) as Record<string, unknown> | undefined;
+    return row !== undefined;
+  }
+
   getAllocationHoldRemaining(referenceId: string): number {
     // Ledger amounts are signed (debits negative, credits positive), so the
     // hold-minus-releases net for this reference is -SUM(amount). Floored at

--- a/services/relay/src/accounts.ts
+++ b/services/relay/src/accounts.ts
@@ -179,6 +179,15 @@ export function hasTransactionWithReference(
   return sqliteAccountStoreFor(db).hasDepositWithReference(motebitId, referenceId);
 }
 
+/** True when a `fee` debit with this reference already exists (proxy-debit idempotency). */
+export function hasFeeWithReference(
+  db: DatabaseDriver,
+  motebitId: string,
+  referenceId: string,
+): boolean {
+  return sqliteAccountStoreFor(db).hasFeeWithReference(motebitId, referenceId);
+}
+
 export function getAllocationHoldRemaining(db: DatabaseDriver, referenceId: string): number {
   return sqliteAccountStoreFor(db).getAllocationHoldRemaining(referenceId);
 }

--- a/services/relay/src/subscriptions.ts
+++ b/services/relay/src/subscriptions.ts
@@ -22,6 +22,7 @@ import {
   getOrCreateAccount,
   creditAccount,
   debitSpendableAccount,
+  hasFeeWithReference,
   toMicro,
   fromMicro,
 } from "./accounts.js";
@@ -203,6 +204,26 @@ export function registerProxyTokenRoutes(
 
     if (typeof body.amount !== "number" || body.amount <= 0) {
       return c.json({ error: "amount must be a positive number (micro-units)" }, 400);
+    }
+
+    // Idempotency. The proxy debits AFTER serving the response (fire-and-forget)
+    // and retries a failed debit with the SAME reference_id — it cannot tell a
+    // dropped request from a lost 200. Re-applying would double-charge the user,
+    // so a debit whose reference_id already recorded a `fee` is a no-op replay:
+    // return success with the current balance. No `await` between this check and
+    // the debit below, so the read+write stays atomic within this process (the
+    // relay is single-instance; better-sqlite3 is synchronous).
+    if (
+      typeof body.reference_id === "string" &&
+      body.reference_id !== "" &&
+      hasFeeWithReference(db, motebitId, body.reference_id)
+    ) {
+      const balance = getAccountBalance(db, motebitId)?.balance ?? 0;
+      logger.info("proxy-debit.idempotent_replay", {
+        motebitId,
+        referenceId: body.reference_id,
+      });
+      return c.json({ success: true, balance, idempotent: true });
     }
 
     // Spend-side debit: a worker's recent/disputed settlement earnings are


### PR DESCRIPTION
## What

Closes the **proxy debit revenue leak** from the repo audit (confirmed against code). The proxy debited the relay for cloud compute with fire-and-forget `void fetch(...).catch(() => {})` after serving the response — two silent-loss modes:

1. A network error was swallowed by `.catch`.
2. **Every non-2xx slipped through** — a 500/401 *resolves* the promise, so `.catch` never fired.

A failed debit vanished with no retry, no log, no record. Lost, invisible revenue.

It couldn't safely retry, because the relay debit endpoint was **not idempotent**: `debitSpendable` inserts a `fee` transaction keyed by `reference_id` but never deduped, so retrying the same `reference_id` would double-charge the user.

## Fix (two-sided)

**Relay** — the debit endpoint is now idempotent on `reference_id`. Before debiting, if a `fee` transaction with that reference already exists it's a no-op replay → return `{success: true, balance, idempotent: true}` (new `hasFeeWithReference`, mirrors `hasDepositWithReference`). No `await` between the check and the debit, so the read+write stays atomic within the single-instance, synchronous-`better-sqlite3` relay.

**Proxy** — `debitRelay` now:
- retries transient failures (network / 5xx) with backoff using the **same** `reference_id` — safe given the idempotency above; a retry after a missed 200 cannot double-charge;
- fails fast on 4xx (bad secret / amount — won't fix on retry);
- on exhausting retries, emits a structured `proxy.debit_failed` event so the dropped debit is **reconcilable from logs** instead of vanishing;
- is awaited in the stream pump's `finally` so retries finish before the task ends — the client already holds the full response, so it never delays the user.

## Tests

- Relay debit idempotency: a retried debit doesn't double-charge; replay succeeds even after the balance later hits zero; distinct references still both apply.
- Proxy `debitRelay`: first-attempt success, 5xx/network retry-then-succeed, 4xx fail-fast, and exhaustion → exactly `DEBIT_MAX_ATTEMPTS` calls + one `proxy.debit_failed` (fake timers drive the backoff).

Relay (1362) + proxy (216) suites + all 119 drift gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
