### PR TITLE
fix(ux): honest failure states across four sibling error-handling gaps

### DIFF
--- a/apps/desktop/src/__tests__/slab-items-screenshot.test.ts
+++ b/apps/desktop/src/__tests__/slab-items-screenshot.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Desktop slab screenshot extraction — sibling of
+ * `apps/web/src/__tests__/slab-items-screenshot.test.ts`.
+ *
+ * Regression guard for the desktop-only drop: the web `extractScreenshot`
+ * accepted both `screenshot` and `navigate` kinds (v1.3 navigate returns inline
+ * bytes), but desktop accepted only `screenshot`, so a post-navigate observation
+ * fell through to the text reader instead of rendering the page. Pure-function
+ * tests, no DOM.
+ */
+import { describe, it, expect } from "vitest";
+import { extractScreenshot } from "../ui/slab-items.js";
+
+const BYTES = "iVBORw0KGgo="; // truncated PNG magic header
+
+describe("extractScreenshot (desktop)", () => {
+  it("extracts a screenshot-kind result with bytes", () => {
+    const out = extractScreenshot({ kind: "screenshot", bytes_base64: BYTES, image_format: "png" });
+    expect(out).not.toBeNull();
+    expect(out!.bytes_base64).toBe(BYTES);
+    expect(out!.image_format).toBe("png");
+  });
+
+  it("extracts a navigate-kind result that carries inline bytes (the fix)", () => {
+    const out = extractScreenshot({
+      kind: "navigate",
+      bytes_base64: BYTES,
+      image_format: "png",
+      width: 1280,
+      height: 720,
+    });
+    expect(out).not.toBeNull();
+    expect(out!.bytes_base64).toBe(BYTES);
+    expect(out!.width).toBe(1280);
+    expect(out!.height).toBe(720);
+  });
+
+  it("returns null for a navigate result with no inline bytes (falls through to reader)", () => {
+    expect(extractScreenshot({ kind: "navigate", ok: true })).toBeNull();
+    expect(extractScreenshot({ kind: "navigate", bytes_base64: "" })).toBeNull();
+  });
+
+  it("returns null for non-screenshot/non-navigate kinds and malformed input", () => {
+    expect(extractScreenshot({ kind: "click", ok: true })).toBeNull();
+    expect(extractScreenshot({ context: "https://example.com", result: "page text" })).toBeNull();
+    expect(extractScreenshot({ kind: "screenshot" })).toBeNull(); // no bytes
+    expect(extractScreenshot({ kind: "screenshot", bytes_base64: 42 })).toBeNull();
+    expect(extractScreenshot(null)).toBeNull();
+    expect(extractScreenshot(undefined)).toBeNull();
+    expect(extractScreenshot("a string")).toBeNull();
+  });
+});

--- a/apps/desktop/src/ui/slab-items.ts
+++ b/apps/desktop/src/ui/slab-items.ts
@@ -769,7 +769,14 @@ export interface ScreenshotPayload {
 export function extractScreenshot(result: unknown): ScreenshotPayload | null {
   if (result === null || typeof result !== "object") return null;
   const r = result as Record<string, unknown>;
-  if (r.kind !== "screenshot") return null;
+  // Two action kinds carry inline screenshot bytes: the explicit `screenshot`
+  // action (always returns bytes) and the `navigate` action (v1.3 hardening —
+  // returns inline bytes so the slab shows the page right after navigation
+  // without depending on the live-screencast deploy). Both produce the same
+  // renderable payload. Sibling of `apps/web/src/ui/slab-items.ts`; the web side
+  // accepted `navigate` and desktop did not, so a post-navigate observation fell
+  // through to the text reader here instead of rendering the page.
+  if (r.kind !== "screenshot" && r.kind !== "navigate") return null;
   const bytes = r.bytes_base64;
   if (typeof bytes !== "string" || bytes.length === 0) return null;
   const format = typeof r.image_format === "string" ? r.image_format : "png";

--- a/apps/mobile/src/components/AgentsPanel.tsx
+++ b/apps/mobile/src/components/AgentsPanel.tsx
@@ -258,6 +258,14 @@ export function AgentsPanel({ visible, app, onClose }: AgentsPanelProps): React.
           <View style={styles.loadingContainer}>
             <ActivityIndicator size="small" color={colors.accent} />
           </View>
+        ) : state.error !== null ? (
+          // A fetch failure (relay unreachable / non-2xx) must NOT look like
+          // "you have no agents" — the controller sets `error`, so surface it
+          // distinctly from the honest-empty states below.
+          <View style={styles.emptyContainer}>
+            <Text style={styles.emptyText}>Couldn't reach the relay.</Text>
+            <Text style={styles.emptySubtext}>{state.error}</Text>
+          </View>
         ) : state.activeTab === "known" ? (
           <FlatList
             data={state.known}

--- a/apps/mobile/src/components/ConversationsPanel.tsx
+++ b/apps/mobile/src/components/ConversationsPanel.tsx
@@ -39,10 +39,19 @@ export function ConversationsPanel({
   const colors = useTheme();
   const styles = useMemo(() => createStyles(colors), [colors]);
   const [conversations, setConversations] = useState<ConversationItem[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   const refresh = useCallback(() => {
-    const list = app.listConversations(50);
-    setConversations(list);
+    // A load failure (e.g. local store error) must not surface as the
+    // honest-empty "No conversations yet" — distinguish it, and never let the
+    // exception escape the panel.
+    try {
+      const list = app.listConversations(50);
+      setConversations(list);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
   }, [app]);
 
   useEffect(() => {
@@ -75,7 +84,11 @@ export function ConversationsPanel({
         </View>
 
         {/* List */}
-        {conversations.length === 0 ? (
+        {error !== null ? (
+          <View style={styles.emptyContainer}>
+            <Text style={styles.emptyText}>Couldn't load conversations.</Text>
+          </View>
+        ) : conversations.length === 0 ? (
           <View style={styles.emptyContainer}>
             <Text style={styles.emptyText}>No conversations yet.</Text>
           </View>

--- a/apps/web/src/ui/pairing.ts
+++ b/apps/web/src/ui/pairing.ts
@@ -12,6 +12,10 @@ import type { WebContext } from "../types";
 import { loadSyncUrl, DEFAULT_RELAY_URL, normalizeRelayUrl } from "../storage";
 
 const POLL_INTERVAL_MS = 2000;
+// Consecutive poll failures before we tell the user the connection dropped.
+// One transient blip shouldn't flash a scary message; ~6s of silence should.
+// We keep polling either way (recoverable), so it auto-clears on reconnect.
+const POLL_FAILURE_THRESHOLD = 3;
 
 // DOM elements
 const backdrop = document.getElementById("pairing-backdrop") as HTMLDivElement;
@@ -108,13 +112,20 @@ export function startLinkDevice(ctx: WebContext): void {
         codeDisplay.textContent = pairingCode;
         codeDisplay.style.display = "block";
         connectBtn.remove();
-        setStatus("Show this code on the other device");
+        const linkWaitingText = "Show this code on the other device";
+        setStatus(linkWaitingText);
 
         // Poll for claim
+        let pollFailures = 0;
         pollTimer = setInterval(() => {
           void (async () => {
             try {
               const session = await ctx.app.getPairingSession(url, pairingId);
+              // Relay answered — clear any prior connection-lost notice.
+              if (pollFailures > 0) {
+                pollFailures = 0;
+                if (status.textContent?.startsWith("Connection lost")) setStatus(linkWaitingText);
+              }
               if (session.status === "claimed") {
                 if (pollTimer) {
                   clearInterval(pollTimer);
@@ -169,7 +180,13 @@ export function startLinkDevice(ctx: WebContext): void {
                 });
               }
             } catch {
-              // Poll error — keep trying
+              // Poll error — keep polling (recoverable), but after a sustained
+              // run of failures tell the user instead of leaving them on a
+              // "show this code" screen that will never advance.
+              pollFailures++;
+              if (pollFailures >= POLL_FAILURE_THRESHOLD) {
+                setStatus("Connection lost — retrying…");
+              }
             }
           })();
         }, POLL_INTERVAL_MS);
@@ -218,13 +235,20 @@ export function startClaimDevice(ctx: WebContext): void {
         inputRow.style.display = "none";
         urlRow.style.display = "none";
         submitBtn.remove();
-        setStatus("Waiting for approval from the other device...");
+        const claimWaitingText = "Waiting for approval from the other device...";
+        setStatus(claimWaitingText);
 
         // Poll for approval
+        let pollFailures = 0;
         pollTimer = setInterval(() => {
           void (async () => {
             try {
               const result = await ctx.app.pollPairingStatus(url, pairingId);
+              // Relay answered — clear any prior connection-lost notice.
+              if (pollFailures > 0) {
+                pollFailures = 0;
+                if (status.textContent?.startsWith("Connection lost")) setStatus(claimWaitingText);
+              }
               if (result.status === "approved" && result.device_id && result.motebit_id) {
                 if (pollTimer) {
                   clearInterval(pollTimer);
@@ -264,7 +288,13 @@ export function startClaimDevice(ctx: WebContext): void {
                 setStatus("Pairing was denied by the other device");
               }
             } catch {
-              // Poll error — keep trying
+              // Poll error — keep polling (recoverable), but after a sustained
+              // run of failures surface it instead of leaving the user on a
+              // "waiting for approval" screen that will never resolve.
+              pollFailures++;
+              if (pollFailures >= POLL_FAILURE_THRESHOLD) {
+                setStatus("Connection lost — retrying…");
+              }
             }
           })();
         }, POLL_INTERVAL_MS);


### PR DESCRIPTION
## What

A **sibling-boundary sweep** of how the surfaces behave on the *unhappy* path (the audit's UX-resilience cluster). Four spots where a failure was swallowed or rendered as honest-empty, so the user couldn't tell "broken" from "nothing here yet":

### 1. Desktop slab dropped the post-navigate screenshot
`apps/desktop/src/ui/slab-items.ts` — `extractScreenshot` accepted only `kind: "screenshot"`, but the web sibling also accepts `navigate` (v1.3 returns inline bytes so the slab shows the page right after navigation). Desktop fell through to the text reader instead of rendering the page. Added the `navigate` arm + ported the explaining comment. **Unit test added** mirroring web's.

### 2. Mobile Agents panel showed "no agents" when the relay was down
`apps/mobile/src/components/AgentsPanel.tsx` — the controller sets `state.error` on a fetch failure, but the render never checked it: a relay-down looked identical to a legitimately empty trust graph. Added an error branch before the empty states, mirroring `ActivityPanel`.

### 3. Mobile Conversations panel had no failure guard
`apps/mobile/src/components/ConversationsPanel.tsx` — `refresh()` called `listConversations` with no try/catch and no error state; a local-store failure either escaped the component or rendered the honest-empty "No conversations yet." Wrapped it + added a distinct error state.

### 4. Web pairing silently swallowed poll failures
`apps/web/src/ui/pairing.ts` — both flows (Device A generate-code, Device B claim) had `catch { /* keep trying */ }` on the poll loop, so a dropped connection left the user on "show this code" / "waiting for approval" **forever** with no signal. Now after a sustained run of failures (`POLL_FAILURE_THRESHOLD`, ~6s) it shows "Connection lost — retrying…" **without tearing down** the dialog — it keeps polling and auto-clears the notice on reconnect. (The audit described this as "tears down on recoverable error"; verifying against source, the initial-claim error path is already correct — inline error + re-enable — and the real gap was the silent poll-catch. Fixed the actual issue; initial-claim path untouched.)

## Tests

Only the desktop fix is a pure function with a test harness (added — covers screenshot kind, the new navigate-with-bytes case, navigate-without-bytes → null, and malformed input). The three UI fixes have no render-test harness in-repo (mobile tests are logic-only; web pairing is DOM-driven), so they're verified by typecheck + faithfully mirroring the existing sibling patterns (`ActivityPanel`, the correct initial-claim path).

Desktop (509) + web (539) + mobile (402) suites + all 119 drift gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
