### PR TITLE
chore: close the audit's LOW items (3 real fixes, 1 false positive)

### DIFF
--- a/apps/operator/src/__tests__/api.test.ts
+++ b/apps/operator/src/__tests__/api.test.ts
@@ -151,10 +151,9 @@ describe("fetchDisputes", () => {
 });
 
 describe("fetchFees", () => {
-  it("returns null when /api/v1/admin/fees is 404 (endpoint pending)", async () => {
+  it("throws ApiError on 404 (endpoint is live — a 404 means a misconfigured relay)", async () => {
     mockFetch({ error: "not_found" }, 404);
-    const result = await fetchFees();
-    expect(result).toBeNull();
+    await expect(fetchFees()).rejects.toThrow(ApiError);
   });
 
   it("returns body when endpoint is live", async () => {
@@ -167,9 +166,8 @@ describe("fetchFees", () => {
       sample_window_days: 30,
     });
     const result = await fetchFees();
-    expect(result).not.toBeNull();
-    expect(result!.total_collected_micro).toBe(12500000);
-    expect(result!.fee_rate).toBe(0.05);
+    expect(result.total_collected_micro).toBe(12500000);
+    expect(result.fee_rate).toBe(0.05);
   });
 });
 

--- a/apps/operator/src/api.ts
+++ b/apps/operator/src/api.ts
@@ -206,11 +206,12 @@ export interface FeesResponse {
   sample_window_days: number;
 }
 
-export function fetchFees(signal?: AbortSignal): Promise<FeesResponse | null> {
-  return apiFetch<FeesResponse>(`/api/v1/admin/fees`, { signal }).catch((err) => {
-    if (err instanceof ApiError && err.status === 404) return null;
-    throw err;
-  });
+export function fetchFees(signal?: AbortSignal): Promise<FeesResponse> {
+  // `/api/v1/admin/fees` is live (relay `index.ts`). It previously caught a 404
+  // and returned `null` to render a "ships in a follow-up" placeholder; now a
+  // 404 means a misconfigured or out-of-date relay and surfaces as an honest
+  // error like any other failure, not a permanent "pending" state.
+  return apiFetch<FeesResponse>(`/api/v1/admin/fees`, { signal });
 }
 
 // === Credential anchoring ===

--- a/apps/operator/src/components/FeesPanel.tsx
+++ b/apps/operator/src/components/FeesPanel.tsx
@@ -45,21 +45,17 @@ export function FeesPanel(): React.ReactElement {
   }
 
   if (data == null) {
+    // The endpoint is live, so a successful load always sets `data`; reaching
+    // here means the fetch failed. Show the error honestly (no "pending" copy).
     return React.createElement(
       "div",
       { className: "panel" },
       React.createElement("h2", null, "Fees"),
-      error != null
-        ? React.createElement(
-            "p",
-            { className: "empty", style: { color: "var(--red)" } },
-            `Error: ${error}`,
-          )
-        : React.createElement(
-            "p",
-            { className: "empty" },
-            "Endpoint not yet available (/api/v1/admin/fees ships in a follow-up commit). Aggregation panel will render once it's live.",
-          ),
+      React.createElement(
+        "p",
+        { className: "empty", style: { color: "var(--red)" } },
+        error != null ? `Error: ${error}` : "Could not load fees.",
+      ),
     );
   }
 

--- a/packages/tools/src/builtins/computer.ts
+++ b/packages/tools/src/builtins/computer.ts
@@ -4,12 +4,17 @@
  * injection, scroll. One tool; the `action` argument is a nested
  * discriminated variant per the `spec/computer-use-v1.md` wire format.
  *
- * Today this handler is a structured stub: every call returns a typed
- * failure reason until the desktop Tauri bridge (Rust screen-capture +
- * input injection + OS accessibility APIs) lands. The tool definition and
- * wire-format parity are finalized so the Rust backend can drop in behind
- * a stable contract without touching any of the signed-receipt,
- * governance, or UI wiring.
+ * This handler is backend-agnostic: it dispatches each action to an injected
+ * backend and shapes the result — or a typed failure `reason` — into a
+ * `ToolResult`. A real dispatcher is wired wherever the OS/world is reachable:
+ * the `desktop_drive` mode on desktop, and the cloud-browser dispatcher for
+ * `virtual_browser` (`packages/runtime/src/cloud-browser-dispatcher.ts`, live).
+ * When NO dispatcher is injected the handler returns a typed failure reason, so
+ * a surface that cannot reach the OS degrades honestly (defense-in-depth). The
+ * tool definition and wire-format parity (`spec/computer-use-v1.md`) are stable,
+ * so a new backend (e.g. the desktop Tauri Rust screen-capture / input-injection
+ * bridge) drops in behind the contract without touching any of the
+ * signed-receipt, governance, or UI wiring.
  *
  * Surface support (`docs/doctrine/motebit-computer.md` § "Embodiment
  * modes"): the `desktop_drive` mode registers this tool on desktop with a

--- a/services/relay/src/__tests__/batch-withdrawals.test.ts
+++ b/services/relay/src/__tests__/batch-withdrawals.test.ts
@@ -424,6 +424,49 @@ describe("evaluateAndFireRail — batch-capable rail", () => {
       .get() as { n: number };
     expect(fired.n).toBe(2);
   });
+
+  it("falls back to serial when two motebits share an idempotency_key (no mis-attribution)", async () => {
+    const db = await openRelay();
+    const rail = new BatchableFakeRail({ name: "fake-batch-collide" });
+    await fundAgent(db, "agent-k", 50 * $1);
+    await fundAgent(db, "agent-l", 50 * $1);
+    // The same CLIENT idempotency_key across DIFFERENT motebits — permitted by
+    // the (motebit_id, idempotency_key) UNIQUE index, so both rows land in one
+    // cross-motebit batch. In a single keyed lookup map they'd collide and one
+    // row's outcome would be mis-attributed; the guard must fall back to serial.
+    enqueuePendingWithdrawal(db, {
+      motebitId: "agent-k",
+      amountMicro: 3 * $1,
+      destination: "dst-k",
+      rail: rail.name,
+      source: "sweep",
+      idempotencyKey: "shared-key",
+    });
+    enqueuePendingWithdrawal(db, {
+      motebitId: "agent-l",
+      amountMicro: 4 * $1,
+      destination: "dst-l",
+      rail: rail.name,
+      source: "sweep",
+      idempotencyKey: "shared-key",
+    });
+
+    await evaluateAndFireRail(db, rail, {});
+
+    // Collision detected → batch NOT used; each row fired individually.
+    expect(rail.batchCalls).toHaveLength(0);
+    expect(rail.calls).toHaveLength(2);
+
+    // Both rows fired + recorded — neither dropped nor mis-attributed.
+    const fired = db
+      .prepare("SELECT COUNT(*) AS n FROM relay_pending_withdrawals WHERE status = 'fired'")
+      .get() as { n: number };
+    expect(fired.n).toBe(2);
+    const withdrawals = db.prepare("SELECT COUNT(*) AS n FROM relay_withdrawals").get() as {
+      n: number;
+    };
+    expect(withdrawals.n).toBe(2);
+  });
 });
 
 describe("getPendingWithdrawalsSummary", () => {

--- a/services/relay/src/batch-withdrawals.ts
+++ b/services/relay/src/batch-withdrawals.ts
@@ -346,10 +346,30 @@ async function fireBatch(
   rail: BatchableGuestRail,
   rows: PendingRow[],
 ): Promise<void> {
-  // Map idempotency_key → row for O(1) lookup of per-item outcomes.
-  // toBatchItem mints the idempotency_key deterministically from
-  // pending_id, so the key is unique per row by construction.
   const items = rows.map((r) => toBatchItem(r));
+
+  // We attribute each per-item batch result back to its pending row by
+  // idempotency_key. `toBatchItem` uses the row's CLIENT-SUPPLIED
+  // idempotency_key when present (only falling back to a pending_id-derived key
+  // when absent), and client keys are not guaranteed unique across motebits — so
+  // a batch CAN contain two rows sharing a key. That would collapse them in the
+  // lookup map and silently mis-attribute one row's outcome (record the wrong
+  // withdrawal, drop the other). Detect the collision and fall back to serial
+  // firing, which records each row by pending_id with no key lookup. (Latent
+  // today — no rail is batchable yet; this keeps the trap from biting whenever
+  // one ships. `BatchableGuestRail` is a `WithdrawableGuestRail`, so it can fire
+  // serially.)
+  const keys = items.map((i) => i.idempotency_key);
+  if (new Set(keys).size !== keys.length) {
+    logger.warn("batch.idempotency_key_collision", {
+      rail: rail.name,
+      count: rows.length,
+      reason: "duplicate idempotency_key in batch — firing serially to avoid mis-attribution",
+    });
+    await fireSerial(db, rail, rows);
+    return;
+  }
+
   const byKey = new Map<string, PendingRow>(rows.map((r, i) => [items[i]!.idempotency_key, r]));
 
   let result;


### PR DESCRIPTION
## What

Bottom of the repo-audit ledger — the LOW items. Each was verified against source before touching; **one was a false positive** and is left alone.

### 1. `batch-withdrawals.ts` — real latent fund-misattribution (guarded)
`fireBatch` attributed each per-item batch result back to its pending row by `idempotency_key`, with a comment claiming the key is "unique per row by construction." It isn't: `toBatchItem` uses the **client-supplied** `idempotency_key` when present, and the UNIQUE index is `(motebit_id, idempotency_key)` — so two **different** motebits can share a key and land in one cross-motebit batch, collapsing in the lookup map and **mis-recording one row's outcome**. Fixed: detect the duplicate-key collision and fall back to serial firing (records each row by `pending_id`, no key lookup); corrected the misleading comment. Latent today (no batchable rail ships yet) — guarded so it can't bite when one does. **Regression test added** (two motebits, shared key → serial fallback, both rows recorded).

### 2. operator `FeesPanel` — stale copy + dead branch
`/api/v1/admin/fees` is live (relay `index.ts`), but `fetchFees` still caught a 404 and returned `null` to render *"Endpoint not yet available … ships in a follow-up commit."* Dropped the 404→null catch (a 404 now surfaces as an honest error like any other failure) and removed the stale placeholder branch. Updated the api tests (404 now throws).

### 3. `computer.ts` — stale doc comment
Claimed *"every call returns a typed failure reason until the desktop Tauri bridge lands"* — but the handler dispatches to an injected backend, the cloud-browser dispatcher (`packages/runtime/src/cloud-browser-dispatcher.ts`) is live, and the same comment block already says `desktop_drive` registers a real dispatcher. Rewrote it to describe the injected-dispatcher reality (typed failure only when no dispatcher is wired).

### 4. token-audience registry "5 missing" — **false positive, no change**
Every `expectedAudience` / `audience:` site is covered by the 17-entry `TokenAudience` union — that's exactly why `check-audience-canonical` passes. There is no missing audience, and a registry change is protocol-level 8-artifact work; making one here would be churn, not a fix.

## Tests

Relay (batch-withdrawals incl. the new collision test) + operator (api) + tools suites + all 119 drift gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
