### PR TITLE
test(memory-graph): de-flake the supersede test by mocking the ONNX embedder

### DIFF
--- a/packages/memory-graph/src/__tests__/index.test.ts
+++ b/packages/memory-graph/src/__tests__/index.test.ts
@@ -9,6 +9,19 @@ import { EventStore, InMemoryEventStore } from "@motebit/event-log";
 import { SensitivityLevel, RelationType, EventType } from "@motebit/sdk";
 import type { AttributedMemoryCandidate } from "@motebit/sdk";
 
+// `supersedeMemoryByNodeId` is the one path here that calls `embedText`, which
+// lazy-loads the @xenova/transformers ONNX model on first use. That first load
+// is heavy and variable under parallel CI load and intermittently blew the
+// default 5s test timeout — the sole cause of this suite flaking (it blocked
+// PRs in the 2026-06-17 audit-merge round). Force `embedText` to its own
+// deterministic offline hash fallback so the test never loads a model. The
+// other exports (and other test files that exercise the real embedText) are
+// untouched — this mock is scoped to this file's module registry.
+vi.mock("../embeddings.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../embeddings.js")>();
+  return { ...actual, embedText: (text: string) => Promise.resolve(actual.embedTextHash(text)) };
+});
+
 // ---------------------------------------------------------------------------
 // computeDecayedConfidence()
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Kills the flaky `MemoryGraph > formMemory > supersedeMemoryByNodeId preserves the old node's provenance` test that intermittently timed out at 5s and **blocked two PRs (#198, #202)** during the 2026-06-17 audit-merge round.

## Root cause (not a timeout flake — a model load)

`supersedeMemoryByNodeId` is the *only* path in `index.test.ts` that calls `embedText`, which lazy-loads the `@xenova/transformers` `all-MiniLM-L6-v2` ONNX model on first use (and reaches the HF CDN). That first load is heavy and variable under parallel `turbo` CI load and intermittently blew vitest's default 5s timeout. Every other test in the file passes a caller-supplied embedding vector, so only this one paid the model cost — which is why it was consistently *this* test.

## Fix

Mock `../embeddings.js` in this test file so `embedText` delegates to `embedTextHash` — `embedText`'s own deterministic offline fallback — eliminating the model load entirely. Production is unchanged; the mock is scoped to this file's module registry, so `embeddings.test.ts` and `memory-formation.test.ts` (which exercise the real `embedText`) are untouched.

The formerly-flaky test now runs in <1ms (deterministic across repeats); the full `@motebit/memory-graph` suite (235 tests) passes in ~1.2s. All 119 drift gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
