### PR TITLE
perf(ai-core): skip embed + retrieval on an empty memory graph (TTFT)

### DIFF
--- a/packages/ai-core/src/__tests__/loop.test.ts
+++ b/packages/ai-core/src/__tests__/loop.test.ts
@@ -1199,6 +1199,39 @@ describe("runTurnStreaming (agentic loop)", () => {
     expect(result2.result.memoriesRetrieved[0]!.content).toBe("User likes cats");
   });
 
+  it("skips similarity retrieval on an empty memory graph, runs it once non-empty (TTFT win)", async () => {
+    const deps = makeDepsWithProvider(
+      makeMockProvider([
+        {
+          text: 'Noted <memory confidence="0.9" sensitivity="none">User likes dogs</memory>',
+          confidence: 0.8,
+          memory_candidates: [
+            { content: "User likes dogs", confidence: 0.9, sensitivity: SensitivityLevel.None },
+          ],
+          state_updates: {},
+        },
+      ]),
+    );
+    const recallSpy = vi.spyOn(deps.memoryGraph, "recallRelevant");
+
+    // Turn 1: empty graph → the emptiness probe skips embed + similarity
+    // retrieval entirely (the ~450ms embed is the dominant TTFT cost and is
+    // pure waste with nothing to retrieve against).
+    const c1: AgenticChunk[] = [];
+    for await (const chunk of runTurnStreaming(deps, "I like dogs")) c1.push(chunk);
+    expect(recallSpy).not.toHaveBeenCalled();
+
+    // Turn 1 formed a memory → the graph is now non-empty.
+    (deps as { provider: StreamingProvider }).provider = makeMockProvider([
+      { text: "ok", confidence: 0.8, memory_candidates: [], state_updates: {} },
+    ]);
+
+    // Turn 2: non-empty → retrieval runs.
+    const c2: AgenticChunk[] = [];
+    for await (const chunk of runTurnStreaming(deps, "what do I like?")) c2.push(chunk);
+    expect(recallSpy).toHaveBeenCalled();
+  });
+
   it("pinned memories appear in memoriesRetrieved", async () => {
     const deps = makeDepsWithProvider(
       makeMockProvider([
@@ -1634,6 +1667,9 @@ describe("runTurnStreaming pipeline stage timeouts", () => {
   it("surfaces a StageTimeoutError when memoryGraph.recallRelevant hangs past its deadline", async () => {
     const { StageTimeoutError, STAGE_TIMEOUTS_MS } = await import("../core");
     const deps = makeDeps();
+    // Force the non-empty path so retrieval actually runs (a fresh in-memory
+    // graph is empty → the emptiness probe would otherwise skip embed+retrieve).
+    vi.spyOn(deps.memoryGraph, "hasAnyMemory").mockResolvedValue(true);
     // Let the Promise.all batch resolve (event/embed/pinned all fast against
     // in-memory stores), then hang the similarity retrieve. Models a
     // corrupted vector index that accepts the call but never returns.

--- a/packages/ai-core/src/core.ts
+++ b/packages/ai-core/src/core.ts
@@ -127,6 +127,8 @@ export const STAGE_TIMEOUTS_MS = {
   embed_user_message: 12_000,
   /** Pinned-memory lookup from the memory graph. */
   pinned_memories: 10_000,
+  /** Cheap "has any memory?" probe (limit:1) that gates embed + retrieval. */
+  memory_probe: 10_000,
   /** Similarity search against the memory graph. */
   memory_retrieve: 10_000,
   /** Runtime-level agent-context assembly (pre-turn hop). */

--- a/packages/ai-core/src/loop.ts
+++ b/packages/ai-core/src/loop.ts
@@ -832,6 +832,21 @@ export async function* runTurnStreaming(
   // `STAGE_TIMEOUTS_MS` in core.ts for deadlines (single source of truth).
   const CONTEXT_SAFE_SENSITIVITY = [SensitivityLevel.None, SensitivityLevel.Personal];
 
+  // Emptiness probe BEFORE the context batch. A brand-new / anonymous motebit
+  // has no memory, so embedding the user message (~450ms remote call — the
+  // dominant pipeline cost) AND similarity retrieval are pure waste: there's
+  // nothing to retrieve against. The probe is a `limit: 1` query (pushed LIMIT
+  // on the SQL adapters), negligible for returning users, and gating on it lets
+  // us skip the embed entirely, not just the retrieval. Memory FORMATION (the
+  // write path, post-turn) is unaffected, so the first turn still records memory
+  // and turn 2+ takes the full path. Empty pinned/embed/retrieve degrade to the
+  // same context as before — the agent simply gets no `relevant_memories`.
+  const hasMemory = await withStageTimeout(
+    "memory_probe",
+    STAGE_TIMEOUTS_MS.memory_probe,
+    memoryGraph.hasAnyMemory(),
+  );
+
   const [recentEvents, queryEmbedding, pinnedMemoriesRaw] = await Promise.all([
     withStageTimeout(
       "event_query",
@@ -841,40 +856,47 @@ export async function* runTurnStreaming(
         eventQueryMs = ms;
       },
     ),
-    withStageTimeout(
-      "embed_user_message",
-      STAGE_TIMEOUTS_MS.embed_user_message,
-      embedText(userMessage),
-      (ms) => {
-        embedMs = ms;
-      },
-    ),
-    withStageTimeout(
-      "pinned_memories",
-      STAGE_TIMEOUTS_MS.pinned_memories,
-      memoryGraph.getPinnedMemories(),
-      (ms) => {
-        pinnedMs = ms;
-      },
-    ),
+    hasMemory
+      ? withStageTimeout(
+          "embed_user_message",
+          STAGE_TIMEOUTS_MS.embed_user_message,
+          embedText(userMessage),
+          (ms) => {
+            embedMs = ms;
+          },
+        )
+      : Promise.resolve<number[]>([]),
+    hasMemory
+      ? withStageTimeout(
+          "pinned_memories",
+          STAGE_TIMEOUTS_MS.pinned_memories,
+          memoryGraph.getPinnedMemories(),
+          (ms) => {
+            pinnedMs = ms;
+          },
+        )
+      : Promise.resolve<MemoryNode[]>([]),
   ]);
 
-  // 2. Similarity retrieval depends on the embedding — runs after parallel batch
+  // 2. Similarity retrieval depends on the embedding — runs after parallel batch.
+  // Skipped entirely on an empty graph (no embedding was computed).
   const pinnedMemories = pinnedMemoriesRaw.filter((m) =>
     CONTEXT_SAFE_SENSITIVITY.includes(m.sensitivity),
   );
-  const similarityMemories = await withStageTimeout(
-    "memory_retrieve",
-    STAGE_TIMEOUTS_MS.memory_retrieve,
-    memoryGraph.recallRelevant(queryEmbedding, {
-      limit: 5,
-      strengthenCoRetrieved: true,
-      sensitivityFilter: CONTEXT_SAFE_SENSITIVITY,
-    }),
-    (ms) => {
-      memoryRetrieveMs = ms;
-    },
-  );
+  const similarityMemories = hasMemory
+    ? await withStageTimeout(
+        "memory_retrieve",
+        STAGE_TIMEOUTS_MS.memory_retrieve,
+        memoryGraph.recallRelevant(queryEmbedding, {
+          limit: 5,
+          strengthenCoRetrieved: true,
+          sensitivityFilter: CONTEXT_SAFE_SENSITIVITY,
+        }),
+        (ms) => {
+          memoryRetrieveMs = ms;
+        },
+      )
+    : [];
 
   // Merge: pinned first (cap 5), then similarity (deduplicated)
   const pinnedIds = new Set(pinnedMemories.map((m) => m.node_id));

--- a/packages/memory-graph/src/__tests__/index.test.ts
+++ b/packages/memory-graph/src/__tests__/index.test.ts
@@ -281,6 +281,39 @@ describe("MemoryGraph", () => {
     graph = new MemoryGraph(storage, eventStore, motebitId);
   });
 
+  describe("hasAnyMemory (emptiness probe)", () => {
+    it("returns false on an empty graph", async () => {
+      expect(await graph.hasAnyMemory()).toBe(false);
+    });
+
+    it("returns true once a memory exists", async () => {
+      await graph.formMemory(
+        {
+          content: "first fact",
+          confidence: 0.9,
+          sensitivity: SensitivityLevel.None,
+          source: "user_stated",
+        },
+        [1, 0],
+      );
+      expect(await graph.hasAnyMemory()).toBe(true);
+    });
+
+    it("ignores tombstoned-only graphs (no live memory)", async () => {
+      const node = await graph.formMemory(
+        {
+          content: "to delete",
+          confidence: 0.9,
+          sensitivity: SensitivityLevel.None,
+          source: "user_stated",
+        },
+        [1, 0],
+      );
+      await storage.tombstoneNode(node.node_id);
+      expect(await graph.hasAnyMemory()).toBe(false);
+    });
+  });
+
   describe("getNode (delegate to storage)", () => {
     it("returns a stored node by id", async () => {
       const node = await graph.formMemory(

--- a/packages/memory-graph/src/index.ts
+++ b/packages/memory-graph/src/index.ts
@@ -1180,6 +1180,26 @@ export class MemoryGraph {
   }
 
   /**
+   * Cheap "does this motebit have any live memory?" probe.
+   *
+   * Uses a `limit: 1` query against the existing storage contract (no adapter
+   * change). On the SQL adapters this pushes `LIMIT 1`; everywhere it returns an
+   * empty array immediately for an empty graph. The hot-path turn pipeline uses
+   * this to skip embedding the user message + similarity retrieval entirely for
+   * a brand-new / anonymous motebit (empty graph) — embedding is the dominant
+   * TTFT cost (~450ms remote call) and is pure waste when there's nothing to
+   * retrieve against. Returns false on an empty graph.
+   */
+  async hasAnyMemory(): Promise<boolean> {
+    const nodes = await this.storage.queryNodes({
+      motebit_id: this.motebitId,
+      limit: 1,
+      include_tombstoned: false,
+    });
+    return nodes.length > 0;
+  }
+
+  /**
    * Get a single memory node.
    */
   async getMemory(nodeId: string): Promise<MemoryNode | null> {


### PR DESCRIPTION
## What

A live production TTFT probe (anonymous cloud turns on motebit.com) showed the pre-model pipeline is **embedding-dominated**: ~450ms remote embed + ~112ms similarity retrieve per turn, *steady* across turns (it's a remote round-trip to the proxy `/embed` service, not a local model load that would warm down). For a brand-new / anonymous motebit the memory graph is **empty**, so both are pure waste — there's nothing to retrieve against — yet they sat on the critical path before the first token. That's ~20% of the ~2.9s TTFT, burned entirely on the **new-user cohort** (the segment that churns over "weak/slow" UX, which is what kicked off this whole thread).

| prod sample | total | provider | embed | retrieve |
|---|---|---|---|---|
| warm turn | 2943ms | 1549 | 465 | 111 |
| warm turn | 2850ms | 1849 | 446 | 112 |

## Fix

A cheap emptiness probe before the context batch in `runTurnStreaming`. New `MemoryGraph.hasAnyMemory()` — backed by the **existing** `queryNodes({ limit: 1 })` storage contract, so **no `MemoryStorageAdapter` interface change and no adapter edits** — gates *both* the embed and the retrieval. On an empty graph both are skipped; the agent just gets no `relevant_memories` (same context as before, minus the wait). Memory **formation** (post-turn write path) is untouched, so the first turn still records memory and turn 2+ takes the full path. SQL adapters push `LIMIT 1`; the probe is negligible for returning users.

## De-shelved deliberately

This is the earlier embed-skip that was **shelved** over desktop goal-tick fake-timer test fragility. Two things changed: (1) the win is ~450ms on *every* empty-graph turn, not turn-1-only as first thought; (2) with a clean dist rebuild the single `hasAnyMemory` await does **not** perturb those tests — the full desktop suite passes untouched, so no test had to be loosened.

## Tests

- ai-core: retrieval is skipped on an empty graph, runs once non-empty (spy on `recallRelevant`).
- memory-graph: `hasAnyMemory` — empty / non-empty / tombstoned-only.
- Green: ai-core (514), memory-graph (96), runtime (1134), web (539), mobile (402), desktop (509), browser-persistence (147), + all 119 drift gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
