### PR TITLE
fix(proxy): embed limiter fails open on KV outage + raise daily cap

### DIFF
--- a/services/proxy/src/app/v1/embed/__tests__/rate-limit.test.ts
+++ b/services/proxy/src/app/v1/embed/__tests__/rate-limit.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Embed rate limiter — fail-OPEN behavior.
+ *
+ * Embedding is a best-effort enhancement (client falls back to a local hash
+ * embedding) and the route is origin-gated, so a Vercel KV outage must NOT deny
+ * embeddings platform-wide. The limiter allows when KV is unconfigured (local
+ * dev) or unavailable (transient outage), and only denies a genuine over-limit.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+let incrImpl: () => Promise<number>;
+vi.mock("@vercel/kv", () => ({
+  kv: {
+    incr: () => incrImpl(),
+    expire: () => Promise.resolve(),
+  },
+}));
+
+import { checkRateLimit } from "../route";
+
+describe("embed checkRateLimit (fail-open)", () => {
+  beforeEach(() => {
+    process.env.KV_REST_API_URL = "https://kv.test";
+    incrImpl = () => Promise.resolve(1);
+  });
+  afterEach(() => {
+    delete process.env.KV_REST_API_URL;
+    vi.restoreAllMocks();
+  });
+
+  it("allows when KV is not configured (local dev)", async () => {
+    delete process.env.KV_REST_API_URL;
+    const r = await checkRateLimit("embed:1.2.3.4:2026-06-17", 1000);
+    expect(r.allowed).toBe(true);
+  });
+
+  it("allows under the daily limit", async () => {
+    incrImpl = () => Promise.resolve(5);
+    expect((await checkRateLimit("k", 1000)).allowed).toBe(true);
+  });
+
+  it("denies once the daily limit is genuinely exceeded", async () => {
+    incrImpl = () => Promise.resolve(1001);
+    expect((await checkRateLimit("k", 1000)).allowed).toBe(false);
+  });
+
+  it("FAILS OPEN when KV is configured but unavailable (transient outage)", async () => {
+    incrImpl = () => Promise.reject(new Error("KV down"));
+    const r = await checkRateLimit("k", 1000);
+    expect(r.allowed).toBe(true);
+  });
+});

--- a/services/proxy/src/app/v1/embed/route.ts
+++ b/services/proxy/src/app/v1/embed/route.ts
@@ -5,7 +5,11 @@ export const runtime = "edge";
 import { type NextRequest, NextResponse } from "next/server";
 
 const EMBED_SERVICE_URL = process.env.EMBED_SERVICE_URL ?? "https://motebit-embed.fly.dev";
-const EMBED_DAILY_LIMIT = 100;
+// One embed per chat turn (memory retrieval), so a single active user easily
+// reaches triple digits/day and shared/NAT IPs far more. 100 was too low and
+// bounced real users; 1000 is generous headroom while still capping abuse. The
+// cost is Fly compute on the embed service, not Anthropic spend.
+const EMBED_DAILY_LIMIT = 1000;
 
 function getClientIP(request: NextRequest): string {
   return (
@@ -19,10 +23,16 @@ function todayDate(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
-async function checkRateLimit(
+export async function checkRateLimit(
   key: string,
   dailyLimit: number,
 ): Promise<{ allowed: boolean; remaining: number }> {
+  // Local dev: no Vercel KV configured → skip the limit (the origin allowlist
+  // still gates callers). Mirrors fetch/route.ts; the embed route previously
+  // lacked this and so denied ALL embeds under `next dev`.
+  if (!process.env.KV_REST_API_URL) {
+    return { allowed: true, remaining: dailyLimit };
+  }
   try {
     const { kv } = await import("@vercel/kv");
     const count = await kv.incr(key);
@@ -34,8 +44,15 @@ async function checkRateLimit(
       remaining: Math.max(0, dailyLimit - count),
     };
   } catch {
-    // KV unavailable — fail closed, deny the request
-    return { allowed: false, remaining: 0 };
+    // KV configured but unavailable — FAIL OPEN. Embedding is a best-effort
+    // enhancement: the client falls back to a local hash embedding on failure,
+    // and this route is origin-gated. A transient KV outage must not deny
+    // embeddings platform-wide (which silently degrades memory retrieval for
+    // every user). The daily cap is cost-control, not security, so briefly
+    // allowing extra embeds during an outage is the far smaller harm.
+    // (Contrast fetch/route.ts, which fails CLOSED — arbitrary URL fetching is
+    // a higher-risk surface where deny-on-uncertainty is correct.)
+    return { allowed: true, remaining: -1 };
   }
 }
 


### PR DESCRIPTION
## What

Two reliability fixes to the `/v1/embed` CORS gateway, surfaced while investigating the "got rate limited" churn report. Embedding is on **every chat turn** (memory retrieval), so this gateway's behavior is hot-path.

1. **Failed CLOSED on a Vercel KV blip.** A transient KV outage denied embeds for *every* user, silently degrading memory retrieval platform-wide (the client falls back to a worse local hash embedding). Embedding is a best-effort enhancement *with a fallback*, and the route is origin-gated, so the daily cap is **cost-control, not security**: briefly allowing extra embeds during an outage is far less harm than denying all of them. Now **fails OPEN**. (Contrast `fetch/route.ts`, which correctly fails CLOSED — arbitrary URL fetching is a higher-risk surface; the split is deliberate per-endpoint.)

2. **Missing the local-dev guard** that `fetch/route.ts` has — with no KV configured (`next dev`), the KV import/incr threw → catch → denied **all** embeds locally. Added the same `!KV_REST_API_URL → allow` early return.

3. **Daily cap was 100/IP/day.** One embed per chat turn → a single active user reaches triple digits and shared/NAT IPs far more, so 100 bounced real users. Raised to **1000** (Fly compute cost on the embed service, not Anthropic spend); still bounded.

## Not the churn's rate-limit cause

The chat path's only 429 is a **forwarded Anthropic org-level limit** (the messages route passes through `providerRes.status` and generates no 429 of its own) — i.e. capacity/balance, an operator item. This is a separate reliability fix the investigation turned up, not the first-message-bounce theory (which was disconfirmed).

## Tests

`checkRateLimit` exported + covered: allows when KV unconfigured (local dev), allows under the cap, denies over the cap, and **fails OPEN** when KV throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
