### PR TITLE
test(cli): raise testTimeout to 15s to de-flake CPU-starved scheduler tests

### DIFF
--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -8,5 +8,16 @@ import { defineConfig } from "vitest/config";
 // the standard excludes. (Coverage config is intentionally omitted: this
 // package's `test:coverage` collects without per-package thresholds.)
 export default defineConfig({
-  test: { exclude: ["**/node_modules/**", "**/dist/**", "**/coverage/**"] },
+  test: {
+    exclude: ["**/node_modules/**", "**/dist/**", "**/coverage/**"],
+    // 15s, not vitest's default 5s. These are integration-shaped tests — real
+    // in-memory SQLite + a full GoalScheduler `tickOnce()` — that finish in
+    // milliseconds in isolation but get CPU-starved when the Release job runs
+    // every package's `test:coverage` concurrently under turbo. A normally-fast
+    // `scheduler-approvals` tick intermittently blew the 5s default and failed
+    // the publish run (2026-06-18). The work is fast; the budget was too tight
+    // for the contention. A correct test still completes well under this ceiling
+    // — it only delays how long a genuinely hung test takes to surface.
+    testTimeout: 15_000,
+  },
 });


### PR DESCRIPTION
## What

The `scheduler-approvals` suite runs real in-memory SQLite + a full `GoalScheduler.tickOnce()` against a fully-mocked runtime — milliseconds in isolation, but CPU-starved when the Release job runs every package's `test:coverage` concurrently under turbo. A normally-instant tick intermittently blew vitest's 5s default and **failed the publish run** during the standing-delegation@1.1 release (2026-06-18).

Same flake *class* as the memory-graph supersede test, **different cause**: there's nothing to mock here (the runtime is already mocked) — the work is fast, the 5s budget was just too tight for the contention.

## Fix

Bump `apps/cli`'s `testTimeout` to 15s. A correct test still completes well under the ceiling (locally: 9 tests in ~1s); it only delays how long a genuinely hung test takes to surface. Scoped to `apps/cli` (the integration-shaped `motebit` runtime package), not the shared config — unit-only packages keep the strict 5s default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)