### PR TITLE
test(trust): pin direct-witness-only trust writes (anti delegation-laundering)

### DIFF
--- a/docs/doctrine/agents-as-first-person-trust-graph.md
+++ b/docs/doctrine/agents-as-first-person-trust-graph.md
@@ -383,7 +383,21 @@ what keeps the cost from eating the property it paid for.
   only multi-hop structure is delegation edges I personally witnessed. **Bound:**
   do not market "trust graph" as recommendation/reachability; transitive or
   delegated trust is a future axis with its own threat model (trust laundering
-  through cheap intermediaries), never a silent default.
+  through cheap intermediaries), never a silent default. **Enforced invariant
+  (the current posture against that laundering):** trust is written for the
+  _direct counterparty of a receipt my runtime received only_ — `bumpTrustFromReceipt`
+  ([`packages/runtime/src/agent-trust.ts`](../../packages/runtime/src/agent-trust.ts))
+  writes `[me, receipt.motebit_id]` and never recurses into `delegation_receipts`,
+  so a compromised intermediary B that sub-delegates to its own sybil C cannot
+  bootstrap `[me, C]` standing by handing me a tree that names C. A sub-delegated
+  receipt informs _routing_ — `addDelegationEdges`
+  ([`packages/semiring/src/agent-network.ts`](../../packages/semiring/src/agent-network.ts))
+  writes the peer→peer edge `B→C`, never `me→C` — but it must never write my
+  first-person trust ledger. This property is held by call-site discipline, not by
+  a structural type, so it is pinned by regression test (the "does NOT launder trust
+  through a sub-delegation" case in
+  [`packages/runtime/src/__tests__/agent-trust.test.ts`](../../packages/runtime/src/__tests__/agent-trust.test.ts));
+  reopening delegated-trust harvesting is a deliberate threat-model decision, not a refactor.
 
 - **The sigil's distinctness budget is necessary, not sufficient (§4).** The
   measurable bound is output-space size; the real limit is human perceptual

--- a/packages/runtime/src/__tests__/agent-trust.test.ts
+++ b/packages/runtime/src/__tests__/agent-trust.test.ts
@@ -294,6 +294,33 @@ describe("MotebitRuntime bumpTrustFromReceipt", () => {
     // Trust should be at least the static FirstContact score (0.3)
     expect(edge!.weight.trust).toBeGreaterThanOrEqual(0.3);
   });
+
+  // INVARIANT — direct-witness-only trust writes (anti delegation-laundering).
+  // Trust is first-person and pairwise: I write a trust edge only for the DIRECT
+  // counterparty of a receipt my runtime received, never for a sub-worker buried
+  // in the receipt tree (docs/doctrine/agents-as-first-person-trust-graph.md §"It
+  // is an ego-star, not a transitive graph"). A compromised intermediary B that
+  // sub-delegates to its own sybil C must NOT be able to bootstrap [me, C] standing
+  // by handing me a tree whose nested receipt names C. Sub-delegation informs
+  // ROUTING — peer→peer edges in the agent graph (addDelegationEdges writes B→C,
+  // never me→C) — but it must never write my first-person trust ledger. This test
+  // pins that property: today it holds because `bumpTrustFromReceipt` does not
+  // recurse into `delegation_receipts`, but nothing structural enforces it (cf. the
+  // recursive `collect()` walk in agent-graph.ts), so the regression net lives here.
+  it("does NOT launder trust through a sub-delegation — a nested receipt writes no edge at my root", async () => {
+    const subWorker = { ...fakeReceipt("sybil-C"), task_id: "sub-task" };
+    const intermediary = {
+      ...fakeReceipt("intermediary-B"),
+      delegation_receipts: [subWorker],
+    };
+
+    await runtime.bumpTrustFromReceipt(intermediary, true);
+
+    // The direct counterparty earns first-person trust...
+    expect(await trustStore.getAgentTrust("test-mote", "intermediary-B")).not.toBeNull();
+    // ...the buried sub-worker earns NOTHING from me — it never witnessed me, I never witnessed it.
+    expect(await trustStore.getAgentTrust("test-mote", "sybil-C")).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Pins an anti-Sybil invariant that was real but only **emergent from call-site discipline**: my first-person trust ledger must never absorb a *sub-delegated* worker's standing.

`bumpTrustFromReceipt` writes only `[me, receipt.motebit_id]` and never recurses into `delegation_receipts`. So a compromised intermediary **B** that sub-delegates to its own sybil **C** cannot bootstrap `[me, C]` trust by handing me a receipt tree that names C. Sub-delegation informs **routing** (`addDelegationEdges` writes the peer edge `B→C`, never `me→C`), never my trust ledger.

The protection held by convention, not by a structural type — and the recursive `collect()` walk ~30 lines away in `agent-graph.ts` is the exact shape one well-meaning refactor away from silently reopening it, with no failing test.

## Changes

- **Regression test** (`packages/runtime/src/__tests__/agent-trust.test.ts`) — a receipt carrying a nested sub-worker receipt writes the direct edge `[me, B]` and **nothing** for the buried sub-worker `[me, C]`. Asserts both sides so it can't false-green on a no-op.
- **Doctrine** (`docs/doctrine/agents-as-first-person-trust-graph.md`) — names "direct-witness-only trust writes" as the current enforced posture against delegation-laundering in the ego-star bound, cross-referencing producer (`agent-trust.ts`), router (`agent-network.ts`), and the test.

## Review done

- **Mutation-verified** the test has teeth: temporarily made the trust path recurse into `delegation_receipts` → the laundering case failed with the right assertion (sybil-C got an edge), and *only* that case → reverted clean.
- **Sibling-audited** every `setAgentTrust` writer in the runtime: all key to a direct counterparty (`receipt.motebit_id` or an explicit peer id); none recurse.
- **CI siblings clear**: doctrine edit doesn't feed `llms-full.txt` (generator globs `apps/docs/content` + root `DOCTRINE.md`); `check-llms-txt-fresh` and `check-doctrine-citations` green. Runtime `test` / `typecheck` / `lint` green.

Out of scope: the relay's own trust store (`services/relay/src/tasks.ts`) is a separate trust domain (coordinator ego-graph, not a sovereign's money-gating ledger).

## Deferred-with-trigger

The **structural** rung — a type-level barrier or `check-*` gate so the trust path *cannot* recurse even if this test is deleted — lands *with* any future delegated/transitive-trust-harvesting work (the doctrine's named "future axis"), at the design-review checkpoint. Not built speculatively now (N=1, no consumer forcing it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)