### PR TITLE
fix(runtime): wire AI-loop tools live, not a wire-time snapshot (+ T2/T3 cleanup)

### DIFF
--- a/packages/runtime/src/__tests__/toolless-loop-regression.test.ts
+++ b/packages/runtime/src/__tests__/toolless-loop-regression.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Toolless-loop regression (T1).
+ *
+ * Bug: `wireLoopDeps` snapshotted `loopDeps.tools` as
+ * `scopedToolRegistry.size > 0 ? wrap(...) : undefined` — a ONE-SHOT read at
+ * wire time. A runtime built with a provider but an EMPTY tool registry (the
+ * live shape on mobile + desktop), then populated via the raw
+ * `getToolRegistry().register(...)` (which has no re-wire hook, unlike
+ * `registerExternalTools`/`setProvider`/`updatePolicyConfig`), kept
+ * `loopDeps.tools === undefined`. `ai-core/loop.ts` reads `deps.tools` and runs
+ * the agentic loop with ZERO tools when it is falsy.
+ *
+ * This test drives the REAL `runTurnStreaming` (deliberately NOT mocking
+ * @motebit/ai-core — that mock is exactly why existing streaming tests miss
+ * this) and asserts via a provider that records the tool definitions the loop
+ * offers it (`contextPack.tools`).
+ */
+import { describe, it, expect, vi } from "vitest";
+import { MotebitRuntime, NullRenderer, createInMemoryStorage } from "../index";
+import type { PlatformAdapters, StreamChunk } from "../index";
+import type { StreamingProvider } from "@motebit/ai-core";
+import type { AIResponse, ContextPack, ToolDefinition } from "@motebit/sdk";
+import { RiskLevel } from "@motebit/sdk";
+
+/** Provider that records the tool names offered to it on each turn. */
+function createToolCapturingProvider(offered: string[][]): StreamingProvider {
+  const response: AIResponse = {
+    text: "ok",
+    confidence: 0.8,
+    memory_candidates: [],
+    state_updates: {},
+  };
+  return {
+    model: "mock-model",
+    setModel: vi.fn(),
+    generate: vi.fn<(ctx: ContextPack) => Promise<AIResponse>>().mockResolvedValue(response),
+    estimateConfidence: vi.fn<() => Promise<number>>().mockResolvedValue(0.8),
+    extractMemoryCandidates: vi.fn<(r: AIResponse) => Promise<never[]>>().mockResolvedValue([]),
+    async *generateStream(ctx: ContextPack) {
+      offered.push((ctx.tools ?? []).map((t) => t.name));
+      yield { type: "text" as const, text: "ok" };
+      yield { type: "done" as const, response };
+    },
+  };
+}
+
+function probeTool(name: string): ToolDefinition {
+  return {
+    name,
+    description: `probe ${name}`,
+    inputSchema: { type: "object" },
+    riskHint: { risk: RiskLevel.R0_READ },
+  };
+}
+
+function makeRuntime(motebitId: string, offered: string[][]): MotebitRuntime {
+  const adapters: PlatformAdapters = {
+    storage: createInMemoryStorage(),
+    renderer: new NullRenderer(),
+    ai: createToolCapturingProvider(offered),
+  };
+  return new MotebitRuntime({ motebitId, tickRateHz: 0 }, adapters);
+}
+
+async function drain(gen: AsyncGenerator<StreamChunk>): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  for await (const _chunk of gen) {
+    // consume — the turn's chunks are not asserted here
+  }
+}
+
+describe("MotebitRuntime — toolless-loop regression (T1)", () => {
+  it("offers tools registered AFTER construction on an empty registry (no incidental re-wire)", async () => {
+    const offered: string[][] = [];
+    const runtime = makeRuntime("toolless-1", offered);
+
+    // The mobile/desktop shape: constructed provider-only (empty registry →
+    // wireLoopDeps already ran), then populated via the RAW registry with no
+    // re-wire. Before the fix, loopDeps.tools stayed undefined → toolless loop.
+    runtime.getToolRegistry().register(probeTool("probe_tool"), async () => ({ ok: true }));
+
+    await drain(runtime.sendMessageStreaming("hi"));
+
+    expect(offered.length).toBeGreaterThan(0);
+    expect(offered[0]).toContain("probe_tool");
+  });
+
+  it("an empty registry still runs the loop cleanly (always-wrap tolerates an empty list)", async () => {
+    const offered: string[][] = [];
+    const runtime = makeRuntime("toolless-2", offered);
+
+    // No tools registered at all — the loop must still complete without error
+    // and simply offer nothing. Guards the fix's empty-registry path.
+    await drain(runtime.sendMessageStreaming("hi"));
+
+    expect(offered.length).toBeGreaterThan(0);
+    expect(offered[0]).toEqual([]);
+  });
+});

--- a/packages/runtime/src/motebit-runtime.ts
+++ b/packages/runtime/src/motebit-runtime.ts
@@ -440,7 +440,6 @@ export class MotebitRuntime {
   };
   private stateSnapshot?: StateSnapshotAdapter;
   private compactionThreshold: number;
-  private lastKnownClock = 0;
   private running = false;
   private toolRegistry: SimpleToolRegistry;
   /** Presence-scoped view onto `toolRegistry`. Filters tool visibility +
@@ -1201,10 +1200,14 @@ export class MotebitRuntime {
     this._idleTick?.stop();
     this.sync.stop();
     this.state.stop();
-    // Snapshot synchronously, compact in background
+    // Snapshot synchronously so state survives an immediate exit; compact in
+    // background. The synchronous stamp uses clock 0 — `stop()` cannot await
+    // `getLatestClock()`, restore (`loadState`) does not read the snapshot
+    // clock, and the `autoCompact()` below re-saves with the authoritative
+    // clock anyway. (Was a never-assigned `lastKnownClock` field that implied
+    // a tracked clock; removed.)
     if (this.stateSnapshot) {
-      const clock = this.lastKnownClock;
-      this.stateSnapshot.saveState(this.motebitId, this.state.serialize(), clock);
+      this.stateSnapshot.saveState(this.motebitId, this.state.serialize(), 0);
     }
     void this.autoCompact();
     // Disconnect MCP servers in background
@@ -3088,19 +3091,33 @@ export class MotebitRuntime {
    *
    * Returns `null` when there are no pending receipts.
    */
-  async anchorPendingConsolidationReceipts(
-    submitter?: ChainAnchorSubmitter,
-  ): Promise<ConsolidationAnchor | null> {
-    const signedEvents = await this.events.query({
-      motebit_id: this.motebitId,
-      event_types: [EventType.ConsolidationReceiptSigned],
-    });
-    const anchoredEvents = await this.events.query({
-      motebit_id: this.motebitId,
-      event_types: [EventType.ConsolidationReceiptsAnchored],
-    });
+  /**
+   * Shared "pending = signed − anchored" computation for the consolidation
+   * anchor pair. Returns the signed consolidation receipts not yet covered by
+   * any `ConsolidationReceiptsAnchored` batch, plus the most recent anchor
+   * timestamp. Single source of truth so the auto-anchor TRIGGER
+   * (`maybeAutoAnchor`) and the actual anchor BATCH
+   * (`anchorPendingConsolidationReceipts`) can never disagree on what counts as
+   * "pending" — the divergence hazard if the predicate were duplicated.
+   */
+  private async computePendingConsolidationReceipts(): Promise<{
+    pending: ConsolidationReceipt[];
+    lastAnchorAt: number;
+  }> {
+    const [signedEvents, anchoredEvents] = await Promise.all([
+      this.events.query({
+        motebit_id: this.motebitId,
+        event_types: [EventType.ConsolidationReceiptSigned],
+      }),
+      this.events.query({
+        motebit_id: this.motebitId,
+        event_types: [EventType.ConsolidationReceiptsAnchored],
+      }),
+    ]);
     const alreadyAnchored = new Set<string>();
+    let lastAnchorAt = 0;
     for (const ev of anchoredEvents) {
+      if (ev.timestamp > lastAnchorAt) lastAnchorAt = ev.timestamp;
       const anchor = (ev.payload as { anchor?: ConsolidationAnchor }).anchor;
       if (anchor) for (const id of anchor.receipt_ids) alreadyAnchored.add(id);
     }
@@ -3109,6 +3126,13 @@ export class MotebitRuntime {
       const receipt = (ev.payload as { receipt?: ConsolidationReceipt }).receipt;
       if (receipt && !alreadyAnchored.has(receipt.receipt_id)) pending.push(receipt);
     }
+    return { pending, lastAnchorAt };
+  }
+
+  async anchorPendingConsolidationReceipts(
+    submitter?: ChainAnchorSubmitter,
+  ): Promise<ConsolidationAnchor | null> {
+    const { pending } = await this.computePendingConsolidationReceipts();
     if (pending.length === 0) return null;
 
     // Stable leaf order: the receipt's signed `finished_at` (cycle clock),
@@ -3282,28 +3306,8 @@ export class MotebitRuntime {
     const threshold = policy.batchThreshold ?? 8;
     const intervalMs = policy.minAnchorIntervalMs ?? 0;
     try {
-      const [signedEvents, anchoredEvents] = await Promise.all([
-        this.events.query({
-          motebit_id: this.motebitId,
-          event_types: [EventType.ConsolidationReceiptSigned],
-        }),
-        this.events.query({
-          motebit_id: this.motebitId,
-          event_types: [EventType.ConsolidationReceiptsAnchored],
-        }),
-      ]);
-      const alreadyAnchored = new Set<string>();
-      let lastAnchorAt = 0;
-      for (const ev of anchoredEvents) {
-        if (ev.timestamp > lastAnchorAt) lastAnchorAt = ev.timestamp;
-        const anchor = (ev.payload as { anchor?: ConsolidationAnchor }).anchor;
-        if (anchor) for (const id of anchor.receipt_ids) alreadyAnchored.add(id);
-      }
-      let pendingCount = 0;
-      for (const ev of signedEvents) {
-        const receipt = (ev.payload as { receipt?: ConsolidationReceipt }).receipt;
-        if (receipt && !alreadyAnchored.has(receipt.receipt_id)) pendingCount++;
-      }
+      const { pending, lastAnchorAt } = await this.computePendingConsolidationReceipts();
+      const pendingCount = pending.length;
       if (pendingCount === 0) return;
       const thresholdReached = threshold > 0 && pendingCount >= threshold;
       const timeReached = intervalMs > 0 && Date.now() - lastAnchorAt >= intervalMs;
@@ -3517,10 +3521,15 @@ export class MotebitRuntime {
         // boundary. Local-only tools (read_file, recall_memories, etc.)
         // dispatch unchanged. The scoped registry's presence-aware
         // predicate continues to apply through the wrapper.
-        tools:
-          this.scopedToolRegistry.size > 0
-            ? this.wrapToolRegistryForSensitivity(this.scopedToolRegistry)
-            : undefined,
+        //
+        // ALWAYS wrap — never gate on `size > 0`. The wrapper forwards
+        // `list()`/`execute()` LIVE against the scoped registry, and ai-core
+        // tolerates an empty `list()`. Gating on the wire-time size froze
+        // `tools` to `undefined` for any runtime built with an empty registry
+        // (mobile/desktop construct provider-only, then populate via the raw
+        // `getToolRegistry().register(...)` with no re-wire hook) → a toolless
+        // AI loop. See toolless-loop-regression.test.ts.
+        tools: this.wrapToolRegistryForSensitivity(this.scopedToolRegistry),
         policyGate: this.policy,
         memoryGovernor: this.memoryGovernor,
         consolidationProvider,


### PR DESCRIPTION
Surfaced by the adversarial runtime audit. T1 is a **live correctness bug**; T2/T3 are bundled correctness-positive cleanups in the same file.

## T1 — toolless AI loop on mobile/desktop (the bug)

`wireLoopDeps` snapshotted `loopDeps.tools = scopedToolRegistry.size > 0 ? wrap(...) : undefined` — a **one-shot read at wire time**. A runtime built with a provider but an **empty** tool registry, then populated via the raw `getToolRegistry().register(...)` (which has **no re-wire hook**, unlike `registerExternalTools`/`setProvider`/`updatePolicyConfig`), kept `loopDeps.tools === undefined` — and `ai-core/loop.ts` runs the agentic loop with **zero tools** when `deps.tools` is falsy.

That is the live construction shape on **both** surfaces:
- `apps/mobile/src/mobile-app.ts` — construct with `ai: provider`, no `tools` adapter → `registerBuiltinTools()` via raw `register`
- `apps/desktop/src/index.ts` — same shape → `registerDesktopTools(getToolRegistry())`

Masked today only by *incidental* re-wires (a configured MCP server, provider reconnect, operator-mode toggle). Masked, not safe.

**Fix:** always wrap — drop the `size > 0` gate. `wrapToolRegistryForSensitivity` forwards `list()`/`execute()` **live** against the scoped registry, and ai-core tolerates an empty `list()`, so this removes the snapshot without changing presence-filtering or sensitivity-gating.

**Test-first** (`toolless-loop-regression.test.ts`): drives the **real** `runTurnStreaming` — deliberately **not** mocking `@motebit/ai-core`, which is exactly why existing streaming tests miss this — and asserts via a provider that records the tools the loop offers it. The regression case **failed pre-fix** (`expected [] to include 'probe_tool'`) and **passes post-fix**; a second case guards that an empty registry still runs the loop cleanly.

### Liveness audit of the rest of `loopDeps` (reviewer note)
This removes `tools` from the manual-invalidation pattern entirely (the scoped registry is constructor-only/stable, so the wrapper is permanently live). The other fields were checked: the live closures (`getEffectiveSensitivity`, etc.) and the never-reassigned references (`events`/`memory`/`state`/`behavior`) are immune; the three reassignable references (`provider`/`policy`/`memoryGovernor`) still rely on manual re-wire, and all three reassignment sites **do** call `wireLoopDeps` today — correct-but-manual, latent fragility, deferred-with-trigger (unchanged by this PR).

## T2 — divergence hazard (correctness)

The "pending = signed − anchored" computation was duplicated byte-for-byte in `anchorPendingConsolidationReceipts` (the batch) and `maybeAutoAnchor` (the trigger). A change to what counts as "pending" in one and not the other would silently desync the trigger from the batch. Extracted a private `this`-bound `computePendingConsolidationReceipts() → { pending, lastAnchorAt }`; both callers consume it. Behavior-identical.

## T3 — dead state (cleanup)

`lastKnownClock` was declared but **never assigned** (frozen at 0), read once in `stop()` to stamp the synchronous snapshot. `stop()` can't await `getLatestClock()`, restore (`loadState`) ignores the snapshot clock, and the immediately-following `autoCompact()` re-saves with the authoritative clock. Removed the misleading field; `stop()` now stamps 0 with a comment explaining why. Behavior-identical.

## Verification

- Full runtime suite **1149/1149** (1147 baseline + 2 new), typecheck + lint clean, pre-push gate suite green.
- **No public API change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)