### PR TITLE
ci: independently reproduce agency.pdf-text.v1 (tool-pinned §7-tool gold rung)

### DIFF
--- a/.github/workflows/pdf-text-v1-reproduction.yml
+++ b/.github/workflows/pdf-text-v1-reproduction.yml
@@ -1,0 +1,32 @@
+# Independent reproduction of agency.computer's `agency.pdf-text.v1` recipe — the
+# tool-pinned §7-tool gold rung (docs/doctrine/evidence-provenance.md). motebit
+# rebuilds the wasm from the pinned spec source in the pinned rust image and
+# asserts the published tool digest, then runs the recipe's conformance over its
+# fixtures. "Verify, don't trust the tarball" — the whole point of tool-pinned.
+#
+# Deliberately NOT a per-PR gate: it depends on an EXTERNAL repo and a multi-
+# minute docker build. A red run is a cross-party reproducibility signal to take
+# back to agency, never a motebit merge blocker. Manual + weekly so drift (a
+# re-pin, a non-deterministic build, a host-divergent fixture) surfaces on a
+# cadence rather than at a filing.
+name: pdf-text.v1 reproduction
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  reproduce:
+    runs-on: ubuntu-latest # docker + node preinstalled
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+      - name: Reproduce agency.pdf-text.v1 (rebuild → assert digest → conformance)
+        run: bash scripts/verify-pdf-text-v1-reproduction.sh

--- a/scripts/verify-pdf-text-v1-reproduction.sh
+++ b/scripts/verify-pdf-text-v1-reproduction.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Independent reproduction of agency.pdf-text.v1 — the tool-pinned §7-tool gold rung.
+#
+# The whole value of a `tool-pinned` projection class is that a third party
+# REBUILDS the tool from pinned source in a pinned image and verifies the digest,
+# rather than trusting a published tarball (docs/doctrine/evidence-provenance.md
+# §7-tool; the second projection conformance class, protocol b4a1c9e3). This is
+# motebit standing up exactly that check against agency.computer's recipe.
+#
+# It is deliberately NOT part of the per-PR `check` gate: it depends on an
+# EXTERNAL repo + a multi-minute docker build, so it runs on its own schedule /
+# on demand (see .github/workflows/pdf-text-v1-reproduction.yml). A red here is a
+# cross-party reproducibility signal, not a motebit merge blocker.
+#
+# Failure modes are kept distinct on purpose:
+#   - exit 3  → the recipe MOVED (pinned spec SHA no longer resolves to itself)
+#   - exit 4  → motebit-side orchestration gap (couldn't locate build.sh / wasm /
+#               conformance.mjs from agency's described layout) — fix THIS script
+#   - exit 5  → REPRODUCIBILITY GAP: the wasm built but its digest != expected.
+#               This is the finding agency asked to hear — same probe-it-loop.
+#   - exit 6  → conformance.mjs failed (wasm not byte-identical over the fixtures)
+#
+# Pins (override via env for a re-pin or a local networked run). When agency cuts
+# a new tool, the recipe id changes (immutable-recipe-id rule, §7-tool.3), so
+# bumping these is a deliberate, reviewable edit — the audit trail is the diff.
+set -euo pipefail
+
+SPEC_REPO="${SPEC_REPO:-https://github.com/agency-computer/pdf-text-spec}"
+SPEC_SHA="${SPEC_SHA:-a6372ed}"
+# Expected sha256 of the built wasm (the §7-tool tool digest, hex, no "sha256:").
+EXPECTED_TOOL_DIGEST="${EXPECTED_TOOL_DIGEST:-89c8f640efdd3a02ac900731137880a0945c432a8522c9b8f53a97e0f5b39045}"
+# The pinned, reproducible build image (rustc 1.93.1). Pinned by digest, not tag.
+BUILD_IMAGE="${BUILD_IMAGE:-rust@sha256:c0a38f5662afdb298898da1d70b909af4bda4e0acff2dc52aea6360a9b9c6956}"
+
+log()  { printf '\033[1m▸ %s\033[0m\n' "$*"; }
+fail() { printf '\033[31m✗ %s\033[0m\n' "$2" >&2; exit "$1"; }
+
+sha256_hex() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}';
+  else shasum -a 256 "$1" | awk '{print $1}'; fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ── 1. Fetch the recipe at its EXACT pin, and prove the pin didn't move ───────
+log "Cloning $SPEC_REPO @ $SPEC_SHA"
+git clone --quiet "$SPEC_REPO" "$WORK/spec"
+git -C "$WORK/spec" checkout --quiet "$SPEC_SHA"
+RESOLVED="$(git -C "$WORK/spec" rev-parse HEAD)"
+case "$RESOLVED" in
+  "$SPEC_SHA"*) log "Spec pin verified: $RESOLVED" ;;
+  *) fail 3 "Pinned spec SHA $SPEC_SHA resolved to $RESOLVED — the recipe moved under its pin." ;;
+esac
+
+# ── 2. Locate agency's described layout (tool/build.sh, conformance.mjs) ───────
+BUILD_SH="$(find "$WORK/spec" -name build.sh -path '*/tool/*' | head -1)"
+[ -n "$BUILD_SH" ] || BUILD_SH="$(find "$WORK/spec" -name build.sh | head -1)"
+[ -n "$BUILD_SH" ] || fail 4 "No tool/build.sh found in the spec repo — layout differs from agency's description; fix this script's discovery."
+TOOL_DIR="$(dirname "$BUILD_SH")"
+log "Found build script: ${BUILD_SH#"$WORK/spec/"}"
+
+# ── 3. Reproducible build in the pinned image (cargo fetches pinned deps) ──────
+log "Pulling pinned build image $BUILD_IMAGE"
+docker pull --quiet "$BUILD_IMAGE" >/dev/null
+log "Building wasm via build.sh inside the pinned image"
+# Mount the whole clone (build.sh may write outside tool/) and run from tool/.
+docker run --rm -v "$WORK/spec":/spec -w "/spec/${TOOL_DIR#"$WORK/spec/"}" \
+  "$BUILD_IMAGE" bash build.sh \
+  || fail 4 "build.sh exited non-zero inside the pinned image — build orchestration gap (not yet a reproducibility verdict)."
+
+# Discover the produced wasm (don't hardcode an output path we haven't seen).
+WASM="$(find "$WORK/spec" -name '*.wasm' -newer "$BUILD_SH" | head -1)"
+[ -n "$WASM" ] || WASM="$(find "$WORK/spec" -name '*.wasm' | head -1)"
+[ -n "$WASM" ] || fail 4 "build.sh produced no .wasm under the spec repo — orchestration gap; locate the real output."
+log "Built artifact: ${WASM#"$WORK/spec/"}"
+
+# ── 4. The reproducibility assertion — the heart of the gold rung ─────────────
+ACTUAL="$(sha256_hex "$WASM")"
+log "Expected digest: $EXPECTED_TOOL_DIGEST"
+log "Rebuilt  digest: $ACTUAL"
+if [ "$ACTUAL" != "$EXPECTED_TOOL_DIGEST" ]; then
+  fail 5 "REPRODUCIBILITY GAP — motebit's rebuilt wasm digest does not match agency's published tool digest. Per the gold-rung contract this is a finding to report back to agency (same probe-it-empirically loop), not a silent pass."
+fi
+log "✓ Reproducibility verified: rebuilt wasm IS byte-identical to sha256:$EXPECTED_TOOL_DIGEST"
+
+# ── 5. Conformance — run the verified wasm over the public-domain fixtures ─────
+CONF="$(find "$WORK/spec" -name conformance.mjs | head -1)"
+[ -n "$CONF" ] || fail 4 "No conformance.mjs found — layout differs from agency's description; fix discovery."
+CONF_DIR="$(dirname "$CONF")"
+if [ -f "$CONF_DIR/package.json" ] && [ ! -d "$CONF_DIR/node_modules" ]; then
+  log "Installing conformance deps (npm ci)"
+  ( cd "$CONF_DIR" && (npm ci --silent || npm install --silent) )
+fi
+log "Running conformance.mjs over the fixtures"
+( cd "$CONF_DIR" && node "$(basename "$CONF")" ) \
+  || fail 6 "conformance.mjs failed — the verified wasm is NOT byte-identical over the fixtures."
+
+log "✓ pdf-text.v1 independently reproduced: digest matches AND conformance passes."


### PR DESCRIPTION
motebit's side of the tool-pinned reproduction agency.computer asked for. The whole value of a `tool-pinned` projection class (docs/doctrine/evidence-provenance.md §7-tool; protocol `b4a1c9e3`) is that a third party **rebuilds and verifies** rather than trusting a published tarball. This stands that up: rebuild the wasm from pinned source in the pinned image, assert the published tool digest, run conformance over the fixtures.

> Until this runs green, motebit holds the rung as **agency's attestation, not motebit's reproduction.**

## What it does

`scripts/verify-pdf-text-v1-reproduction.sh`:
1. Clones `agency-computer/pdf-text-spec @ a6372ed` and **proves the pin didn't move** (HEAD == pinned SHA).
2. Rebuilds via `tool/build.sh` inside `rust@sha256:c0a38f…` (rustc 1.93.1).
3. **Asserts the rebuilt wasm digest == `sha256:89c8f640…`** — the heart of the gold rung.
4. Runs `conformance.mjs` over the public-domain IRS fixtures (byte-identity).

All pins are overridable env; a re-pin is a reviewable diff (immutable-recipe-id rule, §7-tool.3). Failure modes are **kept distinct on purpose**: exit `3` pin-moved · `4` motebit-side orchestration gap · `5` **reproducibility gap (the finding to report back to agency)** · `6` conformance fail.

`.github/workflows/pdf-text-v1-reproduction.yml` — `workflow_dispatch` + weekly. **Deliberately NOT a per-PR gate**: it depends on an external repo + a multi-minute docker build, so a red run is a cross-party reproducibility *signal*, never a motebit merge blocker.

## Honesty / validation path

This env is **network-blocked**, so the script is written against agency's *described* layout (`tool/build.sh`, `conformance.mjs`, the pinned image) and validated only for syntax (bash ✓, YAML ✓). **The first dispatch is the real test.** The script discovers exact paths and logs what it finds, so a first-run mismatch is a clean confirm-or-correct (likely exit `4` if a path differs), not a debug hunt.

Because `workflow_dispatch` only activates on the default branch, the first validation run happens **after merge** (`gh workflow run pdf-text-v1-reproduction.yml`). The change is fully additive and isolated — zero impact on existing CI or any package — so merging an isolated, non-blocking monitor and validating via the first dispatch is the intended flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)