### PR TITLE
ci(pdf-text-repro): surface exit 5 cleanly + Cargo.lock diagnostic

### DIFF
--- a/scripts/verify-pdf-text-v1-reproduction.sh
+++ b/scripts/verify-pdf-text-v1-reproduction.sh
@@ -42,7 +42,12 @@ sha256_hex() {
 }
 
 WORK="$(mktemp -d)"
-trap 'rm -rf "$WORK"' EXIT
+# build.sh's docker run writes target/ as ROOT (containers run as root), so a
+# plain `rm -rf` by the non-root runner fails — and a failing EXIT-trap rm both
+# floods the log and MASKS the script's real exit code (a reproducibility gap at
+# exit 5 looked like a bare exit 1). Clean as root via the runner's sudo, and
+# never let cleanup change the verdict.
+trap 'rm -rf "$WORK" 2>/dev/null || sudo rm -rf "$WORK" 2>/dev/null || true' EXIT
 
 # ── 1. Fetch the recipe at its EXACT pin, and prove the pin didn't move ───────
 log "Cloning $SPEC_REPO @ $SPEC_SHA"
@@ -60,6 +65,17 @@ BUILD_SH="$(find "$WORK/spec" -name build.sh -path '*/tool/*' | head -1)"
 [ -n "$BUILD_SH" ] || fail 4 "No tool/build.sh found in the spec repo — layout differs from agency's description; fix this script's discovery."
 TOOL_DIR="$(dirname "$BUILD_SH")"
 log "Found build script: ${BUILD_SH#"$WORK/spec/"}"
+
+# Reproducibility diagnostic. An unlocked dependency graph is the classic
+# non-hermetic build: transitive crates resolve to whatever crates.io serves at
+# build time, so the wasm bytes drift over time even from pinned source in a
+# pinned image. Surfaced because run 28169687361 rebuilt 76d7fbfb… ≠ 89c8f640…
+# while "Updating crates.io index" fetched current versions.
+if [ -f "$TOOL_DIR/Cargo.lock" ]; then
+  log "Cargo.lock present — dependency graph is locked."
+else
+  log "⚠ NO Cargo.lock in tool/ — transitive deps resolve at build time (primary reproducibility-gap suspect)."
+fi
 
 # ── 3. Reproducible build ─────────────────────────────────────────────────────
 # build.sh is the HOST orchestrator: it drives the pinned image ITSELF (it calls


### PR DESCRIPTION
Follow-up to #218. The reproduction's first real build (run `28169687361`) delivered the gold-rung finding agency invited.

## Finding: agency.pdf-text.v1 does NOT reproduce on a second host

At the **verified** pin `a6372ed`, in the **digest-verified** image `rust@sha256:c0a38f…`, `build.sh`'s `cargo build --release --target wasm32-wasip1` (with `--remap-path-prefix`) produces:

```
rebuilt (motebit):    76d7fbfbc215bf9b061fc90c3b11c9ac86482274a228bb39ad7833c0d6fbaddc
published (agency):   89c8f640efdd3a02ac900731137880a0945c432a8522c9b8f53a97e0f5b39045
→ REPRODUCIBILITY GAP (exit 5)
```

Not a measurement artifact: `build.sh`'s **own** `echo wasm sha256:` and motebit's computed digest agree on `76d7fbfb`. This is exactly the falsification the §7-tool gold rung exists to surface.

**Likely cause:** the run shows a fresh `Updating crates.io index` pulling current transitive versions (`adler2 2.0.1`, `thiserror 2.0.18`, …). With no committed `tool/Cargo.lock`, pinned image + pinned source still drift as crates.io publishes patches — the classic non-hermetic build. agency's "89c8f640 twice, Mac + CI" held *at one moment*, not over time.

## This PR (hygiene + diagnosis, not the finding)

- **EXIT trap** couldn't `rm` the root-owned `target/` that `build.sh`'s docker creates → the failing `rm` flooded the log **and masked exit 5 as a bare exit 1**. Now sudo-cleaned; cleanup never changes the verdict.
- **`Cargo.lock` diagnostic** — log whether `tool/Cargo.lock` exists, to confirm the root cause on the next run.

The finding stands regardless of these — the run is correctly RED. After merge, one re-dispatch yields a clean exit 5 + the `Cargo.lock` answer = the actionable report to hand agency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)