### PR TITLE
feat(policy): grant blast-radius enforcer — the vault before autonomous money (Inc 1)

### DIFF
--- a/packages/policy/src/__tests__/grant-blast-radius.test.ts
+++ b/packages/policy/src/__tests__/grant-blast-radius.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Adversarial suite for the grant blast-radius enforcer — the proof that the vault
+ * holds. Each test is a named attack from the threat analysis in
+ * `docs/doctrine/verify-family-fail-closed.md` §"Offline revocation freshness" and
+ * the principal audit of the implementation plan.
+ *
+ * Scope (honest): these exercise the TRUSTED-RUNTIME guarantees only — the
+ * cumulative/window/lifetime/action/nonce ceilings against an honest-but-fallible
+ * runtime (bugs, runaway loops, injection short of key-compromise) and the
+ * decomposition race. They do NOT and cannot prove the offline guarantee (a
+ * key/store-compromised delegate controls its own accumulator); that floor is
+ * grant-expiry + counterparty + onchain caps, and the revoke-then-deny COMPOSITION
+ * (verifier ∧ enforcer) is an Increment-2 test in the runtime, where the crypto
+ * verifier and this enforcer meet. The nonce tests here prove the dedupe MECHANISM;
+ * replay-of-a-signed-token binds when the nonce is the token's signed sequence (Inc 2).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  evaluateBlastRadius,
+  freshGrantSpendState,
+  canonicalizeCounterparty,
+  InMemoryGrantSpendStore,
+  type GrantSpendCeiling,
+  type GrantSpendState,
+  type MoneyAction,
+} from "../grant-blast-radius";
+
+const M = 1_000_000; // 1 USD in micro-units
+const GID = "grant-1";
+const PAYEE = "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpZHY5e7pump"; // base58-ish
+const T0 = 1_000_000_000;
+
+const act = (usd: number, counterparty = PAYEE): MoneyAction => ({
+  amount_micro: usd * M,
+  counterparty,
+});
+
+/** Drive a sequence of actions through the pure evaluator, threading state. */
+function runSeq(
+  ceiling: GrantSpendCeiling,
+  actions: Array<{ a: MoneyAction; nonce: number; now?: number }>,
+  start?: GrantSpendState,
+) {
+  let state = start ?? freshGrantSpendState(GID, T0);
+  const decisions = actions.map(({ a, nonce, now }) => {
+    const ev = evaluateBlastRadius(ceiling, state, a, nonce, now ?? T0);
+    if (ev.decision.allowed && ev.nextState) state = ev.nextState;
+    return ev.decision;
+  });
+  return { decisions, state };
+}
+
+describe("grant blast-radius — fail-closed defaults", () => {
+  it("absent total bound ⇒ deny (a money grant authorizes nothing without a cap)", () => {
+    expect(evaluateBlastRadius({}, freshGrantSpendState(GID, T0), act(1), 0, T0).decision).toEqual({
+      allowed: false,
+      denial: "ceiling_absent",
+    });
+    // per-counterparty / action-count alone do NOT bound total value → still denied.
+    const noTotal: GrantSpendCeiling = { per_counterparty_limit_micro: 10 * M, window_ms: 1000 };
+    expect(
+      evaluateBlastRadius(noTotal, freshGrantSpendState(GID, T0), act(1), 0, T0).decision.denial,
+    ).toBe("ceiling_absent");
+  });
+
+  it("a present limit of 0 is deny-all on that dimension, not allow-all", () => {
+    const zero: GrantSpendCeiling = { cumulative_limit_micro: 0, window_ms: 1000 };
+    expect(
+      evaluateBlastRadius(zero, freshGrantSpendState(GID, T0), act(1), 0, T0).decision.denial,
+    ).toBe("cumulative_exceeded");
+    const zeroLife: GrantSpendCeiling = { lifetime_limit_micro: 0 };
+    expect(
+      evaluateBlastRadius(zeroLife, freshGrantSpendState(GID, T0), act(1), 0, T0).decision.denial,
+    ).toBe("lifetime_exceeded");
+  });
+
+  it("a per-window limit with window_ms ≤ 0 is rejected (no roll math)", () => {
+    for (const window_ms of [0, -1]) {
+      const c: GrantSpendCeiling = { cumulative_limit_micro: 100 * M, window_ms };
+      expect(
+        evaluateBlastRadius(c, freshGrantSpendState(GID, T0), act(1), 0, T0).decision.denial,
+      ).toBe("invalid_window");
+    }
+  });
+});
+
+describe("grant blast-radius — amount validation (the refund/overflow bypass)", () => {
+  const c: GrantSpendCeiling = { cumulative_limit_micro: 100 * M, window_ms: 1000 };
+  it("negative, zero, NaN, Infinity, and non-integer amounts are denied", () => {
+    for (const bad of [-1 * M, 0, NaN, Infinity, -Infinity, 1.5]) {
+      const a: MoneyAction = { amount_micro: bad, counterparty: PAYEE };
+      expect(evaluateBlastRadius(c, freshGrantSpendState(GID, T0), a, 0, T0).decision.denial).toBe(
+        "invalid_amount",
+      );
+    }
+  });
+  it("a sum that would exceed MAX_SAFE_INTEGER is denied (overflow)", () => {
+    const huge: GrantSpendCeiling = { lifetime_limit_micro: Number.MAX_SAFE_INTEGER };
+    const state: GrantSpendState = {
+      ...freshGrantSpendState(GID, T0),
+      lifetime_spent_micro: Number.MAX_SAFE_INTEGER - 10,
+    };
+    const a: MoneyAction = { amount_micro: 100, counterparty: PAYEE };
+    expect(evaluateBlastRadius(huge, state, a, 0, T0).decision.denial).toBe("invalid_amount");
+  });
+});
+
+describe("grant blast-radius — the decomposition attack", () => {
+  it("N individually-small spends are denied at the one that crosses the cumulative cap", () => {
+    // Per-turn value ($10) always passes a per-turn check; the cumulative window ($100) blocks the 11th.
+    const c: GrantSpendCeiling = { cumulative_limit_micro: 100 * M, window_ms: 60_000 };
+    const actions = Array.from({ length: 12 }, (_, i) => ({ a: act(10), nonce: i }));
+    const { decisions } = runSeq(c, actions);
+    const allowed = decisions.filter((d) => d.allowed).length;
+    expect(allowed).toBe(10); // $10 × 10 = $100 exactly
+    expect(decisions[10]!.denial).toBe("cumulative_exceeded"); // the 11th ($110) crosses
+    expect(decisions[11]!.denial).toBe("cumulative_exceeded");
+  });
+
+  it("the grant-lifetime cap bounds total spend across MANY windows (the real total bound)", () => {
+    // $50/window but $120 lifetime: window rolls let cumulative reset, lifetime does not.
+    const c: GrantSpendCeiling = {
+      cumulative_limit_micro: 50 * M,
+      lifetime_limit_micro: 120 * M,
+      window_ms: 1000,
+    };
+    // Three windows, $50 each = $150 attempted; lifetime caps at $120.
+    const actions = [
+      { a: act(50), nonce: 0, now: T0 },
+      { a: act(50), nonce: 1, now: T0 + 1000 }, // window 2
+      { a: act(50), nonce: 2, now: T0 + 2000 }, // window 3 — would be $150 lifetime
+    ];
+    const { decisions, state } = runSeq(c, actions);
+    expect(decisions[0]!.allowed).toBe(true);
+    expect(decisions[1]!.allowed).toBe(true);
+    expect(decisions[2]!.denial).toBe("lifetime_exceeded"); // $100 + $50 > $120
+    expect(state.lifetime_spent_micro).toBe(100 * M);
+  });
+});
+
+describe("grant blast-radius — window roll & boundary gaming", () => {
+  it("the cumulative window resets after window_ms; lifetime persists", () => {
+    const c: GrantSpendCeiling = { cumulative_limit_micro: 100 * M, window_ms: 1000 };
+    const { decisions, state } = runSeq(c, [
+      { a: act(100), nonce: 0, now: T0 },
+      { a: act(100), nonce: 1, now: T0 + 1000 }, // new window → allowed again
+    ]);
+    expect(decisions.every((d) => d.allowed)).toBe(true);
+    expect(state.window_spent_micro).toBe(100 * M); // reset then refilled
+  });
+
+  it("documents the 2×-at-boundary property — and the lifetime cap is the real bound", () => {
+    // Full window at end of W1 + full window at start of W2 = 2× the window cap in seconds.
+    // This is intrinsic to tumbling windows; the LIFETIME cap is what actually bounds it.
+    const noLife: GrantSpendCeiling = { cumulative_limit_micro: 100 * M, window_ms: 1000 };
+    const boundary = runSeq(noLife, [
+      { a: act(100), nonce: 0, now: T0 + 999 }, // end of window 1
+      { a: act(100), nonce: 1, now: T0 + 1000 }, // start of window 2
+    ]);
+    expect(boundary.decisions.every((d) => d.allowed)).toBe(true); // 2× passes without a lifetime cap
+
+    const withLife: GrantSpendCeiling = { ...noLife, lifetime_limit_micro: 150 * M };
+    const bounded = runSeq(withLife, [
+      { a: act(100), nonce: 0, now: T0 + 999 },
+      { a: act(100), nonce: 1, now: T0 + 1000 },
+    ]);
+    expect(bounded.decisions[1]!.denial).toBe("lifetime_exceeded"); // lifetime catches the boundary game
+  });
+
+  it("a rolled-back clock never resets the window (no headroom widening)", () => {
+    const c: GrantSpendCeiling = { cumulative_limit_micro: 100 * M, window_ms: 1000 };
+    const { decisions } = runSeq(c, [
+      { a: act(100), nonce: 0, now: T0 + 500 },
+      { a: act(50), nonce: 1, now: T0 - 10_000 }, // clock jumps backward — must NOT reset
+    ]);
+    expect(decisions[0]!.allowed).toBe(true);
+    expect(decisions[1]!.denial).toBe("cumulative_exceeded"); // window not reset → $150 > $100
+  });
+});
+
+describe("grant blast-radius — nonce dedupe mechanism", () => {
+  it("a nonce ≤ the high-water mark is denied (monotonic)", () => {
+    const c: GrantSpendCeiling = { lifetime_limit_micro: 100 * M };
+    const { decisions } = runSeq(c, [
+      { a: act(1), nonce: 5 },
+      { a: act(1), nonce: 5 }, // replay of same nonce
+      { a: act(1), nonce: 3 }, // older nonce
+      { a: act(1), nonce: 6 }, // strictly newer → ok
+    ]);
+    expect(decisions[0]!.allowed).toBe(true);
+    expect(decisions[1]!.denial).toBe("replay");
+    expect(decisions[2]!.denial).toBe("replay");
+    expect(decisions[3]!.allowed).toBe(true);
+  });
+});
+
+describe("grant blast-radius — per-counterparty cap & address canonicalization", () => {
+  it("EVM hex encoding variants of one payee collapse to a single bucket", () => {
+    const a = "0xAbCdEf0000000000000000000000000000000001";
+    const variants = [a.toLowerCase(), a.toUpperCase().replace("0X", "0x"), a, `  ${a}  `];
+    const canon = variants.map(canonicalizeCounterparty);
+    expect(new Set(canon).size).toBe(1); // all one canonical key
+
+    // Spend $60 to the payee in two encodings against a $100 per-counterparty cap → the 2nd ($120) denied.
+    const c: GrantSpendCeiling = {
+      cumulative_limit_micro: 1000 * M,
+      per_counterparty_limit_micro: 100 * M,
+      window_ms: 60_000,
+    };
+    const { decisions } = runSeq(c, [
+      { a: act(60, variants[0]!), nonce: 0 },
+      { a: act(60, variants[2]!), nonce: 1 }, // same payee, different encoding
+    ]);
+    expect(decisions[0]!.allowed).toBe(true);
+    expect(decisions[1]!.denial).toBe("per_counterparty_exceeded"); // canonicalized → one bucket
+  });
+
+  it("base58 (case-sensitive) addresses are NOT lowercased; distinct payees stay distinct", () => {
+    const c: GrantSpendCeiling = {
+      cumulative_limit_micro: 1000 * M,
+      per_counterparty_limit_micro: 100 * M,
+      window_ms: 60_000,
+    };
+    const { decisions } = runSeq(c, [
+      { a: act(60, "AbcPayee111"), nonce: 0 },
+      { a: act(60, "abcPayee111"), nonce: 1 }, // different base58 case = different address
+    ]);
+    expect(decisions.every((d) => d.allowed)).toBe(true); // two distinct buckets, each under $100
+  });
+
+  it("an unparseable destination is denied", () => {
+    const c: GrantSpendCeiling = { lifetime_limit_micro: 100 * M };
+    const a: MoneyAction = { amount_micro: 1 * M, counterparty: "   " };
+    expect(evaluateBlastRadius(c, freshGrantSpendState(GID, T0), a, 0, T0).decision.denial).toBe(
+      "invalid_counterparty",
+    );
+  });
+
+  it("action-count cap bounds the number of moves per window", () => {
+    const c: GrantSpendCeiling = {
+      cumulative_limit_micro: 1000 * M,
+      max_action_count: 2,
+      window_ms: 60_000,
+    };
+    const { decisions } = runSeq(c, [
+      { a: act(1), nonce: 0 },
+      { a: act(1), nonce: 1 },
+      { a: act(1), nonce: 2 }, // 3rd action in the window
+    ]);
+    expect(decisions[2]!.denial).toBe("action_count_exceeded");
+  });
+});
+
+describe("grant blast-radius — atomic store (the decomposition RACE)", () => {
+  it("two concurrent tryConsume that each pass the read cannot both commit", async () => {
+    const store = new InMemoryGrantSpendStore();
+    const c: GrantSpendCeiling = { cumulative_limit_micro: 100 * M, window_ms: 60_000 };
+    // Each is $60; either alone fits ($60 ≤ $100), but together ($120) must not both pass.
+    const [d1, d2] = await Promise.all([
+      store.tryConsume({ grant_id: GID, ceiling: c, action: act(60), nonce: 0, now: T0 }),
+      store.tryConsume({ grant_id: GID, ceiling: c, action: act(60), nonce: 1, now: T0 }),
+    ]);
+    const allowed = [d1, d2].filter((d) => d.allowed).length;
+    expect(allowed).toBe(1); // exactly one commits; the other sees the committed spend
+    expect(store.peek(GID)!.window_spent_micro).toBe(60 * M);
+  });
+
+  it("the store rejects a replayed nonce across calls", async () => {
+    const store = new InMemoryGrantSpendStore();
+    const c: GrantSpendCeiling = { lifetime_limit_micro: 100 * M };
+    const first = await store.tryConsume({
+      grant_id: GID,
+      ceiling: c,
+      action: act(1),
+      nonce: 7,
+      now: T0,
+    });
+    const replay = await store.tryConsume({
+      grant_id: GID,
+      ceiling: c,
+      action: act(1),
+      nonce: 7,
+      now: T0,
+    });
+    expect(first.allowed).toBe(true);
+    expect(replay.denial).toBe("replay");
+  });
+});

--- a/packages/policy/src/grant-blast-radius.ts
+++ b/packages/policy/src/grant-blast-radius.ts
@@ -1,0 +1,320 @@
+/**
+ * Grant blast-radius enforcement — the cumulative ceiling on autonomous spend
+ * under a standing-delegation grant.
+ *
+ * ## What this is
+ *
+ * A pure, fail-closed enforcer that bounds the CUMULATIVE money an agent may move
+ * autonomously under one grant — across turns, not just within a turn. It is the
+ * "vault" that must exist before any standing-delegation auto-execution (R4_MONEY
+ * with a `verifiedGrant`) is wired live: today's `BudgetEnforcer` bounds a single
+ * turn; nothing bounds the decomposition attack (one large payment split into a
+ * hundred individually-small ones across turns). This closes that, as a SECOND
+ * fail-closed guard that composes with — never relaxes — the R4 standing-authority
+ * invariant in `policy-gate.ts` (step 8b) and `check-money-authority`.
+ *
+ * ## Threat model — read this before trusting it
+ *
+ * These ceilings bind the **trusted-runtime / online path only**: an honest-but-
+ * fallible runtime (a bug, a runaway agentic loop, prompt-injection that does NOT
+ * compromise the signing key or this store), and any path where a trusted party
+ * (the relay) holds the accumulator. They are **NOT an offline guarantee**. Per
+ * `docs/doctrine/verify-family-fail-closed.md` §"Offline revocation freshness", a
+ * cumulative counter the delegate tallies for itself does not bind a delegate that
+ * is itself the adversary — a key/store-compromised delegate controls its own
+ * `GrantSpendStore` and simply does not commit. Offline, the binding ceilings are
+ * the grant's TOTAL SCOPE (`expires_at`), what each COUNTERPARTY independently
+ * enforces against tokens it sees, and onchain rate caps at the rail
+ * (`spec/settlement-v1.md` §"Onchain spending limits"). This module is the
+ * trusted-runtime layer of that defense-in-depth stack — labeled honestly, never
+ * sold as the offline cure.
+ *
+ * ## Don't collapse — this is a FOURTH spend boundary, not a merge
+ *
+ * Distinct from three existing primitives, deliberately:
+ *   - per-turn resource budget — `BudgetEnforcer` (`./budget.ts`): calls/time/cost
+ *     within ONE turn. Reset every turn. Resource, not money-destination.
+ *   - goal self-execution budget — `checkGoalBudget` (`@motebit/runtime` `goals.ts`):
+ *     a goal's own cumulative inference spend. Self-execution, token-axis.
+ *   - per-task peer-delegation cap — `BudgetAllocation` (`@motebit/panels`
+ *     `sovereign/controller.ts`): what a PEER agent may spend on one delegated task.
+ * This is the grant-scoped ceiling on what THIS agent may spend AUTONOMOUSLY (no
+ * human in the loop) under a standing grant. Self-execution vs peer-delegation vs
+ * per-turn-resource vs autonomous-money: four boundaries. Don't collapse them.
+ *
+ * ## Layer
+ *
+ * BSL judgment (`@motebit/policy`). `GrantSpendState` is private accumulated state,
+ * not interop law — it never crosses a wire, so it lives here, not in
+ * `@motebit/protocol`. The signed-grant binding of `GrantSpendCeiling` (the ceiling
+ * as the delegator's cryptographic commitment) is a later increment that will force
+ * the wire shape against the published `StandingDelegation` artifact.
+ */
+
+/**
+ * The cumulative ceiling a grant authorizes. Fail-closed: a money grant MUST bound
+ * total exposure, so at least one of `cumulative_limit_micro` / `lifetime_limit_micro`
+ * is required (see `evaluateBlastRadius` — a ceiling with neither is denied). Every
+ * limit is in integer micro-units (1 USD = 1,000,000); zero floating point on the
+ * money path. A SET limit of `0` denies all positive spend on that dimension
+ * (deny-all, not allow-all). Unset per-dimension limits do not bound that dimension,
+ * but the required total bound still applies.
+ *
+ * Dimensions are an intentionally closed-extensible set (the `goals.ts` axis
+ * pattern): a future axis (e.g. `capability_class_limit`) is an additive field, not
+ * a signature change.
+ */
+export interface GrantSpendCeiling {
+  /** Max cumulative spend within one rolling window. Requires `window_ms`. */
+  readonly cumulative_limit_micro?: number;
+  /** Max spend to any single (canonical) counterparty within one window. Requires `window_ms`. */
+  readonly per_counterparty_limit_micro?: number;
+  /** Max number of money actions within one window. Requires `window_ms`. */
+  readonly max_action_count?: number;
+  /**
+   * Max cumulative spend over the grant's ENTIRE life — never reset by a window
+   * roll. The offline-meaningful total bound (paired with the grant's `expires_at`).
+   */
+  readonly lifetime_limit_micro?: number;
+  /** Rolling window length in ms. Required (and must be > 0) when any per-window limit is set. */
+  readonly window_ms?: number;
+}
+
+/** A proposed autonomous money movement. `amount_micro` is integer micro-units, > 0. */
+export interface MoneyAction {
+  readonly amount_micro: number;
+  /** Destination identity; canonicalized via `canonicalizeCounterparty` before bucketing. */
+  readonly counterparty: string;
+}
+
+/**
+ * Private per-grant accumulator. NOT interop law — never crosses a wire. The
+ * window fields reset on roll; `lifetime_spent_micro` and `high_water_nonce` never do.
+ */
+export interface GrantSpendState {
+  readonly grant_id: string;
+  /** Injected-clock ms at which the current window opened. */
+  readonly window_started_at: number;
+  readonly window_spent_micro: number;
+  readonly window_action_count: number;
+  /** Canonical counterparty → spend within the current window. */
+  readonly per_counterparty_micro: Readonly<Record<string, number>>;
+  /** Cumulative spend over the grant's whole life. Never reset. */
+  readonly lifetime_spent_micro: number;
+  /** Highest token sequence consumed (monotonic). `-1` = none yet. */
+  readonly high_water_nonce: number;
+}
+
+/** Why a blast-radius check denied — first failure wins (ordered most-fundamental first). */
+export type BlastRadiusDenial =
+  | "ceiling_absent" // no total bound set ⇒ a money grant authorizes nothing
+  | "invalid_amount" // non-positive, non-integer, or would overflow MAX_SAFE_INTEGER
+  | "invalid_counterparty" // unparseable / empty destination
+  | "invalid_window" // a per-window limit is set but window_ms ≤ 0
+  | "replay" // nonce ≤ high-water (dedupe; replay-of-signed-token lands with the wire binding)
+  | "lifetime_exceeded"
+  | "cumulative_exceeded"
+  | "per_counterparty_exceeded"
+  | "action_count_exceeded";
+
+export interface BlastRadiusDecision {
+  readonly allowed: boolean;
+  /** Present iff `!allowed`. The first dimension that denied. */
+  readonly denial?: BlastRadiusDenial;
+  /** Headroom remaining after this action would commit (telemetry/UI). Present iff allowed. */
+  readonly remaining?: {
+    readonly cumulative_micro?: number;
+    readonly lifetime_micro?: number;
+    readonly per_counterparty_micro?: number;
+    readonly actions?: number;
+  };
+}
+
+/** Result of the pure evaluator: the decision plus the post-commit state (only on allow). */
+export interface BlastRadiusEvaluation {
+  readonly decision: BlastRadiusDecision;
+  /** The state to persist iff `decision.allowed`. Undefined on denial (no mutation). */
+  readonly nextState?: GrantSpendState;
+}
+
+/** A fresh, zeroed accumulator for a grant whose first window opens at `now`. */
+export function freshGrantSpendState(grant_id: string, now: number): GrantSpendState {
+  return {
+    grant_id,
+    window_started_at: now,
+    window_spent_micro: 0,
+    window_action_count: 0,
+    per_counterparty_micro: {},
+    lifetime_spent_micro: 0,
+    high_water_nonce: -1,
+  };
+}
+
+/**
+ * Canonicalize a counterparty so encoding variants of the same destination map to
+ * one bucket (else an adversary mints N sub-limits by varying the encoding).
+ * EVM hex (`0x` + 40 hex) is case-insensitive (EIP-55 checksum casing) → lowercased.
+ * Other forms (base58 Solana addresses are case-SENSITIVE) are trimmed only.
+ * Empty/whitespace ⇒ `null` (fail-closed: an unparseable destination is denied).
+ */
+export function canonicalizeCounterparty(raw: string): string | null {
+  const t = raw.trim();
+  if (t.length === 0) return null;
+  if (/^0x[0-9a-fA-F]{40}$/.test(t)) return t.toLowerCase();
+  return t;
+}
+
+const deny = (denial: BlastRadiusDenial): BlastRadiusEvaluation => ({
+  decision: { allowed: false, denial },
+});
+
+/**
+ * Pure blast-radius algebra — no I/O, injected clock. Given a ceiling, the current
+ * accumulator, a proposed action, its nonce, and `now`, decide allow/deny and (on
+ * allow) return the next accumulator. Strict & fail-closed throughout; the stateful
+ * `GrantSpendStore` wraps this in an atomic check-and-commit.
+ */
+export function evaluateBlastRadius(
+  ceiling: GrantSpendCeiling,
+  state: GrantSpendState,
+  action: MoneyAction,
+  nonce: number,
+  now: number,
+): BlastRadiusEvaluation {
+  // 1. Amount must be a positive safe integer (negative = refund-headroom attack;
+  //    zero burns a nonce/action for free; non-integer breaks the micro-unit model).
+  const amt = action.amount_micro;
+  if (!Number.isSafeInteger(amt) || amt <= 0) return deny("invalid_amount");
+
+  // 2. Destination must canonicalize.
+  const cp = canonicalizeCounterparty(action.counterparty);
+  if (cp === null) return deny("invalid_counterparty");
+
+  // 3. A money grant must bound total exposure somehow. Neither total bound ⇒ deny.
+  const hasWindowLimit =
+    ceiling.cumulative_limit_micro !== undefined ||
+    ceiling.per_counterparty_limit_micro !== undefined ||
+    ceiling.max_action_count !== undefined;
+  const hasTotalBound =
+    ceiling.cumulative_limit_micro !== undefined || ceiling.lifetime_limit_micro !== undefined;
+  if (!hasTotalBound) return deny("ceiling_absent");
+
+  // 4. A per-window limit requires a positive window.
+  if (hasWindowLimit && !(typeof ceiling.window_ms === "number" && ceiling.window_ms > 0)) {
+    return deny("invalid_window");
+  }
+
+  // 5. Replay dedupe — strictly increasing nonce (monotonic high-water, O(1)).
+  if (nonce <= state.high_water_nonce) return deny("replay");
+
+  // 6. Window roll. Only roll FORWARD: a rolled-back clock (now < window_started_at)
+  //    must never reset the window (that would widen headroom). Lifetime never rolls.
+  const windowMs = ceiling.window_ms ?? 0;
+  const rolled = hasWindowLimit && windowMs > 0 && now >= state.window_started_at + windowMs;
+  const windowStartedAt = rolled ? now : state.window_started_at;
+  const windowSpent = rolled ? 0 : state.window_spent_micro;
+  const windowActions = rolled ? 0 : state.window_action_count;
+  const perCp = rolled ? {} : state.per_counterparty_micro;
+  const cpSpent = perCp[cp] ?? 0;
+
+  // 7. Overflow guard on every running sum before comparing.
+  const newWindow = windowSpent + amt;
+  const newLifetime = state.lifetime_spent_micro + amt;
+  const newCp = cpSpent + amt;
+  if (!Number.isSafeInteger(newWindow) || !Number.isSafeInteger(newLifetime)) {
+    return deny("invalid_amount");
+  }
+
+  // 8. Ceilings — lifetime first (strongest bound), then window dimensions.
+  if (ceiling.lifetime_limit_micro !== undefined && newLifetime > ceiling.lifetime_limit_micro) {
+    return deny("lifetime_exceeded");
+  }
+  if (ceiling.cumulative_limit_micro !== undefined && newWindow > ceiling.cumulative_limit_micro) {
+    return deny("cumulative_exceeded");
+  }
+  if (
+    ceiling.per_counterparty_limit_micro !== undefined &&
+    newCp > ceiling.per_counterparty_limit_micro
+  ) {
+    return deny("per_counterparty_exceeded");
+  }
+  if (ceiling.max_action_count !== undefined && windowActions + 1 > ceiling.max_action_count) {
+    return deny("action_count_exceeded");
+  }
+
+  // 9. Allowed — produce the committed state + remaining headroom.
+  const nextState: GrantSpendState = {
+    grant_id: state.grant_id,
+    window_started_at: windowStartedAt,
+    window_spent_micro: newWindow,
+    window_action_count: windowActions + 1,
+    per_counterparty_micro: { ...perCp, [cp]: newCp },
+    lifetime_spent_micro: newLifetime,
+    high_water_nonce: nonce,
+  };
+  const remaining = {
+    ...(ceiling.cumulative_limit_micro !== undefined
+      ? { cumulative_micro: ceiling.cumulative_limit_micro - newWindow }
+      : {}),
+    ...(ceiling.lifetime_limit_micro !== undefined
+      ? { lifetime_micro: ceiling.lifetime_limit_micro - newLifetime }
+      : {}),
+    ...(ceiling.per_counterparty_limit_micro !== undefined
+      ? { per_counterparty_micro: ceiling.per_counterparty_limit_micro - newCp }
+      : {}),
+    ...(ceiling.max_action_count !== undefined
+      ? { actions: ceiling.max_action_count - (windowActions + 1) }
+      : {}),
+  };
+  return { decision: { allowed: true, remaining }, nextState };
+}
+
+/**
+ * Atomic check-and-commit store for grant spend. The contract is a SINGLE atomic
+ * operation — never a `get()` then a later `commit()` with a gap between — so two
+ * concurrent money actions cannot both pass a ceiling check before either commits
+ * (the decomposition attack's race variant). The persistent (Inc 2) implementation
+ * must achieve this via compare-and-set / `appendWithClock` (`CLAUDE.md`); the
+ * in-memory reference below achieves it by running read→evaluate→write with no
+ * `await` in between (JS run-to-completion).
+ */
+export interface GrantSpendStore {
+  tryConsume(input: {
+    grant_id: string;
+    ceiling: GrantSpendCeiling;
+    action: MoneyAction;
+    nonce: number;
+    now: number;
+  }): Promise<BlastRadiusDecision>;
+}
+
+/** Reference in-memory store. Atomic by construction (no await between read and write). */
+export class InMemoryGrantSpendStore implements GrantSpendStore {
+  private readonly states = new Map<string, GrantSpendState>();
+
+  tryConsume(input: {
+    grant_id: string;
+    ceiling: GrantSpendCeiling;
+    action: MoneyAction;
+    nonce: number;
+    now: number;
+  }): Promise<BlastRadiusDecision> {
+    // read → evaluate → write, synchronously: no interleaving point.
+    const state =
+      this.states.get(input.grant_id) ?? freshGrantSpendState(input.grant_id, input.now);
+    const { decision, nextState } = evaluateBlastRadius(
+      input.ceiling,
+      state,
+      input.action,
+      input.nonce,
+      input.now,
+    );
+    if (decision.allowed && nextState) this.states.set(input.grant_id, nextState);
+    return Promise.resolve(decision);
+  }
+
+  /** Test/inspection helper — current accumulator for a grant, if any. */
+  peek(grant_id: string): GrantSpendState | undefined {
+    return this.states.get(grant_id);
+  }
+}

--- a/packages/policy/src/index.ts
+++ b/packages/policy/src/index.ts
@@ -3,6 +3,21 @@
 export { classifyTool, isToolAllowed } from "./risk-model.js";
 export { BudgetEnforcer, DEFAULT_BUDGET } from "./budget.js";
 export type { BudgetConfig, BudgetCheckResult } from "./budget.js";
+export {
+  evaluateBlastRadius,
+  freshGrantSpendState,
+  canonicalizeCounterparty,
+  InMemoryGrantSpendStore,
+} from "./grant-blast-radius.js";
+export type {
+  GrantSpendCeiling,
+  MoneyAction,
+  GrantSpendState,
+  BlastRadiusDenial,
+  BlastRadiusDecision,
+  BlastRadiusEvaluation,
+  GrantSpendStore,
+} from "./grant-blast-radius.js";
 export { RedactionEngine } from "./redaction.js";
 export {
   ContentSanitizer,


### PR DESCRIPTION
## What

Increment 1 of the **autonomous standing-delegation execution** arc — the capability that lets a motebit act on your behalf under cryptographic authority you signed once and can revoke. This is **the vault before the gold**: a pure, fail-closed cumulative-spend enforcer that must exist before any live wiring.

`packages/policy/src/grant-blast-radius.ts` bounds what an agent may move **autonomously across turns** under one grant — closing the **decomposition attack** (one large payment split into many individually-small ones) that today's per-turn `BudgetEnforcer` cannot see. It is a **second** fail-closed guard that composes with — never relaxes — the R4 standing-authority invariant (`policy-gate.ts` step 8b / `check-money-authority`, both verified untouched).

## Honest threat model (the principal-review audit's #1 fix)

These ceilings bind the **trusted-runtime / online path only** — an honest-but-fallible runtime (bugs, runaway loops, prompt-injection short of key-compromise). They are **not** an offline guarantee: a key/store-compromised delegate controls its own accumulator. Per `verify-family-fail-closed.md §37`, the offline-binding floor is grant-total-scope (`expires_at`) + counterparty-enforced limits + onchain rail caps. This module is the **trusted-runtime layer of a defense-in-depth stack** — labeled as such in the module and the suite, never sold as the offline cure.

## Design

- **Entirely in `@motebit/policy`** (private accumulator state isn't interop law); `@motebit/protocol` untouched. Modeled on the `goals.ts` axis pattern, with the mandatory "don't-collapse" positioning vs the three sibling spend primitives (`BudgetEnforcer` / `checkGoalBudget` / `BudgetAllocation`).
- **Atomic `tryConsume`** (no check-then-commit race); positive-safe-integer amount validation + overflow guard; **grant-lifetime cap** (never reset by window roll — the real total bound); monotonic high-water nonce (dedupe mechanism; replay-of-a-signed-token binds in Inc 2 with the wire nonce); counterparty address canonicalization (EVM hex lowercased, base58 case-preserved); degenerate-ceiling deny-all; clock-rollback never widens headroom.

## Scope — exposes nothing

No `verifyGrantForTurn` caller, no grant store, no accrual basis, no wire-format change, **no live money**. Cannot move a cent on merge. The live wiring + signed-grant ceiling binding + accrual basis land in Inc 2, **behind a recorded human checkpoint** (the founder ratifies threat model + ceiling semantics + wire shape + revocation-latency bound).

## Verification

17-test adversarial suite (decomposition, the race, replay-dedupe, lifetime cap, address-variant bucketing, degenerate ceilings, amount/overflow validation, clock-rollback, window-boundary). `@motebit/policy` typecheck + lint + full suite green (442 prior + 17); `check-deps` + `check-money-authority` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)