### PR TITLE
feat(protocol,crypto): settlement-invoice@1.0 kernel — the bill that extends the receipt chain to the money

### DIFF
--- a/.changeset/settlement-invoice-kernel.md
+++ b/.changeset/settlement-invoice-kernel.md
@@ -1,0 +1,8 @@
+---
+"@motebit/protocol": minor
+"@motebit/crypto": minor
+---
+
+settlement-invoice@1.0 kernel — the bill that extends the receipt chain to the money.
+
+Adds `CostAttestationV1` + `InvoiceV1` (and their structured verdicts) to `@motebit/protocol`, and `executionReceiptDigest` / `costAttestationDigest` / `signCostAttestation` / `verifyCostAttestation` / `signInvoice` / `verifyInvoice` to `@motebit/crypto`. motebit owns the format; the issuer runs the rails — no charge/balance/ledger primitive. Offline-verifiable, structured per-axis verdicts (including the stale-cost-overstatement customer-protection axis). Spec: `spec/settlement-invoice-v1.md`. Forced by agency.computer stage-2 billing.

--- a/packages/crypto/etc/crypto.api.md
+++ b/packages/crypto/etc/crypto.api.md
@@ -12,6 +12,8 @@ import type { ComputerSessionActionRecord } from '@motebit/protocol';
 import type { ConsolidationMutationManifest } from '@motebit/protocol';
 import type { ConsolidationReceipt } from '@motebit/protocol';
 import type { ContentArtifactType } from '@motebit/protocol';
+import type { CostAttestationV1 } from '@motebit/protocol';
+import type { CostAttestationVerdict } from '@motebit/protocol';
 import type { CredentialBundle } from '@motebit/protocol';
 import type { DelegationRevocation } from '@motebit/protocol';
 import type { DelegationToken } from '@motebit/protocol';
@@ -25,12 +27,15 @@ import type { DisputeRequest } from '@motebit/protocol';
 import type { DisputeResolution } from '@motebit/protocol';
 import type { EvidenceProvenance } from '@motebit/protocol';
 import type { EvidenceRef } from '@motebit/protocol';
+import type { ExecutionReceipt as ExecutionReceipt_2 } from '@motebit/protocol';
 import type { ExecutionTimelineEntry } from '@motebit/protocol';
 import type { FederationSettlementRecord } from '@motebit/protocol';
 import type { GoalExecutionManifest } from '@motebit/protocol';
 import type { HardwareAttestationClaim } from '@motebit/protocol';
 import type { HorizonWitness } from '@motebit/protocol';
 import type { HorizonWitnessRequestBody } from '@motebit/protocol';
+import type { InvoiceV1 } from '@motebit/protocol';
+import type { InvoiceVerdict } from '@motebit/protocol';
 import type { MerkleTreeVersion } from '@motebit/protocol';
 import type { MigrationPresentation } from '@motebit/protocol';
 import type { MigrationRequest } from '@motebit/protocol';
@@ -266,6 +271,13 @@ export interface ContentArtifactManifest {
     readonly signature: string;
     readonly suite: SuiteId;
 }
+
+// @public
+export function costAttestationDigest(att: CostAttestationV1): Promise<string>;
+
+export { CostAttestationV1 }
+
+export { CostAttestationVerdict }
 
 // @public (undocumented)
 export function createPresentation(credentials: VerifiableCredential[], privateKey: Uint8Array, publicKey: Uint8Array): Promise<VerifiablePresentation>;
@@ -508,6 +520,9 @@ export interface ExecutionReceipt {
     // (undocumented)
     tools_used: string[];
 }
+
+// @public
+export function executionReceiptDigest(receipt: ExecutionReceipt_2): Promise<string>;
 
 // @public
 export const FEDERATION_SETTLEMENT_ANCHOR_SUITE: "motebit-jcs-ed25519-hex-v1";
@@ -756,6 +771,10 @@ export interface IdentityVerifyResult extends BaseResult {
 
 // @public
 export type IntegrityVerdict = "verified" | "invalid";
+
+export { InvoiceV1 }
+
+export { InvoiceVerdict }
 
 // @public
 export function isAnnouncementSurface(s: unknown): s is AnnouncementSurface;
@@ -1311,6 +1330,9 @@ export interface SignContentArtifactOptions {
 }
 
 // @public
+export function signCostAttestation(input: Omit<CostAttestationV1, "signature" | "suite">, issuerPrivateKey: Uint8Array): Promise<CostAttestationV1>;
+
+// @public
 export function signCredentialBundle(bundle: Omit<CredentialBundle, "bundle_hash" | "signature">, privateKey: Uint8Array): Promise<CredentialBundle>;
 
 // @public
@@ -1394,6 +1416,9 @@ export function signHorizonWitness(cert: Extract<DeletionCertificate, {
 
 // @public
 export function signHorizonWitnessRequestBody(body: HorizonWitnessRequestBody, privateKey: Uint8Array): Promise<string>;
+
+// @public
+export function signInvoice(input: Omit<InvoiceV1, "signature" | "suite">, issuerPrivateKey: Uint8Array): Promise<InvoiceV1>;
 
 // @public
 export function signKeySuccession(oldPrivateKey: Uint8Array, newPrivateKey: Uint8Array, newPublicKey: Uint8Array, oldPublicKey: Uint8Array, reason?: string): Promise<KeySuccessionRecord>;
@@ -1745,6 +1770,11 @@ export interface VerifyContentArtifactResult {
 }
 
 // @public
+export function verifyCostAttestation(att: CostAttestationV1, registeredIssuerKeyHex: string, options?: {
+    receipt?: ExecutionReceipt_2;
+}): Promise<CostAttestationVerdict>;
+
+// @public
 export function verifyCredentialAnchor(credential: Record<string, unknown>, anchorProof: CredentialAnchorProofFields, chainVerifier?: ChainAnchorVerifier): Promise<CredentialAnchorVerifyResult>;
 
 // @public
@@ -1829,6 +1859,14 @@ export function verifyHorizonWitnessRequestSignature(body: HorizonWitnessRequest
 
 // @public
 export function verifyIdentityBindingAnchored(identity: MotebitIdentityFile, signingKeyHex: string, atTimestampMs: number, proof: IdentityLogInclusionProof, guardianPublicKeyHex?: string): Promise<KeyBindingResult>;
+
+// @public
+export function verifyInvoice(invoice: InvoiceV1, registeredIssuerKeyHex: string, options?: {
+    costAttestations?: readonly CostAttestationV1[];
+    receipts?: readonly ExecutionReceipt_2[];
+    latestCostAttestations?: ReadonlyMap<string, CostAttestationV1>;
+    otherInvoices?: readonly InvoiceV1[];
+}): Promise<InvoiceVerdict>;
 
 // @public
 export function verifyKeyBindingAtTime(identity: MotebitIdentityFile, signingKeyHex: string, atTimestampMs: number, guardianPublicKeyHex?: string): Promise<KeyBindingResult>;

--- a/packages/crypto/src/__tests__/settlement-invoice.test.ts
+++ b/packages/crypto/src/__tests__/settlement-invoice.test.ts
@@ -1,0 +1,313 @@
+/**
+ * settlement-invoice@1.0 — CostAttestation + Invoice sign/verify.
+ *
+ * The bill that extends the receipt chain to the money (spec/settlement-invoice-v1.md).
+ * Every axis of the two structured verdicts is exercised, including the three that
+ * agency.computer's forcing-consumer pass sharpened: the `≤`/floor passthrough law,
+ * the `attested_at >= completed_at` temporal commitment (Catch 2), the CostAttestation
+ * substitution belt + per-line cost binding (Catch 1), and the stale-cost overstatement
+ * axis on a DOWNWARD supersession (Catch 3 — the customer-protection direction).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  generateKeypair,
+  bytesToHex,
+  executionReceiptDigest,
+  costAttestationDigest,
+  signCostAttestation,
+  verifyCostAttestation,
+  signInvoice,
+  verifyInvoice,
+} from "../index.js";
+import type { CostAttestationV1, InvoiceV1, ExecutionReceipt, DigestRef } from "@motebit/protocol";
+
+type Kp = { publicKey: Uint8Array; privateKey: Uint8Array };
+const NOW = 1_700_000_000_000;
+const ISSUER = "did:motebit:agency";
+
+/** A minimal ExecutionReceipt — only the fields the invoice law reads + a stable shape to digest. */
+function makeReceipt(
+  taskId: string,
+  motebitId = ISSUER,
+  completedAt: number = NOW,
+): ExecutionReceipt {
+  return {
+    task_id: taskId,
+    motebit_id: motebitId,
+    device_id: "dev-1",
+    submitted_at: completedAt - 1000,
+    completed_at: completedAt,
+    status: "completed",
+    result: "ok",
+    tools_used: [],
+    memories_formed: 0,
+    prompt_hash: "p",
+    result_hash: "r",
+    suite: "motebit-jcs-ed25519-b64-v1",
+    signature: "sig",
+  } as unknown as ExecutionReceipt;
+}
+
+const dref = (value: string): DigestRef => ({ algorithm: "sha-256", value });
+
+async function attestation(
+  kp: Kp,
+  receipt: ExecutionReceipt,
+  cost_nanos: number,
+  over: Partial<CostAttestationV1> = {},
+): Promise<CostAttestationV1> {
+  return signCostAttestation(
+    {
+      schema: "motebit.cost-attestation.v1",
+      attestation_id: "att-1",
+      receipt_id: receipt.task_id,
+      receipt_digest: dref(await executionReceiptDigest(receipt)),
+      cost_nanos,
+      rate_table_id: "agency-rates-v1",
+      covers: "recon",
+      issuer_id: ISSUER,
+      attested_at: NOW + 5000,
+      ...over,
+    },
+    kp.privateKey,
+  );
+}
+
+async function invoice(
+  kp: Kp,
+  lines: Array<{ receipt: ExecutionReceipt; att: CostAttestationV1; cost_nanos: number }>,
+  over: Partial<InvoiceV1> = {},
+): Promise<InvoiceV1> {
+  const line_items = await Promise.all(
+    lines.map(async (l) => ({
+      receipt_id: l.receipt.task_id,
+      receipt_digest: dref(await executionReceiptDigest(l.receipt)),
+      cost_nanos: l.cost_nanos,
+      cost_attestation_digest: dref(await costAttestationDigest(l.att)),
+    })),
+  );
+  const sumNanos = line_items.reduce((s, li) => s + li.cost_nanos, 0);
+  const passthrough = Math.floor(sumNanos / 10_000_000);
+  const flat = 500;
+  return signInvoice(
+    {
+      schema: "motebit.invoice.v1",
+      invoice_id: "inv-1",
+      issuer_id: ISSUER,
+      customer_ref: "cust-1",
+      currency: "USD",
+      period_start: NOW,
+      period_end: NOW + 86_400_000,
+      line_items,
+      flat_fee_minor: flat,
+      passthrough_cost_minor: passthrough,
+      total_minor: flat + passthrough,
+      rate_table_id: "agency-rates-v1",
+      issued_at: NOW + 10_000,
+      ...over,
+    },
+    kp.privateKey,
+  );
+}
+
+describe("CostAttestation", () => {
+  it("round-trips and verifies all axes against its receipt", async () => {
+    const kp = await generateKeypair();
+    const r = makeReceipt("t1");
+    const att = await attestation(kp, r, 200_000_000); // $0.20
+    const v = await verifyCostAttestation(att, bytesToHex(kp.publicKey), { receipt: r });
+    expect(v).toEqual({
+      valid: true,
+      signature_valid: true,
+      cost_positive: true,
+      binding: "valid",
+      temporal: "valid",
+    });
+  });
+
+  it("rejects a wrong issuer key, a non-positive cost, and a carried key that mismatches", async () => {
+    const kp = await generateKeypair();
+    const other = await generateKeypair();
+    const r = makeReceipt("t1");
+
+    const att = await attestation(kp, r, 100);
+    expect((await verifyCostAttestation(att, bytesToHex(other.publicKey))).signature_valid).toBe(
+      false,
+    );
+
+    const zero = await attestation(kp, r, 0);
+    const vz = await verifyCostAttestation(zero, bytesToHex(kp.publicKey));
+    expect(vz.cost_positive).toBe(false);
+    expect(vz.valid).toBe(false);
+
+    const carried = await attestation(kp, r, 100, {
+      issuer_public_key: bytesToHex(other.publicKey),
+    });
+    expect((await verifyCostAttestation(carried, bytesToHex(kp.publicKey))).signature_valid).toBe(
+      false,
+    );
+  });
+
+  it("binding fails on the wrong receipt or a mismatched issuer", async () => {
+    const kp = await generateKeypair();
+    const r = makeReceipt("t1");
+    const att = await attestation(kp, r, 100);
+
+    const wrongReceipt = makeReceipt("t2");
+    expect(
+      (await verifyCostAttestation(att, bytesToHex(kp.publicKey), { receipt: wrongReceipt }))
+        .binding,
+    ).toBe("invalid");
+
+    const foreignReceipt = makeReceipt("t1", "did:motebit:someone-else");
+    // digest also differs (motebit_id is in the body), so binding is invalid either way.
+    expect(
+      (await verifyCostAttestation(att, bytesToHex(kp.publicKey), { receipt: foreignReceipt }))
+        .binding,
+    ).toBe("invalid");
+  });
+
+  it("temporal axis (Catch 2): a cost attested BEFORE the work finished is rejected", async () => {
+    const kp = await generateKeypair();
+    const r = makeReceipt("t1", ISSUER, NOW);
+    const early = await attestation(kp, r, 100, { attested_at: NOW - 1 }); // before completed_at
+    const v = await verifyCostAttestation(early, bytesToHex(kp.publicKey), { receipt: r });
+    expect(v.temporal).toBe("invalid");
+    expect(v.valid).toBe(false);
+  });
+});
+
+describe("Invoice", () => {
+  it("round-trips and verifies the MUST axes", async () => {
+    const kp = await generateKeypair();
+    const r = makeReceipt("t1");
+    const att = await attestation(kp, r, 200_000_000);
+    const inv = await invoice(kp, [{ receipt: r, att, cost_nanos: 200_000_000 }]);
+
+    const v = await verifyInvoice(inv, bytesToHex(kp.publicKey), {
+      costAttestations: [att],
+      receipts: [r],
+    });
+    expect(v.valid).toBe(true);
+    expect(v.signature_valid).toBe(true);
+    expect(v.arithmetic).toBe(true);
+    expect(v.passthrough_cap).toBe(true);
+    expect(v.per_line_binding).toBe("valid");
+    expect(v.issuer_consistency).toBe("valid");
+  });
+
+  it("passthrough law is ≤/floor: overstatement fails, understatement (discount) passes", async () => {
+    const kp = await generateKeypair();
+    const r = makeReceipt("t1");
+    const att = await attestation(kp, r, 200_000_000); // $0.20 = 20 cents
+    const base = await invoice(kp, [{ receipt: r, att, cost_nanos: 200_000_000 }]);
+
+    // Overstate: claim 21 cents passthrough over a 20-cent cost.
+    const over = await invoice(kp, [{ receipt: r, att, cost_nanos: 200_000_000 }], {
+      passthrough_cost_minor: 21,
+      total_minor: 500 + 21,
+    });
+    expect((await verifyInvoice(over, bytesToHex(kp.publicKey))).passthrough_cap).toBe(false);
+
+    // Understate (discount): claim 5 cents. Allowed.
+    const under = await invoice(kp, [{ receipt: r, att, cost_nanos: 200_000_000 }], {
+      passthrough_cost_minor: 5,
+      total_minor: 500 + 5,
+    });
+    expect((await verifyInvoice(under, bytesToHex(kp.publicKey))).passthrough_cap).toBe(true);
+    // base sanity
+    expect((await verifyInvoice(base, bytesToHex(kp.publicKey))).passthrough_cap).toBe(true);
+  });
+
+  it("arithmetic fails when total ≠ flat + passthrough", async () => {
+    const kp = await generateKeypair();
+    const r = makeReceipt("t1");
+    const att = await attestation(kp, r, 200_000_000);
+    const bad = await invoice(kp, [{ receipt: r, att, cost_nanos: 200_000_000 }], {
+      total_minor: 999,
+    });
+    expect((await verifyInvoice(bad, bytesToHex(kp.publicKey))).arithmetic).toBe(false);
+  });
+
+  it("per-line binding (Catch 1): a line charging ABOVE its cited attestation is invalid", async () => {
+    const kp = await generateKeypair();
+    const r = makeReceipt("t1");
+    const att = await attestation(kp, r, 100_000_000); // attested $0.10
+    // line claims $0.20 against a $0.10 attestation
+    const inv = await invoice(kp, [{ receipt: r, att, cost_nanos: 200_000_000 }]);
+    const v = await verifyInvoice(inv, bytesToHex(kp.publicKey), { costAttestations: [att] });
+    expect(v.per_line_binding).toBe("invalid");
+    expect(v.valid).toBe(false);
+  });
+
+  it("issuer-consistency fails on a receipt produced by a different issuer", async () => {
+    const kp = await generateKeypair();
+    const r = makeReceipt("t1");
+    const att = await attestation(kp, r, 100_000_000);
+    const inv = await invoice(kp, [{ receipt: r, att, cost_nanos: 100_000_000 }]);
+    const foreign = makeReceipt("t1", "did:motebit:not-the-issuer");
+    const v = await verifyInvoice(inv, bytesToHex(kp.publicKey), { receipts: [foreign] });
+    expect(v.issuer_consistency).toBe("invalid");
+    expect(v.valid).toBe(false);
+  });
+
+  it("idempotency is DETECTABLE across held invoices (not enforced)", async () => {
+    const kp = await generateKeypair();
+    const r = makeReceipt("t1");
+    const att = await attestation(kp, r, 100_000_000);
+    const a = await invoice(kp, [{ receipt: r, att, cost_nanos: 100_000_000 }], {
+      invoice_id: "inv-A",
+    });
+    const b = await invoice(kp, [{ receipt: r, att, cost_nanos: 100_000_000 }], {
+      invoice_id: "inv-B",
+    });
+    const v = await verifyInvoice(a, bytesToHex(kp.publicKey), { otherInvoices: [b] });
+    expect(v.idempotency).toBe("duplicate_detected");
+    // detectable, not gating: the invoice itself is still structurally valid.
+    expect(v.valid).toBe(true);
+  });
+
+  it("stale-cost overstatement (Catch 3): a DOWNWARD supersession surfaces, detectable not silent", async () => {
+    const kp = await generateKeypair();
+    const r = makeReceipt("t1");
+    const att = await attestation(kp, r, 100_000_000); // cited cost $0.10 = 10 cents
+    const inv = await invoice(kp, [{ receipt: r, att, cost_nanos: 100_000_000 }]); // passthrough = 10 cents
+
+    // A' supersedes A downward — the TRUE cost was $0.05 (5 cents). The customer was overcharged.
+    const cheaper = await attestation(kp, r, 50_000_000, {
+      attestation_id: "att-2",
+      attested_at: NOW + 9000,
+    });
+    const latest = new Map([[r.task_id, cheaper]]);
+
+    const v = await verifyInvoice(inv, bytesToHex(kp.publicKey), {
+      costAttestations: [att],
+      latestCostAttestations: latest,
+    });
+    expect(v.per_line_binding).toBe("valid"); // still valid against the CITED attestation
+    expect(v.stale_cost_overstatement).toBe("detected"); // but the latest cost is lower — surfaced
+    // detectable, not gating — whether a correction forces re-issue is consumer policy.
+    expect(v.valid).toBe(true);
+
+    // And when the latest cost still covers the bill, no overstatement.
+    const same = new Map([[r.task_id, att]]);
+    expect(
+      (await verifyInvoice(inv, bytesToHex(kp.publicKey), { latestCostAttestations: same }))
+        .stale_cost_overstatement,
+    ).toBe("none");
+  });
+});
+
+describe("digest helpers are reproducible", () => {
+  it("the same artifact always digests the same; a changed field changes it", async () => {
+    const kp = await generateKeypair();
+    const r = makeReceipt("t1");
+    expect(await executionReceiptDigest(r)).toBe(await executionReceiptDigest(makeReceipt("t1")));
+    expect(await executionReceiptDigest(r)).not.toBe(
+      await executionReceiptDigest(makeReceipt("t2")),
+    );
+
+    const att = await attestation(kp, r, 100);
+    expect(await costAttestationDigest(att)).toBe(await costAttestationDigest(att));
+  });
+});

--- a/packages/crypto/src/artifacts.ts
+++ b/packages/crypto/src/artifacts.ts
@@ -752,8 +752,14 @@ import type {
   StandingDelegation,
   DelegationRevocation,
   SubjectBindingV1,
+  ExecutionReceipt,
+  CostAttestationV1,
+  InvoiceV1,
+  CostAttestationVerdict,
+  InvoiceVerdict,
 } from "@motebit/protocol";
 export type { DelegationToken, StandingDelegation, DelegationRevocation, SubjectBindingV1 };
+export type { CostAttestationV1, InvoiceV1, CostAttestationVerdict, InvoiceVerdict };
 
 /** The one suite DelegationTokens sign under today. */
 export const DELEGATION_TOKEN_SUITE = "motebit-jcs-ed25519-b64-v1" as const;
@@ -1093,6 +1099,210 @@ export async function findGrantRevocation(
     if (await verifyDelegationRevocation(rev)) return rev;
   }
   return null;
+}
+
+// === Settlement invoice (settlement-invoice@1.0) ===
+// The bill that extends the receipt chain to the money. motebit owns the FORMAT;
+// the issuer runs the rails. Spec: spec/settlement-invoice-v1.md.
+
+/** 1 minor unit (cent) = 1e7 nano-USD. The only unit crossing in the invoice law (spec §5). */
+const NANOS_PER_MINOR = 10_000_000;
+
+/**
+ * JCS-SHA256 (hex) of the full signed `ExecutionReceipt` (`signature` included).
+ * Producer and verifier MUST use this exact function so a `receipt_digest` binding
+ * is reproducible by construction (the `consolidationReceiptDigest` discipline).
+ */
+export async function executionReceiptDigest(receipt: ExecutionReceipt): Promise<string> {
+  return canonicalSha256(receipt);
+}
+
+/** JCS-SHA256 (hex) of the full signed `CostAttestation`. Same reproducibility discipline. */
+export async function costAttestationDigest(att: CostAttestationV1): Promise<string> {
+  return canonicalSha256(att);
+}
+
+/** Sign a `CostAttestation` with the issuer's private key. */
+export async function signCostAttestation(
+  input: Omit<CostAttestationV1, "signature" | "suite">,
+  issuerPrivateKey: Uint8Array,
+): Promise<CostAttestationV1> {
+  const body = { ...input, suite: DELEGATION_TOKEN_SUITE };
+  const message = new TextEncoder().encode(canonicalJson(body));
+  const sig = await signBySuite(DELEGATION_TOKEN_SUITE, message, issuerPrivateKey);
+  return { ...body, signature: toBase64Url(sig) };
+}
+
+/** Verify a signature against the registered issuer key; the carried key, if present, MUST match it. */
+async function verifyIssuerSig(
+  artifact: { suite: string; signature: string; issuer_public_key?: string },
+  registeredIssuerKeyHex: string,
+): Promise<boolean> {
+  if (artifact.suite !== DELEGATION_TOKEN_SUITE) return false;
+  if (artifact.issuer_public_key != null && artifact.issuer_public_key !== registeredIssuerKeyHex) {
+    return false;
+  }
+  const { signature, ...body } = artifact;
+  const message = new TextEncoder().encode(canonicalJson(body));
+  try {
+    return await verifyBySuite(
+      DELEGATION_TOKEN_SUITE,
+      message,
+      fromBase64Url(signature),
+      hexToBytes(registeredIssuerKeyHex),
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verify a `CostAttestation` → structured verdict (spec §3.1). `valid` iff signature +
+ * positive cost + (binding/temporal not invalid). Binding/temporal are `unchecked`
+ * without the receipt.
+ */
+export async function verifyCostAttestation(
+  att: CostAttestationV1,
+  registeredIssuerKeyHex: string,
+  options?: { receipt?: ExecutionReceipt },
+): Promise<CostAttestationVerdict> {
+  const signature = await verifyIssuerSig(att, registeredIssuerKeyHex);
+  const cost_positive = Number.isSafeInteger(att.cost_nanos) && att.cost_nanos > 0;
+
+  let binding: CostAttestationVerdict["binding"] = "unchecked";
+  let temporal: CostAttestationVerdict["temporal"] = "unchecked";
+  const receipt = options?.receipt;
+  if (receipt) {
+    const expected = await executionReceiptDigest(receipt);
+    const digestOk =
+      att.receipt_digest.algorithm === "sha-256" && att.receipt_digest.value === expected;
+    const issuerOk = receipt.motebit_id === att.issuer_id;
+    binding = digestOk && issuerOk ? "valid" : "invalid";
+    if (receipt.completed_at != null) {
+      temporal = att.attested_at >= receipt.completed_at ? "valid" : "invalid";
+    }
+  }
+
+  const valid = signature && cost_positive && binding !== "invalid" && temporal !== "invalid";
+  return { valid, signature_valid: signature, cost_positive, binding, temporal };
+}
+
+/** Sign an `Invoice` with the issuer's private key. */
+export async function signInvoice(
+  input: Omit<InvoiceV1, "signature" | "suite">,
+  issuerPrivateKey: Uint8Array,
+): Promise<InvoiceV1> {
+  const body = { ...input, suite: DELEGATION_TOKEN_SUITE };
+  const message = new TextEncoder().encode(canonicalJson(body));
+  const sig = await signBySuite(DELEGATION_TOKEN_SUITE, message, issuerPrivateKey);
+  return { ...body, signature: toBase64Url(sig) };
+}
+
+/**
+ * Verify an `Invoice` → structured verdict (spec §4.2). `valid` requires the MUST axes
+ * (signature, arithmetic, passthrough cap, and per-line/issuer not invalid); idempotency
+ * and stale-cost overstatement are DETECTABLE axes (surfaced, never silent, but consumer
+ * policy decides whether they fail the bill).
+ */
+export async function verifyInvoice(
+  invoice: InvoiceV1,
+  registeredIssuerKeyHex: string,
+  options?: {
+    /** The cited cost attestations, resolved against each line's `cost_attestation_digest`. */
+    costAttestations?: readonly CostAttestationV1[];
+    /** The billed receipts, for issuer consistency. */
+    receipts?: readonly ExecutionReceipt[];
+    /** receipt_id → latest non-superseded cost attestation (the §3.3 customer-protection check). */
+    latestCostAttestations?: ReadonlyMap<string, CostAttestationV1>;
+    /** Other held invoices, for double-billing detection. */
+    otherInvoices?: readonly InvoiceV1[];
+  },
+): Promise<InvoiceVerdict> {
+  const signature = await verifyIssuerSig(invoice, registeredIssuerKeyHex);
+
+  const nonNeg = (n: number): boolean => Number.isSafeInteger(n) && n >= 0;
+  const arithmetic =
+    nonNeg(invoice.flat_fee_minor) &&
+    nonNeg(invoice.passthrough_cost_minor) &&
+    invoice.line_items.every((li) => nonNeg(li.cost_nanos)) &&
+    invoice.total_minor === invoice.flat_fee_minor + invoice.passthrough_cost_minor;
+
+  const sumNanos = invoice.line_items.reduce((s, li) => s + li.cost_nanos, 0);
+  const passthrough_cap = invoice.passthrough_cost_minor <= Math.floor(sumNanos / NANOS_PER_MINOR);
+
+  // Per-line binding + issuer consistency (need the cited attestations / receipts).
+  let per_line_binding: InvoiceVerdict["per_line_binding"] = "unchecked";
+  let issuer_consistency: InvoiceVerdict["issuer_consistency"] = "unchecked";
+  const atts = options?.costAttestations;
+  if (atts) {
+    const byDigest = new Map<string, CostAttestationV1>();
+    for (const a of atts) byDigest.set(await costAttestationDigest(a), a);
+    let linesOk = true;
+    let issuerOk = true;
+    for (const li of invoice.line_items) {
+      const att = byDigest.get(li.cost_attestation_digest.value);
+      if (
+        att === undefined ||
+        att.schema !== "motebit.cost-attestation.v1" || // substitution belt
+        att.receipt_id !== li.receipt_id ||
+        li.cost_nanos > att.cost_nanos || // a line above its cited cost
+        !(await verifyCostAttestation(att, registeredIssuerKeyHex)).signature_valid
+      ) {
+        linesOk = false;
+      }
+      if (att !== undefined && att.issuer_id !== invoice.issuer_id) issuerOk = false;
+    }
+    per_line_binding = linesOk ? "valid" : "invalid";
+    issuer_consistency = issuerOk ? "valid" : "invalid";
+  }
+  if (options?.receipts) {
+    const receiptsOk = options.receipts.every((r) => r.motebit_id === invoice.issuer_id);
+    if (issuer_consistency === "unchecked") issuer_consistency = receiptsOk ? "valid" : "invalid";
+    else if (!receiptsOk) issuer_consistency = "invalid";
+  }
+
+  // Idempotency — detectable across held invoices.
+  let idempotency: InvoiceVerdict["idempotency"] = "unchecked";
+  if (options?.otherInvoices) {
+    const mine = new Set(invoice.line_items.map((li) => li.receipt_id));
+    const dup = options.otherInvoices.some(
+      (other) =>
+        other.invoice_id !== invoice.invoice_id &&
+        other.line_items.some((li) => mine.has(li.receipt_id)),
+    );
+    idempotency = dup ? "duplicate_detected" : "ok";
+  }
+
+  // Stale-cost overstatement — passthrough exceeds the LATEST non-superseded cost (§3.3, §4.2.7).
+  let stale_cost_overstatement: InvoiceVerdict["stale_cost_overstatement"] = "unchecked";
+  const latest = options?.latestCostAttestations;
+  if (latest) {
+    const latestSum = invoice.line_items.reduce((s, li) => {
+      const a = latest.get(li.receipt_id);
+      return s + (a ? a.cost_nanos : li.cost_nanos);
+    }, 0);
+    stale_cost_overstatement =
+      invoice.passthrough_cost_minor > Math.floor(latestSum / NANOS_PER_MINOR)
+        ? "detected"
+        : "none";
+  }
+
+  const valid =
+    signature &&
+    arithmetic &&
+    passthrough_cap &&
+    per_line_binding !== "invalid" &&
+    issuer_consistency !== "invalid";
+  return {
+    valid,
+    signature_valid: signature,
+    arithmetic,
+    passthrough_cap,
+    per_line_binding,
+    issuer_consistency,
+    idempotency,
+    stale_cost_overstatement,
+  };
 }
 
 // === Signed Request Envelope (signed-request-envelope@1.0) ===

--- a/packages/protocol/etc/protocol.api.md
+++ b/packages/protocol/etc/protocol.api.md
@@ -1044,6 +1044,33 @@ export interface ConversationSyncResult {
 }
 
 // @public
+export interface CostAttestationV1 {
+    attestation_id: string;
+    attested_at: number;
+    cost_nanos: number;
+    covers: string;
+    issuer_id: string;
+    issuer_public_key?: string;
+    rate_table_id: string;
+    receipt_digest: DigestRef;
+    receipt_id: string;
+    // (undocumented)
+    schema: "motebit.cost-attestation.v1";
+    signature: string;
+    // (undocumented)
+    suite: "motebit-jcs-ed25519-b64-v1";
+}
+
+// @public
+export interface CostAttestationVerdict {
+    binding: "valid" | "invalid" | "unchecked";
+    cost_positive: boolean;
+    signature_valid: boolean;
+    temporal: "valid" | "invalid" | "unchecked";
+    valid: boolean;
+}
+
+// @public
 export const CostSemiring: Semiring<number>;
 
 // @public
@@ -2121,6 +2148,55 @@ export interface InjectionWarning {
 
 // @public
 export type IntentOrigin = "user-tap" | "ai-loop" | "scheduled" | "agent-to-agent";
+
+// @public
+export interface InvoiceLineItem {
+    cost_attestation_digest: DigestRef;
+    cost_nanos: number;
+    receipt_digest: DigestRef;
+    receipt_id: string;
+}
+
+// @public
+export interface InvoiceV1 {
+    // (undocumented)
+    currency: "USD";
+    customer_ref: string;
+    flat_fee_minor: number;
+    invoice_id: string;
+    // (undocumented)
+    issued_at: number;
+    // (undocumented)
+    issuer_id: string;
+    issuer_public_key?: string;
+    // (undocumented)
+    line_items: InvoiceLineItem[];
+    passthrough_cost_minor: number;
+    period_end: number;
+    period_start: number;
+    // (undocumented)
+    rate_table_id: string;
+    // (undocumented)
+    schema: "motebit.invoice.v1";
+    // (undocumented)
+    signature: string;
+    // (undocumented)
+    suite: "motebit-jcs-ed25519-b64-v1";
+    total_minor: number;
+}
+
+// @public
+export interface InvoiceVerdict {
+    arithmetic: boolean;
+    idempotency: "ok" | "duplicate_detected" | "unchecked";
+    issuer_consistency: "valid" | "invalid" | "unchecked";
+    passthrough_cap: boolean;
+    per_line_binding: "valid" | "invalid" | "unchecked";
+    // (undocumented)
+    signature_valid: boolean;
+    stale_cost_overstatement: "none" | "detected" | "unchecked";
+    valid: boolean;
+}
 
 // @public
 export function isAccrualKind(value: unknown): value is AccrualKind;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -430,6 +430,125 @@ export interface DelegationRevocation {
   signature: string;
 }
 
+// === Settlement invoice (settlement-invoice@1.0) ===
+// The settlement-layer members of the receipt family — the bill a customer
+// re-derives offline. motebit owns the FORMAT; the issuer runs the rails. There
+// is no charge/balance/ledger primitive here, ever. Spec: spec/settlement-invoice-v1.md.
+// Doctrine: docs/doctrine/clearing-house-not-thin-waist.md.
+
+/**
+ * An issuer-signed declaration of the cost of ONE execution, in integer nano-USD
+ * against a named rate table — the thing summed by an {@link InvoiceV1}. Separate
+ * from the `ExecutionReceipt` by design: cost is a declaration ("what we computed,
+ * by these rates"), not the receipt's proof ("this work happened"). Correctable via
+ * supersession (a new `attestation_id` against the same receipt) without re-signing
+ * the immutable receipt. Signed/verified by `@motebit/crypto`
+ * `signCostAttestation`/`verifyCostAttestation`.
+ */
+export interface CostAttestationV1 {
+  schema: "motebit.cost-attestation.v1";
+  /** UUIDv7. A supersession is a NEW id (spec §3.3). */
+  attestation_id: string;
+  /** The {@link ExecutionReceipt.task_id} this prices (human/index handle). */
+  receipt_id: string;
+  /** `executionReceiptDigest(receipt)` over the full signed receipt — binds the cost to the exact receipt. */
+  receipt_digest: DigestRef;
+  /** The cost, in integer nano-USD (1 USD = 1e9 nano). Positive. */
+  cost_nanos: number;
+  /** The versioned rate table the cost was computed under (e.g. `"agency-rates-v1"`). */
+  rate_table_id: string;
+  /** Issuer-owned label for what the cost accounts for (rate-table basis). Opaque to motebit. */
+  covers: string;
+  /** The issuer's motebit_id / did. */
+  issuer_id: string;
+  /** Issuer Ed25519 public key, hex (64 lowercase). OPTIONAL (TOFU); verify against the REGISTERED key. */
+  issuer_public_key?: string;
+  /** ms epoch. MUST be >= the receipt's `completed_at` — a cost can't be attested before the work finished. */
+  attested_at: number;
+  suite: "motebit-jcs-ed25519-b64-v1";
+  /** Base64url Ed25519 over JCS(body). */
+  signature: string;
+}
+
+/** One billed line of an {@link InvoiceV1} — binds to a receipt and the cost attestation that priced it. */
+export interface InvoiceLineItem {
+  /** The billed {@link ExecutionReceipt.task_id}. */
+  receipt_id: string;
+  /** `executionReceiptDigest(receipt)` — binds the line to the exact receipt. */
+  receipt_digest: DigestRef;
+  /** The passthrough cost for this line, integer nano-USD. Non-negative. */
+  cost_nanos: number;
+  /** `costAttestationDigest(att)` — binds the line to the {@link CostAttestationV1} that priced it. */
+  cost_attestation_digest: DigestRef;
+}
+
+/**
+ * An issuer-signed demand for payment: a flat fee per signed outcome plus passthrough
+ * compute bounded by the summed {@link CostAttestationV1} costs — re-derivable and
+ * refusable offline. Amounts are minor units (cents); cost references carry nano-USD to
+ * preserve the `≤`/floor passthrough law. Idempotency is the issuer's stateful ledger,
+ * never the artifact. Signed/verified by `signInvoice`/`verifyInvoice`.
+ */
+export interface InvoiceV1 {
+  schema: "motebit.invoice.v1";
+  /** UUIDv7. The bill's idempotency anchor. */
+  invoice_id: string;
+  issuer_id: string;
+  /** hex, optional; verify against the registered key. */
+  issuer_public_key?: string;
+  /** Opaque issuer-owned addressing token. NOT PII. */
+  customer_ref: string;
+  currency: "USD";
+  /** ms epoch, inclusive. */
+  period_start: number;
+  /** ms epoch, exclusive. */
+  period_end: number;
+  line_items: InvoiceLineItem[];
+  /** The per-outcome flat fee, minor units (cents). Non-negative. */
+  flat_fee_minor: number;
+  /** Passthrough compute, minor units. Bounded by `passthrough_cost_minor <= floor(Σ cost_nanos / 1e7)`. */
+  passthrough_cost_minor: number;
+  /** `flat_fee_minor + passthrough_cost_minor`. The verifier recomputes. */
+  total_minor: number;
+  rate_table_id: string;
+  issued_at: number;
+  suite: "motebit-jcs-ed25519-b64-v1";
+  signature: string;
+}
+
+/** Per-axis verdict from `verifyCostAttestation` (structured, never a naked boolean). */
+export interface CostAttestationVerdict {
+  /** All MUST axes hold. */
+  valid: boolean;
+  /** Signature verifies against the registered issuer key. */
+  signature_valid: boolean;
+  /** `cost_nanos` is a positive safe integer. */
+  cost_positive: boolean;
+  /** Digest+issuer binding to the supplied receipt — `unchecked` when no receipt was supplied. */
+  binding: "valid" | "invalid" | "unchecked";
+  /** `attested_at >= receipt.completed_at` — `unchecked` when the receipt/`completed_at` is absent. */
+  temporal: "valid" | "invalid" | "unchecked";
+}
+
+/** Per-axis verdict from `verifyInvoice` (structured — so "valid against the cite" and "stale vs latest" are distinct). */
+export interface InvoiceVerdict {
+  /** All MUST axes hold (idempotency + stale-cost are detectable, not gating). */
+  valid: boolean;
+  signature_valid: boolean;
+  /** `total == flat + passthrough`, all amounts non-negative safe integers. */
+  arithmetic: boolean;
+  /** `passthrough_cost_minor <= floor(Σ line.cost_nanos / 1e7)`. */
+  passthrough_cap: boolean;
+  /** Each line resolves to its cited cost attestation (schema-checked) and `line.cost_nanos <= att.cost_nanos`. */
+  per_line_binding: "valid" | "invalid" | "unchecked";
+  /** Every referenced receipt/attestation shares the invoice's issuer. */
+  issuer_consistency: "valid" | "invalid" | "unchecked";
+  /** A receipt_id seen across supplied invoices — detectable, not gating. */
+  idempotency: "ok" | "duplicate_detected" | "unchecked";
+  /** Passthrough overstates the LATEST non-superseded cost (the §3.3 customer-protection axis) — detectable, not gating. */
+  stale_cost_overstatement: "none" | "detected" | "unchecked";
+}
+
 export enum SensitivityLevel {
   None = "none",
   Personal = "personal",

--- a/scripts/check-signed-artifact-verifiers.ts
+++ b/scripts/check-signed-artifact-verifiers.ts
@@ -107,6 +107,10 @@ export const REGISTRY: Record<string, Classification> = {
   CredentialAnchorProof: { kind: "verifier", verifier: "verifyCredentialAnchor" },
   AdjudicatorVote: { kind: "verifier", verifier: "verifyAdjudicatorVote" },
   ApprovalDecision: { kind: "verifier", verifier: "verifyApprovalDecision" },
+  // Settlement-invoice@1.0 — the bill that extends the receipt chain to the money.
+  // Both issuer-signed, both offline-verifiable against the issuer's registered key.
+  CostAttestationV1: { kind: "verifier", verifier: "verifyCostAttestation" },
+  InvoiceV1: { kind: "verifier", verifier: "verifyInvoice" },
   // Self-anchoring: verifyBondCommitment takes no external key (the key is
   // embedded as bonded_public_key and IS the bonded address). The verifier
   // enforces the anti-sybil address binding in addition to the signature —


### PR DESCRIPTION
## What

Increment 1 (the kernel) of the **settlement-invoice@1.0** arc — the settlement-layer member of the receipt family: a verifiable bill a customer re-derives offline. **motebit owns the format; the issuer runs the rails (Stripe).** No charge/balance/ledger primitive — the out-flow transmitter surface stays structurally zero (`clearing-house-not-thin-waist`). Forced by agency.computer stage-2 billing; shape converged over three forcing-consumer rounds.

## `@motebit/protocol` — two artifacts + two structured verdicts

- **`CostAttestationV1`** — an issuer-signed cost-of-one-execution declaration (integer nano-USD against a named rate table), **separate** from the `ExecutionReceipt` by design (cost is a declaration, not the receipt's proof), supersedable via new `attestation_id`.
- **`InvoiceV1` + `InvoiceLineItem`** — flat fee + passthrough (minor units), idempotent-detectable on receipt id.
- **`CostAttestationVerdict` / `InvoiceVerdict`** — per-axis, never a naked boolean.

## `@motebit/crypto` — sign/verify + the two mandated digest helpers

- `executionReceiptDigest` / `costAttestationDigest` — `canonicalSha256` over the **full signed artifact**; producer and verifier MUST use the same fn (Catch 1).
- `signCostAttestation` / `verifyCostAttestation` — signature, positive cost, digest+issuer binding, **`attested_at >= completed_at`** temporal commitment (Catch 2).
- `signInvoice` / `verifyInvoice` — the **seven-axis structured verdict**: signature, arithmetic, passthrough cap (`≤ floor(Σ cost_nanos / 1e7)`), per-line binding (schema substitution belt + line ≤ cited cost; Catch 1), issuer-consistency MUST, idempotency (detectable), and **stale-cost overstatement on a downward supersession** (Catch 3 — the customer-protection axis that is exactly why structured-verdicts-not-booleans matters).

## Verification

12 adversarial tests (every axis + the three agency-sharpened catches); full crypto suite **679 green**; `check-signed-artifact-verifiers` registry + `check-deps` + `check-api-surface` (regen) green; protocol+crypto minor changeset.

## Scope

Kernel only. The spec (`spec/settlement-invoice-v1.md`, written + agency-accepted) + wire-schemas + the `@motebit/verifier` re-export land as **Increment 2** (the spec needs wire-schemas to satisfy `check-spec-wire-schemas`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)