### PR TITLE
fix(memory-graph): bi-temporal supersede abutment — stamp valid_until/valid_from from one clock read

### DIFF
--- a/.changeset/memory-graph-supersede-abutment.md
+++ b/.changeset/memory-graph-supersede-abutment.md
@@ -1,0 +1,7 @@
+---
+"@motebit/memory-graph": patch
+---
+
+Fix bi-temporal supersede abutment: stamp `valid_until`/`valid_from` from a single clock read.
+
+Both supersede paths (`consolidateAndForm` UPDATE, `supersedeMemoryByNodeId`) read `Date.now()` twice across an `await` — once for the superseded node's `valid_until`, once (inside `formMemory`) for the new node's `valid_from` — so under scheduling jitter the intervals diverged: a temporal **gap** (no belief valid) or **overlap** (two beliefs valid) instead of abutting exactly. `formMemory` now accepts an optional `atMs` stamp; both supersede paths pass a single `now`, so `new.valid_from === old.valid_until` by construction. Surfaced as a flaky CI failure on the consolidation eval (the abutment assertion) that never reproduced on slower hardware; a deterministic jitter test now guards both paths.

--- a/packages/memory-graph/src/__tests__/bitemporal.test.ts
+++ b/packages/memory-graph/src/__tests__/bitemporal.test.ts
@@ -190,3 +190,66 @@ describe("supersession is invalidation-with-provenance + emits validity on the w
     expect(consolidated?.payload.superseded_valid_until).toBe(aAfter!.valid_until);
   });
 });
+
+describe("supersede intervals abut EXACTLY under clock jitter (no temporal hole or overlap)", () => {
+  // Regression for the bi-temporal abutment bug: the superseded node's `valid_until`
+  // and the new node's `valid_from` were stamped from two SEPARATE `Date.now()`
+  // reads across an `await`, so under scheduling jitter they diverged — a temporal
+  // GAP (`consolidateAndForm`: form read the later clock) or an OVERLAP
+  // (`supersedeMemoryByNodeId`: form read the earlier clock). Both now stamp a
+  // single `now`. This surfaced as a flaky CI failure on the consolidation eval that
+  // never reproduced on slower hardware; we make it deterministic by forcing MAXIMAL
+  // jitter — every `Date.now()` read jumps 5s — under which the pre-fix code is
+  // GUARANTEED to diverge, and assert the intervals still abut to the millisecond.
+  const cand = (content: string): AttributedMemoryCandidate => ({
+    content,
+    source: "user_stated",
+    confidence: 0.9,
+    sensitivity: SensitivityLevel.None,
+    memory_type: MemoryType.Semantic,
+  });
+
+  const withJumpingClock = async (fn: () => Promise<void>): Promise<void> => {
+    const realNow = Date.now;
+    let t = 1_700_000_000_000;
+    Date.now = () => (t += 5_000); // every read advances 5s — pre-fix ⇒ guaranteed divergence
+    try {
+      await fn();
+    } finally {
+      Date.now = realNow;
+    }
+  };
+
+  it("consolidateAndForm UPDATE: new.valid_from === old.valid_until (no gap)", async () => {
+    await withJumpingClock(async () => {
+      const storage = new InMemoryMemoryStorage();
+      const graph = new MemoryGraph(storage, new EventStore(new InMemoryEventStore()), "m");
+      const a = await graph.formMemory(cand("home=Paris"), EMB);
+      const provider: ConsolidationProvider = {
+        classify: () =>
+          Promise.resolve({
+            action: ConsolidationAction.UPDATE,
+            existingNodeId: a.node_id,
+            reason: "moved",
+          }),
+      };
+      const { node: b } = await graph.consolidateAndForm(cand("home=Lyon"), EMB, provider);
+      const aAfter = (await storage.getNode(a.node_id))!;
+      expect(typeof aAfter.valid_until).toBe("number");
+      expect(b!.valid_from).toBe(aAfter.valid_until); // abut to the ms — no temporal hole
+    });
+  });
+
+  it("supersedeMemoryByNodeId: new.valid_from === old.valid_until (no overlap)", async () => {
+    await withJumpingClock(async () => {
+      const storage = new InMemoryMemoryStorage();
+      const graph = new MemoryGraph(storage, new EventStore(new InMemoryEventStore()), "m");
+      const a = await graph.formMemory(cand("home=Paris"), EMB);
+      const newId = await graph.supersedeMemoryByNodeId(a.node_id, "home=Lyon", "moved");
+      const aAfter = (await storage.getNode(a.node_id))!;
+      const b = (await storage.getNode(newId))!;
+      expect(typeof aAfter.valid_until).toBe("number");
+      expect(b.valid_from).toBe(aAfter.valid_until); // abut to the ms — no overlap
+    });
+  });
+});

--- a/packages/memory-graph/src/index.ts
+++ b/packages/memory-graph/src/index.ts
@@ -711,6 +711,7 @@ export class MemoryGraph {
     candidate: AttributedMemoryCandidate,
     embedding: number[],
     halfLife?: number,
+    atMs?: number,
   ): Promise<MemoryNode> {
     // Guard: reject redacted content that arrives via sync.
     // The relay redacts sensitive memory_formed events, replacing content with
@@ -724,7 +725,12 @@ export class MemoryGraph {
     }
 
     const nodeId = crypto.randomUUID();
-    const now = Date.now();
+    // Accept an injected stamp so a supersede can make the new node's `valid_from`
+    // EQUAL the superseded node's `valid_until` — the bi-temporal intervals must
+    // abut exactly (no gap, no overlap), which two separate `Date.now()` reads
+    // across an `await` cannot guarantee. Defaults to the wall clock for the
+    // standalone ADD path.
+    const now = atMs ?? Date.now();
     const memoryType = candidate.memory_type ?? MemoryType.Semantic;
     const resolvedHalfLife =
       halfLife ??
@@ -855,8 +861,9 @@ export class MemoryGraph {
           oldNode.valid_until = now;
           await this.storage.saveNode(oldNode);
         }
-        // Form new node with valid_from = now
-        const newNode = await this.formMemory(candidate, embedding, halfLife);
+        // Form new node with valid_from = now — the SAME `now` stamped on the old
+        // node's valid_until above, so the intervals abut exactly (no temporal hole).
+        const newNode = await this.formMemory(candidate, embedding, halfLife, now);
         // Create Supersedes edge
         if (decision.existingNodeId) {
           await this.link(newNode.node_id, decision.existingNodeId, RT.Supersedes);
@@ -1313,6 +1320,10 @@ export class MemoryGraph {
     const { embedText } = await import("./embeddings.js");
     const embedding = await embedText(newContent);
 
+    // Stamp once, BEFORE forming the new node, so the new node's `valid_from`
+    // equals the old node's `valid_until` exactly — intervals abut with no
+    // overlap (two beliefs valid at once) and no gap.
+    const now = Date.now();
     const newNode = await this.formMemory(
       {
         content: newContent,
@@ -1328,9 +1339,9 @@ export class MemoryGraph {
       },
       embedding,
       oldNode.half_life,
+      now,
     );
 
-    const now = Date.now();
     oldNode.valid_until = now;
     oldNode.tombstoned = true;
     await this.storage.saveNode(oldNode);


### PR DESCRIPTION
## The flake was the eval catching a real bug

CI's `check` job intermittently failed on `consolidation-dedup-eval.test.ts > PART 3` — and the failing assertion (`lyon.valid_from === parisAfter.valid_until`) was *correct*. Both bi-temporal supersede paths read `Date.now()` **twice across an `await`** — the superseded node's `valid_until` at the call site, the new node's `valid_from` inside `formMemory` — so under parallel-CI scheduling jitter the intervals diverged:

- **`consolidateAndForm`** (UPDATE) → temporal **gap**: form read the *later* clock ⇒ a window where no belief is valid.
- **`supersedeMemoryByNodeId`** → temporal **overlap**: form read the *earlier* clock ⇒ two beliefs valid at once.

Either corrupts as-of recall. The flake reddened 3 of the last 5 `main` merges and never reproduced on slower hardware (sub-ms window).

## Fix

`formMemory` takes an optional `atMs` stamp; both supersede paths read `now` **once** and pass it, so `new.valid_from === old.valid_until` **by construction**.

## Proof it bites (not just "passes locally")

Added a deterministic jitter test (`bitemporal.test.ts`) — every `Date.now()` read jumps 5s, guaranteeing pre-fix divergence:
- **With** the fix: both paths abut to the ms ✓
- **Without** it (production change stashed): both fail — `+5s` gap on one path, `−5s` overlap on the other ✓

The aging fix already in the eval addressed Paris's *own* interval width; this fixes the actual Paris↔Lyon boundary.

Gates: full `test:coverage`, eval (4/4), typecheck, lint. memory-graph **patch** changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)