### PR TITLE
fix(test): raise contention-timeout budget 15s→30s (shared default + apps/cli) — release-path flake class

### DIFF
--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -10,14 +10,26 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     exclude: ["**/node_modules/**", "**/dist/**", "**/coverage/**"],
-    // 15s, not vitest's default 5s. These are integration-shaped tests — real
+    // 30s, not vitest's default 5s. These are integration-shaped tests — real
     // in-memory SQLite + a full GoalScheduler `tickOnce()` — that finish in
     // milliseconds in isolation but get CPU-starved when the Release job runs
-    // every package's `test:coverage` concurrently under turbo. A normally-fast
-    // `scheduler-approvals` tick intermittently blew the 5s default and failed
-    // the publish run (2026-06-18). The work is fast; the budget was too tight
-    // for the contention. A correct test still completes well under this ceiling
-    // — it only delays how long a genuinely hung test takes to surface.
-    testTimeout: 15_000,
+    // every package's tests under load. A normally-fast `scheduler-approvals`
+    // tick intermittently blew the 5s default and failed the publish run
+    // (2026-06-18 → raised 5s→15s), then blew 15s the same way (2026-06-29,
+    // release run on #230 — by then the workspace had grown to 52 ignore-listed
+    // packages and the contention with it). The work is genuinely fast (~ms; a
+    // 6s spike shows even in isolation = runtime/GC/scheduler variance, not a
+    // hang), so this is a CONTENTION BUDGET, not a bug being masked: raising it
+    // costs nothing on normal runs (a timeout only fires when exceeded) and only
+    // delays how long a genuinely hung test takes to surface. 30s gives ~2x
+    // headroom over the last failure and ~5x over the worst isolation spike.
+    //
+    // ESCALATION (if even 30s recurs): the durable cure is structural, not a
+    // bigger number — contention grows as packages are added, so the next step
+    // is reducing the publish path's concurrency (release.yml's "Test published
+    // packages" step re-runs full suites that already passed in PR CI). Cap
+    // vitest workers there, or thin that step to a build/smoke check. Do NOT
+    // just bump this past 30s — that IS the treadmill.
+    testTimeout: 30_000,
   },
 });

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -51,16 +51,24 @@ const BASE_TEST_EXCLUDE = ["**/node_modules/**", "**/dist/**", "**/coverage/**"]
 const BASE_COVERAGE_INCLUDE = ["src/**/*.ts"];
 const BASE_COVERAGE_EXCLUDE = ["src/__tests__/**", "src/**/*.d.ts"];
 
-// 15s, not vitest's default 5s. The monorepo's `test:coverage` runs every
+// 30s, not vitest's default 5s. The monorepo's `test:coverage` runs every
 // package concurrently under turbo (CI `check` + the Release job), so an
 // integration-shaped test that finishes in milliseconds in isolation can get
-// CPU-starved enough to blow the 5s default and fail the whole run — a pure
+// CPU-starved enough to blow a tight timeout and fail the whole run — a pure
 // contention flake, not a slow test. Seen on apps/cli `scheduler-approvals`
-// (fixed inline, bare config) and `@motebit/ai-core` terrarium. Raising the
-// shared default fixes the class in one place instead of per-package; a correct
-// test still completes well under this ceiling, so the only effect is how long
-// a genuinely hung test takes to surface. Override per-package via `extra.testTimeout`.
-const DEFAULT_TEST_TIMEOUT_MS = 15_000;
+// (fixed inline, bare config) and `@motebit/ai-core` terrarium; this default
+// went 5s→15s for it, then 15s blew the same way on `@motebit/verify`
+// published-contents (2026-06-29, CI `check` job) as the workspace grew to 52
+// ignore-listed packages and the contention with it. Raising the shared default
+// fixes the class in ONE place instead of per-package; a correct test still
+// completes well under this ceiling (raising costs nothing on normal runs — a
+// timeout only fires when exceeded), so the only effect is how long a genuinely
+// hung test takes to surface. Override per-package via `extra.testTimeout`.
+//
+// ESCALATION (if 30s recurs): the cure is structural, not a bigger number —
+// contention grows with every package added, so cap the test concurrency
+// (turbo `--concurrency`, or vitest workers) rather than bumping this again.
+const DEFAULT_TEST_TIMEOUT_MS = 30_000;
 
 export function defineMotebitTest(opts: MotebitVitestOptions): ViteUserConfig {
   const { thresholds, testExclude = [], coverageInclude, coverageExclude = [], extra, vite } = opts;


### PR DESCRIPTION
## What & why

The `scheduler-approvals` integration test (real in-memory SQLite + a full `GoalScheduler.tickOnce()`) **timed out at 15s on the Release run for #230**, failing the "Test published packages" step that gates the changesets/action — i.e. it can block a publish.

Diagnosis (grounded, not guessed):
- Traced the path: `tickOnce` → `tick` → a clean `for await` over a mocked stream + SQLite. **No logic hang** — no unresolved promise, no dangling timer.
- **Measured:** ~ms of real work, but a **6.16s process spike even in isolation** → pure runtime/GC/scheduler variance.
- **History:** the 15s was itself an earlier fix (5s→15s, 2026-06-18) for this same flake. Contention has since grown (52 ignore-listed packages), so 15s became too tight.

## The fix (not a treadmill)

A timeout is the correct instrument for contention variance — and raising it has **zero cost on normal runs** (a timeout only fires when exceeded). There's no bug to mask. Raised to **30s** (~2x the last failure, ~5x the worst spike). Critically, the comment now records the **structural escalation** — if 30s ever recurs, cap the publish path's concurrency / thin the smoke step, *not* another blind bump.

No changeset: `vitest.config.ts` is dev config, not published output. All 9 scheduler tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)