### PR TITLE
Interior reasoning capture (Inc 1): stop destroying the model's thinking

### DIFF
--- a/.changeset/interior-reasoning-capture-ignored.md
+++ b/.changeset/interior-reasoning-capture-ignored.md
@@ -1,0 +1,5 @@
+---
+"@motebit/ai-core": minor
+---
+
+New `extractReasoningTags` producer captures the model's `<thinking>` interior-reasoning trace (concatenating all blocks, no length cap) into `AIResponse.reasoning`, on both the streaming and non-streaming OpenAI-provider paths. Counterpart to `extractNarrationTag`, but cumulative (full trace) and interior-only — it feeds the owner-facing `mind` organ, never the chat register (still stripped from visible text via `stripTags`). Increment 1 of the interior-cognition arc.

--- a/.changeset/interior-reasoning-capture.md
+++ b/.changeset/interior-reasoning-capture.md
@@ -1,0 +1,5 @@
+---
+"@motebit/sdk": minor
+---
+
+`AIResponse` gains an optional `reasoning` field — the model's interior cognition (`<thinking>`), captured for the owner-facing `mind` embodiment organ (render-engine `EMBODIMENT_MODE_CONTRACTS.mind`, `source:"interior"`/`observer:"self"`). Previously the reasoning trace was stripped from the visible text and captured nowhere — destroyed before it could reach the surface built to render it. It stays stripped from the visible `text` (the chat register stays clean) and is INTERIOR-ONLY by contract: never synced, egressed, persisted to a shared surface, or sent to external AI. Additive and fail-closed — absent when the model emitted no reasoning. Increment 1 of the interior-cognition arc (`felt-interior.md`); the `mind`-organ render follows in Increment 2.

--- a/packages/ai-core/src/__tests__/reasoning-tag-extraction.test.ts
+++ b/packages/ai-core/src/__tests__/reasoning-tag-extraction.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for the producer of `AIResponse.reasoning` — the interior-cognition
+ * capture that stops motebit from DESTROYING the model's `<thinking>` trace
+ * before it can reach the owner-facing `mind` organ.
+ *
+ * Producer = `extractReasoningTags` in `core.ts`. It is the counterpart to
+ * `extractNarrationTag`, but with three deliberate differences that pin the
+ * interior-vs-chrome distinction:
+ *   - narration is current-state (LAST tag wins, ~80-char cap, chrome register);
+ *   - reasoning is the cumulative interior trace (ALL blocks concatenated, no
+ *     cap, `mind` register — interior, owner-only).
+ *
+ * The load-bearing invariant: reasoning is captured but STILL stripped from the
+ * visible `text` (via `stripTags`) — the chat register stays clean; the trace
+ * feeds the interior organ, never the conversation.
+ */
+
+import { describe, it, expect } from "vitest";
+import { extractReasoningTags, stripTags } from "../core.js";
+
+describe("extractReasoningTags", () => {
+  it("returns null when no <thinking> tag is present", () => {
+    expect(extractReasoningTags("Just some visible text")).toBeNull();
+    expect(extractReasoningTags("")).toBeNull();
+  });
+
+  it("captures the reasoning content of a single tag", () => {
+    expect(extractReasoningTags("<thinking>I should read the page first</thinking>Done")).toBe(
+      "I should read the page first",
+    );
+  });
+
+  it("concatenates ALL blocks in order (cumulative trace, unlike last-wins narration)", () => {
+    const text =
+      "<thinking>First, weigh the options</thinking>ok<thinking>Now commit to A</thinking>";
+    expect(extractReasoningTags(text)).toBe("First, weigh the options\n\nNow commit to A");
+  });
+
+  it("trims whitespace and skips empty blocks", () => {
+    expect(extractReasoningTags("<thinking>  padded  </thinking>")).toBe("padded");
+    expect(extractReasoningTags("<thinking>   </thinking>real<thinking>kept</thinking>")).toBe(
+      "kept",
+    );
+    expect(extractReasoningTags("<thinking></thinking>")).toBeNull();
+  });
+
+  it("does NOT cap length — the interior organ holds the full trace (unlike the calm chrome)", () => {
+    const long = "x".repeat(5000);
+    expect(extractReasoningTags(`<thinking>${long}</thinking>`)).toBe(long);
+  });
+
+  it("preserves multi-line reasoning verbatim", () => {
+    const body = "line one\nline two\n- a bullet";
+    expect(extractReasoningTags(`<thinking>${body}</thinking>`)).toBe(body);
+  });
+
+  it("INTERIOR-ONLY: the captured reasoning is still stripped from the visible chat text", () => {
+    const raw = "<thinking>secret deliberation about the plan</thinking>Here is the answer.";
+    // Captured for the mind organ...
+    expect(extractReasoningTags(raw)).toBe("secret deliberation about the plan");
+    // ...but never in the conversation register.
+    const visible = stripTags(raw);
+    expect(visible).not.toContain("secret deliberation");
+    expect(visible.trim()).toBe("Here is the answer.");
+  });
+});

--- a/packages/ai-core/src/core.ts
+++ b/packages/ai-core/src/core.ts
@@ -499,6 +499,43 @@ export function extractNarrationTag(text: string): string | null {
 // → chrome` per `chrome-as-state-render.md` and
 // `goals-vs-tasks.md`).
 
+/**
+ * Producer for `AIResponse.reasoning` — the model's interior cognition
+ * (`<thinking>`), captured for the owner-facing `mind` embodiment organ
+ * (`render-engine` `EMBODIMENT_MODE_CONTRACTS.mind`: `source:"interior"`,
+ * `observer:"self"`, `consent:"always-permitted"`).
+ *
+ * Until now `<thinking>` was `stripTags`-ped out of the visible text and
+ * captured NOWHERE — the reasoning trace was destroyed before it could reach
+ * the one surface built to hold it. Stripping it from the mote-conversation
+ * register is correct-calm (interior cognition must not clutter the chat); but
+ * DESTROYING it starves the `mind` organ. This extractor is the missing
+ * producer: it captures what the strip discards, so the interior is legible to
+ * the OWNER without cluttering the conversation (`felt-interior.md` — "an
+ * interior the sovereign cannot feel is, to them, no interior").
+ *
+ * INTERIOR-ONLY. Unlike `task_step_narration` (a bounded chrome string) this is
+ * the full reasoning trace, and it is owner-facing by construction: it MUST NOT
+ * be synced, egressed, persisted to a shared surface, or sent to an external
+ * AI. The `mind` contract's `observer:"self"` is the boundary.
+ *
+ * Concatenates ALL `<thinking>` blocks in emission order (a turn may reason in
+ * several passes) — no length cap: the organ is interior, not the calm chrome
+ * strip. Returns `null` when the model emitted no reasoning (fail-closed: no
+ * interior cognition → no `reasoning` field → the organ renders empty), which
+ * keeps the field purely additive.
+ */
+export function extractReasoningTags(text: string): string | null {
+  const regex = /<thinking\s*>([\s\S]*?)<\/thinking\s*>/g;
+  const parts: string[] = [];
+  let match;
+  while ((match = regex.exec(text)) !== null) {
+    const content = match[1]!.trim();
+    if (content !== "") parts.push(content);
+  }
+  return parts.length > 0 ? parts.join("\n\n") : null;
+}
+
 // Action keywords → MotebitState field deltas
 const ACTION_RULES: { pattern: RegExp; updates: Partial<MotebitState> }[] = [
   // Movement / proximity (allow words between verb and direction)

--- a/packages/ai-core/src/openai-provider.ts
+++ b/packages/ai-core/src/openai-provider.ts
@@ -34,6 +34,7 @@ import { buildSystemPromptCacheable } from "./prompt.js";
 import {
   extractMemoryTags,
   extractNarrationTag,
+  extractReasoningTags,
   extractStateTags,
   stripTags,
   fetchWithConnectionTimeout,
@@ -365,6 +366,10 @@ export class OpenAIProvider implements IntelligenceProvider {
     const memoryCandidates = extractMemoryTags(accumulated);
     const stateUpdates = extractStateTags(accumulated);
     const taskStepNarration = extractNarrationTag(accumulated);
+    // Capture interior reasoning BEFORE stripTags discards it. Interior-only —
+    // it never enters `displayText` (the chat register stays clean); it feeds
+    // the owner-facing `mind` organ. See `extractReasoningTags`.
+    const reasoning = extractReasoningTags(accumulated);
     const displayText = stripTags(accumulated);
 
     yield {
@@ -379,6 +384,7 @@ export class OpenAIProvider implements IntelligenceProvider {
           ? { usage: { input_tokens: inputTokens, output_tokens: outputTokens } }
           : {}),
         ...(taskStepNarration !== null ? { task_step_narration: taskStepNarration } : {}),
+        ...(reasoning !== null ? { reasoning } : {}),
       },
     };
   }
@@ -522,6 +528,9 @@ export class OpenAIProvider implements IntelligenceProvider {
     const memoryCandidates = extractMemoryTags(rawText);
     const stateUpdates = extractStateTags(rawText);
     const taskStepNarration = extractNarrationTag(rawText);
+    // Interior reasoning, captured before stripTags discards it (see the
+    // streaming path above + `extractReasoningTags`). Interior-only.
+    const reasoning = extractReasoningTags(rawText);
     const displayText = stripTags(rawText);
 
     const toolCalls: ToolCall[] = (choice?.message?.tool_calls ?? [])
@@ -539,6 +548,7 @@ export class OpenAIProvider implements IntelligenceProvider {
       state_updates: stateUpdates,
       ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
       ...(taskStepNarration !== null ? { task_step_narration: taskStepNarration } : {}),
+      ...(reasoning !== null ? { reasoning } : {}),
     };
 
     if (data.usage) {

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -51,6 +51,7 @@ export interface AIResponse {
     confidence: number;
     // (undocumented)
     memory_candidates: MemoryCandidate[];
+    reasoning?: string;
     // (undocumented)
     state_updates: Partial<MotebitState>;
     task_step_narration?: string;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -364,6 +364,25 @@ export interface AIResponse {
    * recedes to the empty register when absent.
    */
   task_step_narration?: string;
+  /**
+   * Interior reasoning — the model's own cognition trace (`<thinking>`),
+   * captured for the owner-facing `mind` embodiment organ (render-engine
+   * `EMBODIMENT_MODE_CONTRACTS.mind`: `source:"interior"`, `observer:"self"`,
+   * `consent:"always-permitted"`, `sensitivity:"all-tiers"`). Stripped from the
+   * visible `text` (interior cognition must not clutter the conversation), but
+   * — unlike before — no longer destroyed: the `mind` organ is the surface
+   * built to render it (`felt-interior.md`, maximum interiority made legible to
+   * the sovereign).
+   *
+   * INTERIOR-ONLY by contract: this is the full reasoning trace and it MUST NOT
+   * be synced, egressed, persisted to a shared surface, or sent to an external
+   * AI — the `mind` contract's `observer:"self"` is the boundary. Producer is
+   * `extractReasoningTags` in `@motebit/ai-core`.
+   *
+   * Optional. Absent when the model emitted no reasoning this turn (the organ
+   * renders empty).
+   */
+  reasoning?: string;
 }
 
 export interface IntelligenceProvider {


### PR DESCRIPTION
## What

The model's `<thinking>` reasoning trace was `stripTags`-ped out of the visible text and captured **nowhere** (`openai-provider.ts:368`) — destroyed before it could reach the `mind` embodiment organ (`render-engine` `EMBODIMENT_MODE_CONTRACTS.mind`: `source:"interior"`, `observer:"self"`, `consent:"always-permitted"`) that is literally built to render interior cognition. Stripping it from the chat register is correct-calm; **destroying** it starves the organ and violates felt-interior ("an interior the sovereign cannot feel is, to them, no interior").

Increment 1 — the honest, zero-blast-radius foundation: **stop the discard.**

- `extractReasoningTags` (`@motebit/ai-core`) — the missing producer. Counterpart to `extractNarrationTag`, but cumulative (concatenates all `<thinking>` blocks, no cap — the interior organ holds the full trace, unlike the ~80-char calm chrome) and fail-closed (`null` → additive field absent).
- `AIResponse.reasoning` (`@motebit/sdk`) — optional field, captured on **both** the streaming and non-streaming OpenAI-provider paths. Still stripped from the visible `text`; the chat register stays clean.
- **INTERIOR-ONLY by contract**, documented at the type + producer + capture sites: never synced, egressed, persisted to a shared surface, or sent to external AI. The `mind` contract's `observer:"self"` is the boundary. No new sync/persist/egress path is added, so the constraint holds by construction.

## Scope note

Producer + typed capture only, no render — mirroring how `AccrualBasis` shipped as a type before its producer before its render. **Inc 2** adds the interior chunk + the `mind`-organ render across surfaces (desktop already has a mind slab-item renderer). Kept separate to avoid coupling the delicate provider-stream change to the surface fan-out.

## Why this arc (principal-engineer note)

The birds-eye's first pick — wiring the trust/delegation accrual producers — **did not survive grounding**. Those three kinds (`trust_edge` / `prior_approval_pattern` / `standing_delegation`) are stubbed for a principled reason: no honest in-turn producer exists (`standing_delegation`'s `verifyGrantForTurn` is dormant; trust is consumed only post-hoc from receipts, not in an act-shaping in-turn decision). Minting them would **fabricate** a leverage moment — the exact honesty floor the feature gates on. This arc has no such risk: the reasoning genuinely exists, is genuinely discarded, and has a genuinely-built home.

## Verification

7 new producer tests (concatenation, fail-closed, no-cap, interior-stays-out-of-chat); ai-core 527 + sdk 136 suites; workspace typecheck 145/145; sdk api-surface baseline regenerated (additive `reasoning?`); all 126 drift gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)