### PR TITLE
ci: raise check-job timeout 15→20 (the suite outgrew the budget)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,14 @@ env:
 jobs:
   check:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 20, not 15: the full monorepo `test:coverage` now completes at ~14–15 min
+    # on a cold cache (tests PASS, then the job is cancelled at the 15-min wall —
+    # a false red that cancelled #245's first run and every recent Dependabot PR).
+    # Concurrency is already pinned to the runner's core count (`--concurrency=4`
+    # below), so lowering it would only slow the suite; headroom is the lever.
+    # Precedent: the deploy jobs carry 30 for the same cold-build class. Revisit
+    # (make the suite faster / shard) if this trends toward the ceiling again.
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6


### PR DESCRIPTION
The full-monorepo `test:coverage` now completes at **~14–15 min** on a cold cache; the `check` job's 15-min wall then cancels it *after the tests pass* — a false red.

Evidence it's chronic, not a flake:
- Cancelled **#245**'s first run (all tests green; cancelled during post-cleanup at 15:04) — needed a warm-cache re-run to land.
- Currently failing every recent Dependabot PR (**#232 / #233 / #241 / #237**), each cancelled at the wall with no real failure.
- Would hit new feature PRs the same way.

**Why headroom, not concurrency:** the `test:coverage` step already pins `--concurrency=4` to the runner's core count, so lowering it only *slows* the suite and makes the timeout worse. 20 gives ~5 min over the worst observed run (precedent: the deploy jobs carry 30 for the same cold-build class). If it trends toward the ceiling again, the real fix is a faster/sharded suite — noted in the comment, not a bigger number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)