### PR TITLE
Interior reasoning render (Inc 2): the mind register in chat

### DIFF
--- a/.changeset/interior-reasoning-capture-ignored.md
+++ b/.changeset/interior-reasoning-capture-ignored.md
@@ -1,0 +1,5 @@
+---
+"@motebit/ai-core": minor
+---
+
+New `extractReasoningTags` producer captures the model's `<thinking>` interior-reasoning trace (concatenating all blocks, no length cap) into `AIResponse.reasoning`, on both the streaming and non-streaming OpenAI-provider paths. Counterpart to `extractNarrationTag`, but cumulative (full trace) and interior-only — it feeds the owner-facing `mind` organ, never the chat register (still stripped from visible text via `stripTags`). Increment 1 of the interior-cognition arc.

--- a/.changeset/interior-reasoning-capture.md
+++ b/.changeset/interior-reasoning-capture.md
@@ -1,0 +1,5 @@
+---
+"@motebit/sdk": minor
+---
+
+`AIResponse` gains an optional `reasoning` field — the model's interior cognition (`<thinking>`), captured for the owner-facing `mind` embodiment organ (render-engine `EMBODIMENT_MODE_CONTRACTS.mind`, `source:"interior"`/`observer:"self"`). Previously the reasoning trace was stripped from the visible text and captured nowhere — destroyed before it could reach the surface built to render it. It stays stripped from the visible `text` (the chat register stays clean) and is INTERIOR-ONLY by contract: never synced, egressed, persisted to a shared surface, or sent to external AI. Additive and fail-closed — absent when the model emitted no reasoning. Increment 1 of the interior-cognition arc (`felt-interior.md`); the `mind`-organ render follows in Increment 2.

--- a/.changeset/interior-reasoning-render-ignored.md
+++ b/.changeset/interior-reasoning-render-ignored.md
@@ -1,0 +1,7 @@
+---
+"@motebit/ai-core": minor
+"@motebit/runtime": minor
+"@motebit/web": patch
+---
+
+Interior reasoning render (Inc 2) — the captured `AIResponse.reasoning` now reaches the owner. A new `reasoning` stream chunk (`AgenticChunk` in ai-core, `StreamChunk` in runtime) carries the trace from the loop through the runtime's pass-through to surfaces; the web chat renders it as a **calm, opt-in, collapsed `<details>` disclosure** attached to the assistant message. This is the `mind` register's correct flat-surface form: mind-mode content is hidden on the slab plane by doctrine (`motebit-computer.md`) and "lives in chat" — so reasoning is legible to the sovereign when they choose to expand it (`felt-interior.md`), never a loud panel, never the visible reply text, and rendered as ephemeral DOM (`textContent`, not persisted/synced — interior-only holds). Fail-closed: no reasoning → no chunk → no disclosure. Web-first; mobile/desktop/spatial fan-out to follow.

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -454,6 +454,40 @@
         border: 1px solid var(--border-light);
         border-bottom-left-radius: 4px;
       }
+      /* Interior reasoning — the `mind` register in chat. Collapsed by
+         default (calm: no clutter), opt-in expand (felt-interior: the
+         sovereign can look). Muted + smaller than the reply so the
+         conversation stays primary. */
+      .chat-reasoning {
+        margin-top: 8px;
+        border-top: 1px solid var(--border-light);
+        padding-top: 6px;
+        font-size: 0.85em;
+      }
+      .chat-reasoning-summary {
+        cursor: pointer;
+        color: var(--text-faint);
+        letter-spacing: 0.02em;
+        user-select: none;
+        list-style: none;
+      }
+      .chat-reasoning-summary::-webkit-details-marker {
+        display: none;
+      }
+      .chat-reasoning-summary::before {
+        content: "▸ ";
+        color: var(--text-faint);
+      }
+      .chat-reasoning[open] > .chat-reasoning-summary::before {
+        content: "▾ ";
+      }
+      .chat-reasoning-body {
+        margin-top: 6px;
+        color: var(--text-secondary);
+        white-space: pre-wrap;
+        word-break: break-word;
+        line-height: 1.5;
+      }
       .chat-bubble.system {
         align-self: center;
         background: var(--system-bubble);

--- a/apps/web/src/ui/chat.ts
+++ b/apps/web/src/ui/chat.ts
@@ -771,6 +771,33 @@ export function initChat(ctx: WebContext, callbacks: ChatCallbacks): ChatAPI {
             break;
           }
 
+          case "reasoning": {
+            // Interior cognition made legible to the OWNER without cluttering
+            // the conversation. The `mind` register is hidden on the slab plane
+            // by doctrine and "lives in chat"; this is its calm, opt-in form —
+            // a collapsed <details> the sovereign can expand to feel the
+            // interior (`felt-interior.md`), never an always-open panel.
+            // INTERIOR-ONLY: rendered as ephemeral DOM, never added to
+            // `accumulated`, so it is not persisted to (or synced from) the
+            // conversation. `textContent` keeps the trace literal — no markdown,
+            // no HTML injection from model output.
+            if (bubble && chunk.text.trim() !== "") {
+              const details = document.createElement("details");
+              details.className = "chat-reasoning";
+              const summary = document.createElement("summary");
+              summary.className = "chat-reasoning-summary";
+              summary.textContent = "reasoning";
+              const body = document.createElement("div");
+              body.className = "chat-reasoning-body";
+              body.textContent = chunk.text;
+              details.appendChild(summary);
+              details.appendChild(body);
+              bubble.appendChild(details);
+              chatLog.scrollTop = chatLog.scrollHeight;
+            }
+            break;
+          }
+
           case "tool_status": {
             if (chunk.status === "calling") {
               showToolStatus(chunk.name, chunk.context);

--- a/packages/ai-core/src/__tests__/loop.test.ts
+++ b/packages/ai-core/src/__tests__/loop.test.ts
@@ -1499,6 +1499,60 @@ describe("runTurnStreaming — task_step_narration emission", () => {
   });
 });
 
+// The loop emits a `reasoning` chunk per model response when the provider's
+// `AIResponse.reasoning` (produced by `extractReasoningTags`) is non-empty —
+// the in-flight carrier for the interior `mind` register. Surfaces render it
+// as a calm, opt-in, collapsed disclosure in chat; it is never the chat text.
+// Fail-closed: no reasoning → no chunk → no disclosure. Doctrine:
+// `felt-interior.md` + `motebit-computer.md` § "Embodiment modes."
+describe("runTurnStreaming — reasoning emission", () => {
+  it("emits a reasoning chunk when the provider supplies interior reasoning", async () => {
+    const provider = makeMockProvider([
+      {
+        text: "Here is the answer.",
+        confidence: 0.8,
+        memory_candidates: [],
+        state_updates: {},
+        reasoning: "First weigh A vs B, then commit to A because it is cheaper.",
+      },
+    ]);
+    const deps = makeDepsWithProvider(provider);
+
+    const chunks: AgenticChunk[] = [];
+    for await (const chunk of runTurnStreaming(deps, "Which is better?")) {
+      chunks.push(chunk);
+    }
+
+    const reasoningChunks = chunks.filter((c) => c.type === "reasoning") as Array<{
+      type: "reasoning";
+      text: string;
+    }>;
+    expect(reasoningChunks).toHaveLength(1);
+    expect(reasoningChunks[0]!.text).toBe(
+      "First weigh A vs B, then commit to A because it is cheaper.",
+    );
+
+    // Interior-only: the reasoning is NOT the visible reply text.
+    const textChunks = chunks.filter((c) => c.type === "text") as Array<{ text: string }>;
+    const visible = textChunks.map((c) => c.text).join("");
+    expect(visible).not.toContain("weigh A vs B");
+  });
+
+  it("omits the chunk when no reasoning is supplied (the disclosure never appears)", async () => {
+    const provider = makeMockProvider([
+      { text: "Hello!", confidence: 0.8, memory_candidates: [], state_updates: {} },
+    ]);
+    const deps = makeDepsWithProvider(provider);
+
+    const chunks: AgenticChunk[] = [];
+    for await (const chunk of runTurnStreaming(deps, "Hi")) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.filter((c) => c.type === "reasoning")).toHaveLength(0);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // projectForAi pixel gate — sovereignty / sensitivity / consent composition
 // ---------------------------------------------------------------------------

--- a/packages/ai-core/src/__tests__/reasoning-tag-extraction.test.ts
+++ b/packages/ai-core/src/__tests__/reasoning-tag-extraction.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for the producer of `AIResponse.reasoning` — the interior-cognition
+ * capture that stops motebit from DESTROYING the model's `<thinking>` trace
+ * before it can reach the owner-facing `mind` organ.
+ *
+ * Producer = `extractReasoningTags` in `core.ts`. It is the counterpart to
+ * `extractNarrationTag`, but with three deliberate differences that pin the
+ * interior-vs-chrome distinction:
+ *   - narration is current-state (LAST tag wins, ~80-char cap, chrome register);
+ *   - reasoning is the cumulative interior trace (ALL blocks concatenated, no
+ *     cap, `mind` register — interior, owner-only).
+ *
+ * The load-bearing invariant: reasoning is captured but STILL stripped from the
+ * visible `text` (via `stripTags`) — the chat register stays clean; the trace
+ * feeds the interior organ, never the conversation.
+ */
+
+import { describe, it, expect } from "vitest";
+import { extractReasoningTags, stripTags } from "../core.js";
+
+describe("extractReasoningTags", () => {
+  it("returns null when no <thinking> tag is present", () => {
+    expect(extractReasoningTags("Just some visible text")).toBeNull();
+    expect(extractReasoningTags("")).toBeNull();
+  });
+
+  it("captures the reasoning content of a single tag", () => {
+    expect(extractReasoningTags("<thinking>I should read the page first</thinking>Done")).toBe(
+      "I should read the page first",
+    );
+  });
+
+  it("concatenates ALL blocks in order (cumulative trace, unlike last-wins narration)", () => {
+    const text =
+      "<thinking>First, weigh the options</thinking>ok<thinking>Now commit to A</thinking>";
+    expect(extractReasoningTags(text)).toBe("First, weigh the options\n\nNow commit to A");
+  });
+
+  it("trims whitespace and skips empty blocks", () => {
+    expect(extractReasoningTags("<thinking>  padded  </thinking>")).toBe("padded");
+    expect(extractReasoningTags("<thinking>   </thinking>real<thinking>kept</thinking>")).toBe(
+      "kept",
+    );
+    expect(extractReasoningTags("<thinking></thinking>")).toBeNull();
+  });
+
+  it("does NOT cap length — the interior organ holds the full trace (unlike the calm chrome)", () => {
+    const long = "x".repeat(5000);
+    expect(extractReasoningTags(`<thinking>${long}</thinking>`)).toBe(long);
+  });
+
+  it("preserves multi-line reasoning verbatim", () => {
+    const body = "line one\nline two\n- a bullet";
+    expect(extractReasoningTags(`<thinking>${body}</thinking>`)).toBe(body);
+  });
+
+  it("INTERIOR-ONLY: the captured reasoning is still stripped from the visible chat text", () => {
+    const raw = "<thinking>secret deliberation about the plan</thinking>Here is the answer.";
+    // Captured for the mind organ...
+    expect(extractReasoningTags(raw)).toBe("secret deliberation about the plan");
+    // ...but never in the conversation register.
+    const visible = stripTags(raw);
+    expect(visible).not.toContain("secret deliberation");
+    expect(visible.trim()).toBe("Here is the answer.");
+  });
+});

--- a/packages/ai-core/src/core.ts
+++ b/packages/ai-core/src/core.ts
@@ -499,6 +499,43 @@ export function extractNarrationTag(text: string): string | null {
 // → chrome` per `chrome-as-state-render.md` and
 // `goals-vs-tasks.md`).
 
+/**
+ * Producer for `AIResponse.reasoning` — the model's interior cognition
+ * (`<thinking>`), captured for the owner-facing `mind` embodiment organ
+ * (`render-engine` `EMBODIMENT_MODE_CONTRACTS.mind`: `source:"interior"`,
+ * `observer:"self"`, `consent:"always-permitted"`).
+ *
+ * Until now `<thinking>` was `stripTags`-ped out of the visible text and
+ * captured NOWHERE — the reasoning trace was destroyed before it could reach
+ * the one surface built to hold it. Stripping it from the mote-conversation
+ * register is correct-calm (interior cognition must not clutter the chat); but
+ * DESTROYING it starves the `mind` organ. This extractor is the missing
+ * producer: it captures what the strip discards, so the interior is legible to
+ * the OWNER without cluttering the conversation (`felt-interior.md` — "an
+ * interior the sovereign cannot feel is, to them, no interior").
+ *
+ * INTERIOR-ONLY. Unlike `task_step_narration` (a bounded chrome string) this is
+ * the full reasoning trace, and it is owner-facing by construction: it MUST NOT
+ * be synced, egressed, persisted to a shared surface, or sent to an external
+ * AI. The `mind` contract's `observer:"self"` is the boundary.
+ *
+ * Concatenates ALL `<thinking>` blocks in emission order (a turn may reason in
+ * several passes) — no length cap: the organ is interior, not the calm chrome
+ * strip. Returns `null` when the model emitted no reasoning (fail-closed: no
+ * interior cognition → no `reasoning` field → the organ renders empty), which
+ * keeps the field purely additive.
+ */
+export function extractReasoningTags(text: string): string | null {
+  const regex = /<thinking\s*>([\s\S]*?)<\/thinking\s*>/g;
+  const parts: string[] = [];
+  let match;
+  while ((match = regex.exec(text)) !== null) {
+    const content = match[1]!.trim();
+    if (content !== "") parts.push(content);
+  }
+  return parts.length > 0 ? parts.join("\n\n") : null;
+}
+
 // Action keywords → MotebitState field deltas
 const ACTION_RULES: { pattern: RegExp; updates: Partial<MotebitState> }[] = [
   // Movement / proximity (allow words between verb and direction)

--- a/packages/ai-core/src/loop.ts
+++ b/packages/ai-core/src/loop.ts
@@ -707,6 +707,22 @@ export type AgenticChunk =
     }
   | {
       /**
+       * Interior reasoning — the model's `<thinking>` trace, carrier for
+       * `AIResponse.reasoning` (produced by `extractReasoningTags`). Interior
+       * cognition for the owner-facing `mind` register: mind-mode content is
+       * hidden on the slab plane by doctrine (`motebit-computer.md`) and
+       * "lives in chat" — surfaces render it as a CALM, opt-in, collapsed
+       * disclosure, never a loud panel and never the chat text itself (it
+       * stays stripped from the visible message). INTERIOR-ONLY: never synced,
+       * egressed, persisted to a shared surface, or sent to external AI — the
+       * `mind` contract's `observer:"self"` is the boundary. Emitted per model
+       * response (a turn may reason across several tool-call rounds).
+       */
+      type: "reasoning";
+      text: string;
+    }
+  | {
+      /**
        * Emitted when `options.deferMemoryFormation === true`. Carries the
        * candidates + relevantMemories snapshot the formation pass would
        * have consumed. The runtime catches this chunk and queues formation
@@ -1087,6 +1103,15 @@ export async function* runTurnStreaming(
           valid: narrationResult.valid,
         };
       }
+    }
+
+    // Interior reasoning → the owner-facing mind register (a calm, opt-in
+    // disclosure in chat; mind content is hidden on the slab plane by
+    // doctrine). No validation — this is the model's own cognition, rendered
+    // for the sovereign, not a claim about wire truth. Interior-only; absent
+    // reasoning emits no chunk (fail-closed → the disclosure never appears).
+    if (aiResponse.reasoning !== undefined && aiResponse.reasoning.trim() !== "") {
+      yield { type: "reasoning", text: aiResponse.reasoning };
     }
 
     // If no tool calls or no tool registry, exit the loop

--- a/packages/ai-core/src/openai-provider.ts
+++ b/packages/ai-core/src/openai-provider.ts
@@ -34,6 +34,7 @@ import { buildSystemPromptCacheable } from "./prompt.js";
 import {
   extractMemoryTags,
   extractNarrationTag,
+  extractReasoningTags,
   extractStateTags,
   stripTags,
   fetchWithConnectionTimeout,
@@ -365,6 +366,10 @@ export class OpenAIProvider implements IntelligenceProvider {
     const memoryCandidates = extractMemoryTags(accumulated);
     const stateUpdates = extractStateTags(accumulated);
     const taskStepNarration = extractNarrationTag(accumulated);
+    // Capture interior reasoning BEFORE stripTags discards it. Interior-only —
+    // it never enters `displayText` (the chat register stays clean); it feeds
+    // the owner-facing `mind` organ. See `extractReasoningTags`.
+    const reasoning = extractReasoningTags(accumulated);
     const displayText = stripTags(accumulated);
 
     yield {
@@ -379,6 +384,7 @@ export class OpenAIProvider implements IntelligenceProvider {
           ? { usage: { input_tokens: inputTokens, output_tokens: outputTokens } }
           : {}),
         ...(taskStepNarration !== null ? { task_step_narration: taskStepNarration } : {}),
+        ...(reasoning !== null ? { reasoning } : {}),
       },
     };
   }
@@ -522,6 +528,9 @@ export class OpenAIProvider implements IntelligenceProvider {
     const memoryCandidates = extractMemoryTags(rawText);
     const stateUpdates = extractStateTags(rawText);
     const taskStepNarration = extractNarrationTag(rawText);
+    // Interior reasoning, captured before stripTags discards it (see the
+    // streaming path above + `extractReasoningTags`). Interior-only.
+    const reasoning = extractReasoningTags(rawText);
     const displayText = stripTags(rawText);
 
     const toolCalls: ToolCall[] = (choice?.message?.tool_calls ?? [])
@@ -539,6 +548,7 @@ export class OpenAIProvider implements IntelligenceProvider {
       state_updates: stateUpdates,
       ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
       ...(taskStepNarration !== null ? { task_step_narration: taskStepNarration } : {}),
+      ...(reasoning !== null ? { reasoning } : {}),
     };
 
     if (data.usage) {

--- a/packages/runtime/src/runtime-config.ts
+++ b/packages/runtime/src/runtime-config.ts
@@ -398,6 +398,20 @@ export type StreamChunk =
       text: string;
       valid: boolean;
     }
+  | {
+      /**
+       * Interior reasoning — the model's `<thinking>` trace, carrier for
+       * `AIResponse.reasoning`. The `mind` register: mind-mode content is
+       * hidden on the slab plane by doctrine (`motebit-computer.md`) and
+       * "lives in chat" — surfaces render it as a CALM, opt-in, collapsed
+       * disclosure, never a loud panel and never the visible reply text.
+       * INTERIOR-ONLY: never synced, egressed, persisted to a shared surface,
+       * or sent to external AI (`mind` contract `observer:"self"`). Emitted at
+       * most once per model response; absent reasoning produces no chunk.
+       */
+      type: "reasoning";
+      text: string;
+    }
   | { type: "result"; result: TurnResult }
   | { type: "task_result"; receipt: ExecutionReceipt }
   | { type: "delegation_start"; server: string; tool: string; motebit_id?: string }

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -51,6 +51,7 @@ export interface AIResponse {
     confidence: number;
     // (undocumented)
     memory_candidates: MemoryCandidate[];
+    reasoning?: string;
     // (undocumented)
     state_updates: Partial<MotebitState>;
     task_step_narration?: string;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -364,6 +364,25 @@ export interface AIResponse {
    * recedes to the empty register when absent.
    */
   task_step_narration?: string;
+  /**
+   * Interior reasoning — the model's own cognition trace (`<thinking>`),
+   * captured for the owner-facing `mind` embodiment organ (render-engine
+   * `EMBODIMENT_MODE_CONTRACTS.mind`: `source:"interior"`, `observer:"self"`,
+   * `consent:"always-permitted"`, `sensitivity:"all-tiers"`). Stripped from the
+   * visible `text` (interior cognition must not clutter the conversation), but
+   * — unlike before — no longer destroyed: the `mind` organ is the surface
+   * built to render it (`felt-interior.md`, maximum interiority made legible to
+   * the sovereign).
+   *
+   * INTERIOR-ONLY by contract: this is the full reasoning trace and it MUST NOT
+   * be synced, egressed, persisted to a shared surface, or sent to an external
+   * AI — the `mind` contract's `observer:"self"` is the boundary. Producer is
+   * `extractReasoningTags` in `@motebit/ai-core`.
+   *
+   * Optional. Absent when the model emitted no reasoning this turn (the organ
+   * renders empty).
+   */
+  reasoning?: string;
 }
 
 export interface IntelligenceProvider {


### PR DESCRIPTION
Stacked on #247 (Inc 1). **Base is #247's branch** — GitHub retargets this to `main` automatically when #247 merges.

## What

Inc 1 stopped destroying the model's `<thinking>` and captured it into `AIResponse.reasoning`. Inc 2 makes it **legible to the owner**, in the correct register.

**Grounding reshaped the plan.** The `mind` embodiment mode is *not* a visible panel: the desktop renderer (`slab-items.ts:1902`) deliberately **hides** mind-mode items on the slab plane —

> *"mind items don't render on the plane — they live in chat and in the creature's own animations"* (`motebit-computer.md`)

So a reasoning *panel* would be wrong. The correct flat-surface form is a **calm, opt-in, collapsed `<details>` disclosure** in the chat register — collapsed by default (calm-software: no clutter), expandable by the sovereign (felt-interior: "an interior the sovereign cannot feel is no interior"), muted and secondary to the reply.

## How

- **ai-core** — new `reasoning` chunk on `AgenticChunk`, emitted once per model response when `AIResponse.reasoning` is non-empty (fail-closed: absent → no chunk → no disclosure). No validation — it's the model's own cognition rendered for the owner, not a wire-truth claim.
- **runtime** — `reasoning` variant added to the surface-facing `StreamChunk`; the streaming wrapper's existing catch-all `yield chunk` passes it through untouched. **Zero new runtime logic.**
- **web** — a collapsed `<details>` appended to the assistant bubble, muted/smaller than the reply. Rendered via `textContent` (no markdown, no HTML injection) as **ephemeral DOM** — never added to the persisted/synced message text, so the **interior-only** contract holds by construction. Calm CSS inline in `index.html` (▸/▾, default-collapsed).

Web-first; mobile/desktop/spatial fan-out to follow.

## Verification

2 new loop-emission tests (emits when reasoning present + is NOT the visible text; omits when absent); ai-core 529 + runtime 1153; workspace typecheck 145/145 (no surface's chunk switch broke); all 126 gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)