### PR TITLE
Interior reasoning render (Inc 3): desktop + mobile fan-out

### DIFF
--- a/.changeset/interior-reasoning-fanout-ignored.md
+++ b/.changeset/interior-reasoning-fanout-ignored.md
@@ -1,0 +1,6 @@
+---
+"@motebit/desktop": patch
+"@motebit/mobile": patch
+---
+
+Interior reasoning render (Inc 3) — fan the `reasoning` disclosure out to desktop and mobile. Desktop mirrors web's calm collapsed `<details>` in the assistant bubble (DOM, inline CSS). Mobile renders a native `ReasoningDisclosure` (a `TouchableOpacity` ▸/▾ toggle over muted body text) under the reply, with a `reasoning?` field carried on the chat message and accumulated across the turn's reasoning rounds. Both are the `mind` register's flat-surface form: collapsed by default (calm), opt-in expand (felt-interior), muted + secondary to the reply, and INTERIOR-ONLY (held in ephemeral DOM / local UI state, never persisted or synced). Spatial expresses reasoning-happening through the existing presence/creature cue (content-in-AR is a separate arc, not forced text); cli deferred (a terminal stream has no collapse affordance).

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -358,6 +358,39 @@
         border: 1px solid var(--border-light);
         border-bottom-left-radius: 4px;
       }
+      /* Interior reasoning — the `mind` register in chat. Collapsed by
+         default (calm: no clutter), opt-in expand (felt-interior). Muted +
+         smaller than the reply so the conversation stays primary. */
+      .chat-reasoning {
+        margin-top: 8px;
+        border-top: 1px solid var(--border-light);
+        padding-top: 6px;
+        font-size: 0.85em;
+      }
+      .chat-reasoning-summary {
+        cursor: pointer;
+        color: var(--text-faint);
+        letter-spacing: 0.02em;
+        user-select: none;
+        list-style: none;
+      }
+      .chat-reasoning-summary::-webkit-details-marker {
+        display: none;
+      }
+      .chat-reasoning-summary::before {
+        content: "▸ ";
+        color: var(--text-faint);
+      }
+      .chat-reasoning[open] > .chat-reasoning-summary::before {
+        content: "▾ ";
+      }
+      .chat-reasoning-body {
+        margin-top: 6px;
+        color: var(--text-secondary);
+        white-space: pre-wrap;
+        word-break: break-word;
+        line-height: 1.5;
+      }
       .thinking-indicator {
         align-self: flex-start;
         display: flex;

--- a/apps/desktop/src/ui/chat.ts
+++ b/apps/desktop/src/ui/chat.ts
@@ -1185,6 +1185,29 @@ export function initChat(ctx: DesktopContext, callbacks: ChatCallbacks): ChatAPI
           te.textContent = stripPartialActionTag(accumulated);
           chatLog.scrollTop = chatLog.scrollHeight;
           callbacks.pushTTSChunk(chunk.text);
+        } else if (chunk.type === "reasoning") {
+          // Interior cognition made legible to the OWNER without cluttering the
+          // conversation. The `mind` register is hidden on the slab plane by
+          // doctrine and "lives in chat"; this is its calm, opt-in form — a
+          // collapsed <details> the sovereign can expand (`felt-interior.md`),
+          // never an always-open panel. INTERIOR-ONLY: ephemeral DOM, never
+          // added to `accumulated`, so it is not persisted/synced. `textContent`
+          // keeps the trace literal (no HTML injection from model output).
+          if (chunk.text.trim() !== "") {
+            const { bubble: rb } = ensureBubble();
+            const details = document.createElement("details");
+            details.className = "chat-reasoning";
+            const summary = document.createElement("summary");
+            summary.className = "chat-reasoning-summary";
+            summary.textContent = "reasoning";
+            const body = document.createElement("div");
+            body.className = "chat-reasoning-body";
+            body.textContent = chunk.text;
+            details.appendChild(summary);
+            details.appendChild(body);
+            rb.appendChild(details);
+            chatLog.scrollTop = chatLog.scrollHeight;
+          }
         } else if (chunk.type === "tool_status") {
           if (chunk.status === "calling") {
             removeThinkingIndicator(thinkingEl);

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -27,6 +27,7 @@ import {
   Appearance,
   Alert,
 } from "react-native";
+import type { StyleProp, ViewStyle, TextStyle } from "react-native";
 import { WebView } from "react-native-webview";
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-member-access
 const Feather = require("@expo/vector-icons/Feather").default as React.ComponentType<{
@@ -91,6 +92,42 @@ interface ChatMessage {
   // present when this turn drew on a recalled memory; absent is the
   // fail-closed default (no attribution).
   accrualBasis?: import("@motebit/sdk").AccrualBasis;
+  // Interior reasoning — the model's `<thinking>` for this turn (the `mind`
+  // register), rendered as a calm, opt-in collapsed disclosure under the reply.
+  // INTERIOR-ONLY: local UI state, never persisted/synced. Absent when the model
+  // emitted no reasoning.
+  reasoning?: string;
+}
+
+// === Interior reasoning disclosure ===
+
+/**
+ * The `mind` register in mobile chat — mind-mode content is hidden on the slab
+ * plane by doctrine and "lives in chat". Calm, opt-in form: collapsed by
+ * default (no clutter), tapped to expand (`felt-interior.md`), muted + smaller
+ * than the reply. `text` is the interior trace, held only in UI state (never
+ * persisted/synced).
+ */
+function ReasoningDisclosure({
+  text,
+  containerStyle,
+  summaryStyle,
+  bodyStyle,
+}: {
+  text: string;
+  containerStyle: StyleProp<ViewStyle>;
+  summaryStyle: StyleProp<TextStyle>;
+  bodyStyle: StyleProp<TextStyle>;
+}): React.ReactElement {
+  const [open, setOpen] = useState(false);
+  return (
+    <View style={containerStyle}>
+      <TouchableOpacity onPress={() => setOpen((v) => !v)} activeOpacity={0.6}>
+        <Text style={summaryStyle}>{open ? "▾ reasoning" : "▸ reasoning"}</Text>
+      </TouchableOpacity>
+      {open ? <Text style={bodyStyle}>{text}</Text> : null}
+    </View>
+  );
 }
 
 // === App singleton ===
@@ -1117,6 +1154,14 @@ export default function App(): React.ReactElement {
                     {`↻ ${resolveAccrualAttribution(item.accrualBasis).text}`}
                   </Text>
                 ) : null}
+                {item.reasoning ? (
+                  <ReasoningDisclosure
+                    text={item.reasoning}
+                    containerStyle={ds.reasoning}
+                    summaryStyle={ds.reasoningSummary}
+                    bodyStyle={ds.reasoningBody}
+                  />
+                ) : null}
               </AnimatedBubble>
             );
           }}
@@ -1511,6 +1556,25 @@ function createDynamicStyles(c: ThemeColors) {
       fontStyle: "italic",
       color: c.assistantBubbleText,
       opacity: 0.7,
+    },
+    // Interior reasoning — the `mind` register. Muted, collapsed by default.
+    reasoning: {
+      marginTop: 8,
+      paddingTop: 6,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderTopColor: c.assistantBubbleText,
+    },
+    reasoningSummary: {
+      fontSize: 12,
+      color: c.assistantBubbleText,
+      opacity: 0.5,
+    },
+    reasoningBody: {
+      marginTop: 6,
+      fontSize: 13,
+      lineHeight: 19,
+      color: c.assistantBubbleText,
+      opacity: 0.8,
     },
     systemText: {
       color: c.systemText,

--- a/apps/mobile/src/use-chat-stream.ts
+++ b/apps/mobile/src/use-chat-stream.ts
@@ -57,6 +57,14 @@ export interface ChatStreamMessage {
   approvalResolved?: boolean;
   /** Full signed receipt for role === "receipt" messages. */
   receipt?: ExecutionReceipt;
+  /**
+   * Interior reasoning — the model's `<thinking>` trace for this turn (the
+   * `mind` register). Rendered as a calm, opt-in, collapsed disclosure under
+   * the assistant reply, never the reply itself. INTERIOR-ONLY: held in local
+   * UI state, never persisted or synced. Accumulated across the turn's
+   * reasoning rounds; absent when the model emitted no reasoning.
+   */
+  reasoning?: string;
 }
 
 export interface UseChatStreamDeps {
@@ -106,6 +114,7 @@ export function useChatStream(deps: UseChatStreamDeps): UseChatStreamResult {
   const consumeStream = useCallback(
     async (stream: AsyncGenerator<StreamChunk>) => {
       let assistantContent = "";
+      let assistantReasoning = "";
       const assistantId = crypto.randomUUID();
 
       // Add placeholder
@@ -127,6 +136,23 @@ export function useChatStream(deps: UseChatStreamDeps): UseChatStreamResult {
                 ),
               );
               pushTTSChunk(chunk.text);
+              break;
+
+            case "reasoning":
+              // Interior cognition for the owner-facing `mind` register —
+              // rendered as a calm, opt-in collapsed disclosure under the reply
+              // (App.tsx), never the reply text. Accumulate the turn's reasoning
+              // rounds. INTERIOR-ONLY: local UI state, never persisted/synced.
+              if (chunk.text.trim() !== "") {
+                assistantReasoning = assistantReasoning
+                  ? `${assistantReasoning}\n\n${chunk.text}`
+                  : chunk.text;
+                setMessages((prev) =>
+                  prev.map((m) =>
+                    m.id === assistantId ? { ...m, reasoning: assistantReasoning } : m,
+                  ),
+                );
+              }
               break;
 
             case "tool_status":


### PR DESCRIPTION
Completes the interior-reasoning arc's flat-surface fan-out (Inc 1 capture → Inc 2 web render → **Inc 3 desktop + mobile**). Each surface renders the `reasoning` disclosure in its **medium-native calm idiom**.

- **Desktop** — web's collapsed `<details>` in the assistant bubble (DOM via `ensureBubble`, inline CSS, ▸/▾, default-collapsed, muted). `textContent` (no injection), ephemeral DOM never added to `accumulated` — interior-only holds.
- **Mobile** — a native `ReasoningDisclosure` (a `TouchableOpacity` ▸/▾ toggle over muted body; RN has no `<details>`). A `reasoning?` field rides the chat message (both `ChatStreamMessage` and App's `ChatMessage`), accumulated across the turn's reasoning rounds in `use-chat-stream`. Local UI state, never persisted/synced.

**Principled scope of the other two surfaces (decisions, not omissions):**
- **Spatial** expresses reasoning-*happening* through the existing presence/creature cue (Ring-1 capability via medium-native form). Reasoning *content* in AR is a separate ambient-render arc — forcing a text panel would violate the doctrine that hides mind-mode on the plane.
- **CLI** deferred — a terminal stream has no collapse affordance; dumping the full trace breaks calm.

## Verification
Workspace typecheck 145/145; desktop + mobile lint clean; all 126 gates. No new logic tests — the producer + chunk emission are covered by Inc 1/2 (#247/#249); this is pure surface render (mirrors the accrual/felt-interior fan-out pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)