### PR TITLE
web: capture reasoning in WebLLMProvider — close the in-browser on-device gap

### DIFF
--- a/.changeset/webllm-reasoning-capture-ignored.md
+++ b/.changeset/webllm-reasoning-capture-ignored.md
@@ -1,0 +1,5 @@
+---
+"@motebit/web": patch
+---
+
+Close the in-browser on-device reasoning gap. `WebLLMProvider` (WebGPU/MLC) was the last provider still `stripTags`-ping `<thinking>` and capturing nothing — the pre-arc "strip and destroy" behavior every other provider was fixed for. It now captures reasoning the same way: native `reasoning_content` deltas (in-browser reasoning models like DeepSeek-R1 distills) + the `<thinking>`-tag convention, merged via `mergeReasoning` into `AIResponse.reasoning`, on both the streaming and no-`done` fallback paths. Interior-only — accumulated raw off the stream, never into the visible text. With this, the reasoning disclosure is universal across every path that can produce reasoning: motebit cloud, BYOK, and on-device (local-server AND in-browser).

--- a/apps/web/src/__tests__/providers.test.ts
+++ b/apps/web/src/__tests__/providers.test.ts
@@ -5,20 +5,28 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock @motebit/ai-core/browser to avoid pulling in the full module
-vi.mock("@motebit/ai-core/browser", () => ({
-  AnthropicProvider: class MockAnthropicProvider {
-    constructor(public config: Record<string, unknown>) {}
-  },
-  OpenAIProvider: class MockOpenAIProvider {
-    constructor(public config: Record<string, unknown>) {}
-  },
-  DEFAULT_OLLAMA_URL: "http://127.0.0.1:11434",
-  extractMemoryTags: () => [],
-  extractStateTags: () => ({}),
-  stripTags: (s: string) => s,
-}));
+// Spread the REAL browser exports (pure, browser-safe tag/reasoning/prompt
+// helpers — needed so generateStream's capture runs for real), and stub only
+// the two heavy providers the config-inspection tests read `.config` off.
+vi.mock("@motebit/ai-core/browser", async (importActual) => {
+  const actual = await importActual<typeof import("@motebit/ai-core/browser")>();
+  return {
+    ...actual,
+    AnthropicProvider: class MockAnthropicProvider {
+      constructor(public config: Record<string, unknown>) {}
+    },
+    OpenAIProvider: class MockOpenAIProvider {
+      constructor(public config: Record<string, unknown>) {}
+    },
+    DEFAULT_OLLAMA_URL: "http://127.0.0.1:11434",
+    // Stubbed: orthogonal to reasoning capture, and the real one needs a full
+    // MotebitState. The tag/reasoning helpers above stay REAL.
+    buildSystemPrompt: () => "test system prompt",
+  };
+});
 
 import { checkWebGPU, createProvider, WebLLMProvider } from "../providers.js";
+import type { ContextPack, AIResponse } from "@motebit/sdk";
 
 beforeEach(() => {
   vi.restoreAllMocks();
@@ -183,5 +191,72 @@ describe("WebLLMProvider", () => {
       typeof p.extractMemoryCandidates
     >[0];
     expect(await p.extractMemoryCandidates(response)).toEqual([]);
+  });
+
+  // Inject a mock MLC engine (getEngine returns a cached `engine`, bypassing the
+  // CDN import) so generateStream runs against scripted chunks.
+  function withEngine(p: WebLLMProvider, chunks: unknown[]): WebLLMProvider {
+    (p as unknown as { engine: unknown }).engine = {
+      chat: {
+        completions: {
+          create: () =>
+            Promise.resolve(
+              (async function* () {
+                for (const c of chunks) yield c;
+              })(),
+            ),
+        },
+      },
+    };
+    return p;
+  }
+
+  const ctx = {
+    user_message: "which is better?",
+    recent_events: [],
+    relevant_memories: [],
+    current_state: {},
+  } as unknown as ContextPack;
+
+  async function drain(p: WebLLMProvider): Promise<{ text: string; final?: AIResponse }> {
+    const text: string[] = [];
+    let final: AIResponse | undefined;
+    for await (const c of p.generateStream(ctx)) {
+      if (c.type === "text") text.push(c.text);
+      else final = c.response;
+    }
+    return { text: text.join(""), final };
+  }
+
+  it("captures native reasoning_content into response.reasoning, never the visible text", async () => {
+    const p = withEngine(new WebLLMProvider("deepseek-r1-distill"), [
+      { choices: [{ delta: { reasoning_content: "weigh " } }] },
+      { choices: [{ delta: { reasoning_content: "the options" } }] },
+      { choices: [{ delta: { content: "The answer is A." } }] },
+    ]);
+    const { text, final } = await drain(p);
+    expect(final?.reasoning).toBe("weigh the options");
+    expect(text).toBe("The answer is A.");
+    expect(final?.text).not.toContain("weigh");
+  });
+
+  it("captures <thinking> tags into reasoning and strips them from the done-response text", async () => {
+    const p = withEngine(new WebLLMProvider("m"), [
+      { choices: [{ delta: { content: "<thinking>tagged deliberation</thinking>Answer." } }] },
+    ]);
+    const { final } = await drain(p);
+    expect(final?.reasoning).toBe("tagged deliberation");
+    // Stripped from the done-response display text (streamed chunks are raw and
+    // stripped downstream at render, like every other provider).
+    expect(final?.text).toBe("Answer.");
+  });
+
+  it("omits reasoning when the model emits none (fail-closed → no disclosure)", async () => {
+    const p = withEngine(new WebLLMProvider("m"), [
+      { choices: [{ delta: { content: "Just a plain reply." } }] },
+    ]);
+    const { final } = await drain(p);
+    expect(final?.reasoning).toBeUndefined();
+    expect(final?.text).toBe("Just a plain reply.");
   });
 });

--- a/apps/web/src/providers.ts
+++ b/apps/web/src/providers.ts
@@ -7,6 +7,8 @@ import {
   type StreamingProvider,
   extractMemoryTags,
   extractStateTags,
+  extractReasoningTags,
+  mergeReasoning,
   stripTags,
 } from "@motebit/ai-core/browser";
 import type { AIResponse, ContextPack, IntelligenceProvider, MemoryCandidate } from "@motebit/sdk";
@@ -48,7 +50,14 @@ interface WebLLMEngine {
         temperature?: number;
         max_tokens?: number;
         stream: boolean;
-      }): Promise<AsyncIterable<{ choices: Array<{ delta: { content?: string } }> }>>;
+        // `reasoning_content` is emitted by reasoning models (e.g. DeepSeek-R1
+        // distills) run in-browser via MLC/WebLLM — captured as interior
+        // reasoning, never into the visible content.
+      }): Promise<
+        AsyncIterable<{
+          choices: Array<{ delta: { content?: string; reasoning_content?: string } }>;
+        }>
+      >;
     };
   };
 }
@@ -218,16 +227,23 @@ export class WebLLMProvider implements StreamingProvider {
     const {
       extractMemoryTags: emt,
       extractStateTags: est,
+      extractReasoningTags: ert,
+      mergeReasoning: mr,
       stripTags: st,
     } = await import("@motebit/ai-core/browser");
     const memoryCandidates = emt(accumulated);
     const stateUpdates = est(accumulated);
     const displayText = st(accumulated);
+    // Tag-based reasoning only here — the generate() loop above accumulates
+    // text chunks, so native reasoning_content isn't available on this rare
+    // no-`done` fallback. Interior-only.
+    const reasoning = mr("", ert(accumulated));
     return {
       text: displayText,
       confidence: 0.7,
       memory_candidates: memoryCandidates,
       state_updates: stateUpdates,
+      ...(reasoning !== null ? { reasoning } : {}),
     };
   }
 
@@ -256,17 +272,26 @@ export class WebLLMProvider implements StreamingProvider {
     });
 
     let accumulated = "";
+    let nativeReasoning = "";
     for await (const chunk of stream) {
       const delta = chunk.choices[0]?.delta?.content;
       if (delta) {
         accumulated += delta;
         yield { type: "text", text: delta };
       }
+      // Native reasoning stream (in-browser reasoning models). Interior-only —
+      // accumulated raw, never into `accumulated`/the visible text.
+      const reasoningDelta = chunk.choices[0]?.delta?.reasoning_content;
+      if (reasoningDelta) nativeReasoning += reasoningDelta;
     }
 
     const memoryCandidates = extractMemoryTags(accumulated);
     const stateUpdates = extractStateTags(accumulated);
     const displayText = stripTags(accumulated);
+    // Interior reasoning = native stream merged with the <thinking>-tag
+    // convention — the same capture every other provider has, so in-browser
+    // on-device reasoning feeds the `mind` disclosure too. Interior-only.
+    const reasoning = mergeReasoning(nativeReasoning, extractReasoningTags(accumulated));
 
     yield {
       type: "done",
@@ -275,6 +300,7 @@ export class WebLLMProvider implements StreamingProvider {
         confidence: 0.7,
         memory_candidates: memoryCandidates,
         state_updates: stateUpdates,
+        ...(reasoning !== null ? { reasoning } : {}),
       },
     };
   }


### PR DESCRIPTION
`WebLLMProvider` (in-browser WebGPU/MLC) was the **last provider still destroying reasoning** — it `stripTags`-ped `<thinking>` and captured nothing, the pre-capture-arc behavior fixed everywhere else. So in-browser on-device reasoning models fed no `mind` disclosure.

Now it captures the same way `OpenAIProvider` does:
- native `reasoning_content` deltas (in-browser reasoning models, e.g. DeepSeek-R1 distills via MLC — delta type widened),
- `<thinking>`-tag convention via `extractReasoningTags`,
- merged with `mergeReasoning` into `AIResponse.reasoning`, on both the streaming done-response and the rare no-`done` `generate()` fallback (tags-only there).

Interior-only — accumulated raw off the stream, never into the visible text (verified: absent from `response.text`).

**Net:** the reasoning disclosure is now universal across every path that can emit reasoning — cloud, BYOK, and on-device (local-server via `OpenAIProvider` **and** in-browser via WebLLM). The Anthropic extended-thinking *budget* stays Anthropic-only (a request param, orthogonal to capture).

## Verification
3 new tests (inject a mock MLC engine via the `getEngine` cache seam — native `reasoning_content` capture, `<thinking>`-tag capture + strip, fail-closed omit). The `ai-core/browser` test mock switched to spread the REAL pure helpers (`importActual`) so capture runs for real. web 544; web typecheck; all 126 gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)