### PR TITLE
fix(web): stop the on-device WebLLM creature freeze (GPU-yield + render coalescing + honest fallback)

### DIFF
--- a/.changeset/on-device-creature-yield-ignored.md
+++ b/.changeset/on-device-creature-yield-ignored.md
@@ -1,0 +1,13 @@
+---
+"@motebit/web": patch
+---
+
+Stop the on-device creature freeze — GPU-yield during WebLLM inference + honest main-thread fallback.
+
+**The bug (valid, not "weak models"):** on `motebit.com` plugged into WebLLM, the creature freezes while a prompt processes and unfreezes when it finishes. WebLLM runs inference on WebGPU; the creature renders on WebGL/Three.js — both hit the one physical GPU, so during an on-device turn the render loop is starved and stutters into a visible freeze. Weak models give slow/bad answers, not freezes; this was pure GPU contention.
+
+**A — GPU-yield (the real fix).** `WebLLMProvider` raises an `isOnDeviceInferenceActive()` gauge for the duration of the WebGPU drain (depth-counted, `finally`-lowered even on early break). The render loop reads it and throttles the creature to a calm ~12fps while inference runs — asking for fewer frames means each one actually lands, so the creature reads as smooth-but-slow ("thinking inward") instead of frozen-then-janky. `deltaTime` tracks real elapsed time since the last draw, so motion stays wall-clock-correct at any cadence. Only WebLLM raises the gauge; cloud/BYOK (network-bound) render full-rate. This is a rendering concern, deliberately NOT the `responsive | tending | idle` presence machine — the motebit is `responsive` throughout.
+
+**B — honest main-thread fallback.** When no background worker is available and the engine falls back to main-thread inference (which hard-blocks the whole page — the GPU-yield can't help because the thread itself is held), the provider fires `onMainThreadFallback` once; the UI warns the owner and points them at cloud/BYOK, rather than leaving an unexplained freeze. "Failures degrade honestly, not gracefully."
+
+Pairs with the render-coalescing change (Cause C) that removed the O(n²) per-token re-render amplifying all of this.

--- a/.changeset/streaming-render-coalesce-ignored.md
+++ b/.changeset/streaming-render-coalesce-ignored.md
@@ -1,0 +1,7 @@
+---
+"@motebit/web": patch
+---
+
+Coalesce streaming markdown re-renders to one paint per animation frame. The chat stream re-ran the full markdown parse + a `textEl.innerHTML =` DOM write on **every** streamed token — O(n²) in message length, and hundreds of synchronous reflows a second under a fast token burst (on-device WebLLM, cached cloud replies). That is the lag felt while a reply streams, and it amplifies the GPU contention on the on-device path where the WebGL creature and WebGPU inference already share one device.
+
+New `StreamingRenderer` decouples token-arrival rate from DOM-render rate: tokens arriving within one frame collapse into a single markdown render + one DOM write + one scroll, capping re-renders at the display refresh rate. `flush()` forces the final paint at turn end so the last mid-frame tokens are always shown. Wired across all four streaming sites (main send, approval-resume, plan steps, chip invocation). TTS chunking is untouched; only the DOM render coalesces. Universal win — helps cloud and BYOK too, not just on-device.

--- a/apps/web/src/__tests__/chat-rendering.test.ts
+++ b/apps/web/src/__tests__/chat-rendering.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
 import { SensitivityLevel, type AccrualBasis } from "@motebit/sdk";
 
 // Mock @motebit/voice — chat.ts imports StreamingTTSQueue and WebSpeechTTSProvider.
@@ -69,12 +69,14 @@ beforeAll(() => {
 let renderMarkdown: (raw: string) => string;
 let formatErrorMessage: (msg: string) => string;
 let buildAccrualAttributionEl: (basis: AccrualBasis) => { className: string; textContent: string };
+let StreamingRenderer: typeof import("../ui/chat").StreamingRenderer;
 
 beforeAll(async () => {
   const mod = await import("../ui/chat");
   renderMarkdown = mod.renderMarkdown;
   formatErrorMessage = mod.formatErrorMessage;
   buildAccrualAttributionEl = mod.buildAccrualAttributionEl as typeof buildAccrualAttributionEl;
+  StreamingRenderer = mod.StreamingRenderer;
 });
 
 // ─── buildAccrualAttributionEl — the calm leverage-moment render (Inc 3) ───
@@ -299,5 +301,92 @@ describe("renderMarkdown", () => {
   it("handles only internal tags (stripped to empty)", () => {
     const result = renderMarkdown("<thinking>just thoughts</thinking>");
     expect(result).toBe("");
+  });
+});
+
+// ─── StreamingRenderer — the coalesced streaming paint (Cause C fix) ───
+// A controllable requestAnimationFrame: pushes queue a callback we fire by
+// hand, so we can assert exactly how many paints N pushes produce.
+describe("StreamingRenderer", () => {
+  let rafQueue: Array<() => void>;
+  let rafId: number;
+
+  function fakeEl(): { innerHTML: string } {
+    return { innerHTML: "" };
+  }
+
+  beforeEach(() => {
+    rafQueue = [];
+    rafId = 0;
+    vi.stubGlobal("requestAnimationFrame", (cb: () => void) => {
+      rafQueue.push(cb);
+      return ++rafId;
+    });
+    vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+      // Single in-flight frame in these tests; drop the queue on cancel.
+      if (id === rafId) rafQueue = [];
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function drainFrame(): void {
+    const q = rafQueue;
+    rafQueue = [];
+    for (const cb of q) cb();
+  }
+
+  it("coalesces many pushes within one frame into a single paint (latest wins)", () => {
+    const r = new StreamingRenderer();
+    const el = fakeEl() as unknown as HTMLElement;
+    r.push(el, "a");
+    r.push(el, "ab");
+    r.push(el, "abc");
+    // Nothing painted until the frame fires — the O(n²) per-token path is gone.
+    expect(el.innerHTML).toBe("");
+    expect(rafQueue.length).toBe(1); // one scheduled frame, not three
+    drainFrame();
+    expect(el.innerHTML).toBe(renderMarkdown("abc")); // latest source only
+  });
+
+  it("runs the onPaint side-effect exactly once per coalesced frame", () => {
+    const r = new StreamingRenderer();
+    const el = fakeEl() as unknown as HTMLElement;
+    const onPaint = vi.fn();
+    r.push(el, "x", onPaint);
+    r.push(el, "xy", onPaint);
+    drainFrame();
+    expect(onPaint).toHaveBeenCalledTimes(1);
+  });
+
+  it("flush() paints the pending source immediately and cancels the frame", () => {
+    const r = new StreamingRenderer();
+    const el = fakeEl() as unknown as HTMLElement;
+    r.push(el, "final tokens");
+    r.flush();
+    expect(el.innerHTML).toBe(renderMarkdown("final tokens"));
+    // The scheduled frame was cancelled — draining must not double-paint.
+    expect(rafQueue.length).toBe(0);
+  });
+
+  it("flush() with nothing pending is a no-op", () => {
+    const r = new StreamingRenderer();
+    const el = fakeEl() as unknown as HTMLElement;
+    r.flush();
+    expect(el.innerHTML).toBe("");
+  });
+
+  it("schedules a fresh frame for pushes that arrive after a paint", () => {
+    const r = new StreamingRenderer();
+    const el = fakeEl() as unknown as HTMLElement;
+    r.push(el, "one");
+    drainFrame();
+    expect(el.innerHTML).toBe(renderMarkdown("one"));
+    r.push(el, "one two");
+    expect(rafQueue.length).toBe(1); // new frame scheduled, not stuck
+    drainFrame();
+    expect(el.innerHTML).toBe(renderMarkdown("one two"));
   });
 });

--- a/apps/web/src/__tests__/providers.test.ts
+++ b/apps/web/src/__tests__/providers.test.ts
@@ -25,7 +25,12 @@ vi.mock("@motebit/ai-core/browser", async (importActual) => {
   };
 });
 
-import { checkWebGPU, createProvider, WebLLMProvider } from "../providers.js";
+import {
+  checkWebGPU,
+  createProvider,
+  WebLLMProvider,
+  isOnDeviceInferenceActive,
+} from "../providers.js";
 import type { ContextPack, AIResponse } from "@motebit/sdk";
 
 beforeEach(() => {
@@ -258,5 +263,39 @@ describe("WebLLMProvider", () => {
     const { final } = await drain(p);
     expect(final?.reasoning).toBeUndefined();
     expect(final?.text).toBe("Just a plain reply.");
+  });
+
+  // ── GPU-yield gauge (Cause A) ──────────────────────────────────────────
+  // The render loop reads isOnDeviceInferenceActive() to throttle the creature
+  // while WebGPU inference saturates the GPU. It must be raised for the whole
+  // drain and lowered on every exit path.
+
+  it("raises the GPU gauge during the inference drain and lowers it after", async () => {
+    const p = withEngine(new WebLLMProvider("m"), [
+      { choices: [{ delta: { content: "one " } }] },
+      { choices: [{ delta: { content: "two" } }] },
+    ]);
+    expect(isOnDeviceInferenceActive()).toBe(false); // idle before
+
+    let activeMidStream = false;
+    for await (const c of p.generateStream(ctx)) {
+      if (c.type === "text") activeMidStream = isOnDeviceInferenceActive();
+    }
+
+    expect(activeMidStream).toBe(true); // yielding while tokens flow
+    expect(isOnDeviceInferenceActive()).toBe(false); // restored at turn end
+  });
+
+  it("lowers the GPU gauge even when the consumer breaks early", async () => {
+    const p = withEngine(new WebLLMProvider("m"), [
+      { choices: [{ delta: { content: "a" } }] },
+      { choices: [{ delta: { content: "b" } }] },
+      { choices: [{ delta: { content: "c" } }] },
+    ]);
+    // Break after the first token — the generator's `finally` must still run.
+    for await (const c of p.generateStream(ctx)) {
+      if (c.type === "text") break;
+    }
+    expect(isOnDeviceInferenceActive()).toBe(false);
   });
 });

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -16,7 +16,7 @@ import { ProxySession } from "@motebit/runtime";
 import type { ProxyProviderConfig } from "@motebit/runtime";
 import { deriveInteriorColor } from "./ui/color-picker";
 import { initColorPicker } from "./ui/color-picker";
-import { WebLLMProvider, PROXY_BASE_URL } from "./providers";
+import { WebLLMProvider, PROXY_BASE_URL, isOnDeviceInferenceActive } from "./providers";
 import { cleanConversationHistory } from "./bootstrap";
 import { initChat, addMessage, showToast } from "./ui/chat";
 import { initSettings } from "./ui/settings";
@@ -287,6 +287,21 @@ const sovereignPanel = document.getElementById("sovereign-panel") as HTMLDivElem
 const capabilitiesPanelEl = document.getElementById("capabilities-panel") as HTMLDivElement;
 const activityPanelEl = document.getElementById("activity-panel") as HTMLDivElement;
 
+// Honest degradation for the on-device main-thread fallback: when WebLLM can't
+// run in a background worker on this browser, inference blocks the whole page
+// (creature + input freeze during a turn) and the render loop's GPU-yield can't
+// help. Tell the owner once, and point them at the smooth paths — rather than
+// leaving an unexplained freeze. Fired lazily on the first fallback turn.
+let webllmFallbackWarned = false;
+document.addEventListener("motebit:webllm-mainthread-fallback", () => {
+  if (webllmFallbackWarned) return;
+  webllmFallbackWarned = true;
+  addMessage(
+    "system",
+    "On-device is running without a background worker on this browser, so the page may pause while I think. For a smoother experience, switch to motebit cloud or your own key in Settings.",
+  );
+});
+
 document.addEventListener("keydown", (e) => {
   if (e.key === "Escape") {
     if (activityPanelEl.classList.contains("open")) {
@@ -433,12 +448,24 @@ async function bootstrap(): Promise<void> {
   onResize();
 
   // Animation loop
-  let lastTime = 0;
+  // While on-device (WebGPU) inference saturates the GPU, throttle the creature
+  // to a calm ~12fps instead of fighting inference for every frame — asking for
+  // fewer frames means each requested one actually lands, so the creature reads
+  // as smooth-but-slow ("thinking inward") rather than frozen-then-janky. Only
+  // WebLLM raises the gauge; cloud/BYOK render full-rate. Not a presence change
+  // — the motebit is `responsive` throughout; this only governs draw cadence.
+  // `deltaTime` is always the real elapsed time since the last *draw*, so
+  // animation advances at correct wall-clock speed regardless of cadence.
+  const ON_DEVICE_YIELD_FPS = 12;
+  let lastRender = 0;
   const loop = (timestamp: number): void => {
     const time = timestamp / 1000;
-    const deltaTime = lastTime === 0 ? 1 / 60 : time - lastTime;
-    lastTime = time;
-    app.renderFrame(deltaTime, time);
+    const minInterval = isOnDeviceInferenceActive() ? 1 / ON_DEVICE_YIELD_FPS : 0;
+    if (time - lastRender >= minInterval) {
+      const deltaTime = lastRender === 0 ? 1 / 60 : time - lastRender;
+      lastRender = time;
+      app.renderFrame(deltaTime, time);
+    }
     requestAnimationFrame(loop);
   };
   requestAnimationFrame(loop);

--- a/apps/web/src/providers.ts
+++ b/apps/web/src/providers.ts
@@ -103,6 +103,36 @@ interface WebLLMModule {
  */
 const WEBLLM_CONTEXT_WINDOW_TOKENS = 16384;
 
+// ── On-device GPU-contention signal ─────────────────────────────────────────
+// WebLLM runs inference on WebGPU; the creature renders on WebGL/Three.js. Both
+// hit the one physical GPU, so during an on-device turn the creature's render
+// loop is starved for GPU time and stutters into a visible freeze that clears
+// only when generation ends. The render loop (main.ts) reads this gauge to
+// *yield* GPU time while inference runs — dropping the creature to a calm, low
+// cadence so it degrades intentionally instead of freezing. Fewer requested
+// frames means each one actually lands: smooth-but-slow, not stutter-then-jank.
+//
+// Only WebLLM raises it. Cloud and BYOK (and the local-server backend) are
+// network-bound and never contend for the local GPU. This is a rendering
+// concern, deliberately NOT the `responsive | tending | idle` presence state
+// machine: the motebit is `responsive` (actively answering a user turn) the
+// whole time — this only governs how hard the render loop draws. A depth
+// counter tolerates overlapping/nested turns.
+let onDeviceInferenceDepth = 0;
+
+/** True while an on-device (WebGPU) inference turn is saturating the GPU. */
+export function isOnDeviceInferenceActive(): boolean {
+  return onDeviceInferenceDepth > 0;
+}
+
+function beginOnDeviceInference(): void {
+  onDeviceInferenceDepth++;
+}
+
+function endOnDeviceInference(): void {
+  onDeviceInferenceDepth = Math.max(0, onDeviceInferenceDepth - 1);
+}
+
 export class WebLLMProvider implements StreamingProvider {
   private engine: WebLLMEngine | null = null;
   private worker: Worker | null = null;
@@ -110,6 +140,8 @@ export class WebLLMProvider implements StreamingProvider {
   private _temperature: number;
   private _maxTokens: number;
   private onProgress?: (text: string, progress: number) => void;
+  private onMainThreadFallback?: () => void;
+  private _mainThreadFallback = false;
 
   constructor(
     model: string,
@@ -117,12 +149,24 @@ export class WebLLMProvider implements StreamingProvider {
       temperature?: number;
       maxTokens?: number;
       onProgress?: (text: string, progress: number) => void;
+      onMainThreadFallback?: () => void;
     },
   ) {
     this._model = model;
     this._temperature = opts?.temperature ?? 0.7;
     this._maxTokens = opts?.maxTokens ?? 4096;
     this.onProgress = opts?.onProgress;
+    this.onMainThreadFallback = opts?.onMainThreadFallback;
+  }
+
+  /**
+   * True once the engine fell back to running inference on the main thread
+   * (no background worker on this browser). The main-thread path blocks all
+   * rendering during a turn — the render loop can't yield around it — so this
+   * is surfaced to the owner rather than silently frozen.
+   */
+  get usingMainThreadFallback(): boolean {
+    return this._mainThreadFallback;
   }
 
   get model(): string {
@@ -200,7 +244,15 @@ export class WebLLMProvider implements StreamingProvider {
       }
     }
 
-    // Fallback: main thread engine (blocks rendering but still works)
+    // Fallback: main thread engine. This blocks ALL rendering during a turn —
+    // the render loop's GPU-yield can't help because the main thread itself is
+    // held — so we surface it honestly (once) instead of leaving the owner with
+    // an unexplained freeze. See `docs/doctrine/surface-determinism.md`
+    // ("failures degrade honestly, not gracefully").
+    if (!this._mainThreadFallback) {
+      this._mainThreadFallback = true;
+      this.onMainThreadFallback?.();
+    }
     return webllm.CreateMLCEngine(
       this._model,
       { initProgressCallback: progressCb },
@@ -273,16 +325,25 @@ export class WebLLMProvider implements StreamingProvider {
 
     let accumulated = "";
     let nativeReasoning = "";
-    for await (const chunk of stream) {
-      const delta = chunk.choices[0]?.delta?.content;
-      if (delta) {
-        accumulated += delta;
-        yield { type: "text", text: delta };
+    // Raise the GPU-contention gauge for the duration of the WebGPU inference
+    // drain so the render loop yields GPU time (calm low-cadence creature)
+    // instead of freezing. `finally` lowers it even if the consumer breaks
+    // early — an async generator runs its `finally` when closed.
+    beginOnDeviceInference();
+    try {
+      for await (const chunk of stream) {
+        const delta = chunk.choices[0]?.delta?.content;
+        if (delta) {
+          accumulated += delta;
+          yield { type: "text", text: delta };
+        }
+        // Native reasoning stream (in-browser reasoning models). Interior-only —
+        // accumulated raw, never into `accumulated`/the visible text.
+        const reasoningDelta = chunk.choices[0]?.delta?.reasoning_content;
+        if (reasoningDelta) nativeReasoning += reasoningDelta;
       }
-      // Native reasoning stream (in-browser reasoning models). Interior-only —
-      // accumulated raw, never into `accumulated`/the visible text.
-      const reasoningDelta = chunk.choices[0]?.delta?.reasoning_content;
-      if (reasoningDelta) nativeReasoning += reasoningDelta;
+    } finally {
+      endOnDeviceInference();
     }
 
     const memoryCandidates = extractMemoryTags(accumulated);
@@ -423,6 +484,7 @@ function specToProvider(
       return new WebLLMProvider(spec.model, {
         temperature: spec.temperature,
         maxTokens: spec.maxTokens,
+        onMainThreadFallback: options.onMainThreadFallback,
       });
     case "apple-fm":
     case "mlx":
@@ -450,6 +512,18 @@ export interface ProviderOptions {
    * § "PR 4 — chrome narration of routing decisions".
    */
   onRoutingReason?: (reason: string) => void;
+
+  /**
+   * Fired once when the WebLLM (on-device) engine cannot start its
+   * background Web Worker and falls back to running inference on the
+   * main thread. That path hard-blocks the page — creature, input, and
+   * DOM all freeze while a turn generates — so surfacing it honestly is
+   * the "failures degrade honestly, not gracefully" contract: the owner
+   * is told the tab may pause and pointed at cloud/BYOK for smoothness,
+   * rather than left to experience an unexplained freeze. Only the
+   * `webllm` backend can raise it.
+   */
+  onMainThreadFallback?: () => void;
 }
 
 /**

--- a/apps/web/src/ui/chat.ts
+++ b/apps/web/src/ui/chat.ts
@@ -49,6 +49,57 @@ export function renderMarkdown(raw: string): string {
   );
 }
 
+/**
+ * Coalesces streaming markdown re-renders to one paint per animation frame.
+ *
+ * The naive path — `el.innerHTML = renderMarkdown(accumulated)` on every
+ * streamed token — is O(n²): each token re-parses and re-lays-out the entire
+ * growing message, and a fast token burst (on-device WebLLM, cached cloud
+ * replies) fires hundreds of synchronous reflows a second on the main thread.
+ * That is the lag felt while a reply streams, and it amplifies the GPU
+ * contention on the on-device path.
+ *
+ * Coalescing decouples token-arrival rate from DOM-render rate: tokens arriving
+ * within one frame collapse into a single markdown render + one DOM write + one
+ * scroll, capping re-renders at the display refresh rate. `flush()` forces the
+ * final paint at turn end so the last tokens (which may have landed mid-frame)
+ * are always shown. Markdown needs the whole string for correct parsing (a
+ * token can close a code fence or list), so each paint re-renders the full
+ * source — but at ~display-refresh rate, not once per token. TTS chunking is
+ * unaffected; only the DOM render coalesces.
+ */
+export class StreamingRenderer {
+  private frame: number | null = null;
+  private pending: { el: HTMLElement; source: string; onPaint?: () => void } | null = null;
+
+  push(el: HTMLElement, source: string, onPaint?: () => void): void {
+    this.pending = { el, source, onPaint };
+    if (this.frame === null) {
+      this.frame = requestAnimationFrame(() => {
+        this.frame = null;
+        this.paint();
+      });
+    }
+  }
+
+  /** Force the pending paint immediately (call at turn end). Idempotent. */
+  flush(): void {
+    if (this.frame !== null) {
+      cancelAnimationFrame(this.frame);
+      this.frame = null;
+    }
+    this.paint();
+  }
+
+  private paint(): void {
+    const p = this.pending;
+    if (p === null) return;
+    this.pending = null;
+    p.el.innerHTML = renderMarkdown(p.source);
+    p.onPaint?.();
+  }
+}
+
 // === Streaming TTS ===
 
 /**
@@ -724,6 +775,7 @@ export function initChat(ctx: WebContext, callbacks: ChatCallbacks): ChatAPI {
     let textEl: HTMLSpanElement | null = null;
     let accumulated = "";
     let firstChunkReceived = false;
+    const renderer = new StreamingRenderer();
     // Captured from the most recent delegation_complete that carried a full
     // signed receipt. Emerged as a spatial artifact after the result chunk
     // so the review text stays unopposed as the primary content; the receipt
@@ -765,8 +817,9 @@ export function initChat(ctx: WebContext, callbacks: ChatCallbacks): ChatAPI {
             }
 
             accumulated += chunk.text;
-            textEl!.innerHTML = renderMarkdown(accumulated);
-            chatLog.scrollTop = chatLog.scrollHeight;
+            renderer.push(textEl!, accumulated, () => {
+              chatLog.scrollTop = chatLog.scrollHeight;
+            });
             streamingTTS.push(chunk.text);
             break;
           }
@@ -847,8 +900,9 @@ export function initChat(ctx: WebContext, callbacks: ChatCallbacks): ChatAPI {
                   bubble.classList.add("visible");
                 }
                 accumulated += resumeChunk.text;
-                textEl!.innerHTML = renderMarkdown(accumulated);
-                chatLog.scrollTop = chatLog.scrollHeight;
+                renderer.push(textEl!, accumulated, () => {
+                  chatLog.scrollTop = chatLog.scrollHeight;
+                });
                 streamingTTS.push(resumeChunk.text);
               } else if (resumeChunk.type === "tool_status") {
                 if (resumeChunk.status === "calling")
@@ -956,11 +1010,17 @@ export function initChat(ctx: WebContext, callbacks: ChatCallbacks): ChatAPI {
           }
         }
       }
+      // Force the final coalesced paint so the last tokens (which may have
+      // landed mid-frame) are always shown before the turn settles.
+      renderer.flush();
       // Post-loop cleanup: unconditionally remove thinking indicator.
       // Covers all edge cases (tag-only responses, tool-only iterations,
       // early break, missing result chunk). Safe to call if already removed.
       removeThinkingIndicator(thinkingEl);
     } catch (err: unknown) {
+      // Flush before the empty-bubble check below reads textContent — a
+      // coalesced paint may still be pending when the error interrupts.
+      renderer.flush();
       removeThinkingIndicator(thinkingEl);
       const msg = err instanceof Error ? err.message : String(err);
       if (bubble && !textEl?.textContent) {
@@ -997,6 +1057,7 @@ export function initChat(ctx: WebContext, callbacks: ChatCallbacks): ChatAPI {
     let currentBubble: HTMLDivElement | null = null;
     let currentTextEl: HTMLSpanElement | null = null;
     let accumulated = "";
+    const renderer = new StreamingRenderer();
 
     try {
       for await (const chunk of ctx.app.executeGoal(goalId, goal)) {
@@ -1051,11 +1112,14 @@ export function initChat(ctx: WebContext, callbacks: ChatCallbacks): ChatAPI {
           case "step_chunk":
             if (chunk.chunk.type === "text" && currentTextEl) {
               accumulated += chunk.chunk.text;
-              currentTextEl.innerHTML = renderMarkdown(accumulated);
-              chatLog.scrollTop = chatLog.scrollHeight;
+              renderer.push(currentTextEl, accumulated, () => {
+                chatLog.scrollTop = chatLog.scrollHeight;
+              });
             }
             break;
           case "step_completed": {
+            // Paint this step's final text before its element is released.
+            renderer.flush();
             // Update the spatial artifact — mark this step done
             const planArtifact = document.querySelector(`#plan-step-${chunk.step.ordinal}`);
             if (planArtifact) planArtifact.classList.add("step-done");
@@ -1099,9 +1163,11 @@ export function initChat(ctx: WebContext, callbacks: ChatCallbacks): ChatAPI {
         }
       }
     } catch (err: unknown) {
+      renderer.flush();
       const msg = err instanceof Error ? err.message : String(err);
       addMessage("system", `Plan error: ${msg}`);
     } finally {
+      renderer.flush();
       setProcessing(false);
     }
   }
@@ -1139,6 +1205,7 @@ export function initChat(ctx: WebContext, callbacks: ChatCallbacks): ChatAPI {
     let textEl: HTMLSpanElement | null = null;
     let accumulated = "";
     let capturedReceipt: ExecutionReceipt | null = null;
+    const renderer = new StreamingRenderer();
 
     try {
       // A pinned `targetWorkerId` makes this a deterministic hire of THAT worker
@@ -1162,8 +1229,9 @@ export function initChat(ctx: WebContext, callbacks: ChatCallbacks): ChatAPI {
               bubble.classList.add("visible");
             }
             accumulated += chunk.text;
-            textEl!.innerHTML = renderMarkdown(accumulated);
-            chatLog.scrollTop = chatLog.scrollHeight;
+            renderer.push(textEl!, accumulated, () => {
+              chatLog.scrollTop = chatLog.scrollHeight;
+            });
             break;
           }
           case "delegation_complete": {
@@ -1189,6 +1257,7 @@ export function initChat(ctx: WebContext, callbacks: ChatCallbacks): ChatAPI {
       addMessage("system", `Delegation error: ${msg}`);
       return;
     } finally {
+      renderer.flush();
       setProcessing(false);
     }
 

--- a/apps/web/src/web-app.ts
+++ b/apps/web/src/web-app.ts
@@ -1465,6 +1465,13 @@ export class UnbootedWebApp {
         this._routingNarration = reason;
         this.applyChromeToCurrentState();
       },
+      // On-device engine had to run inference on the main thread (no worker on
+      // this browser) — that hard-freezes the page during a turn. Surface it on
+      // the DOM event bus so the UI layer can warn the owner honestly; fired
+      // once, lazily, on the first turn that takes the fallback.
+      onMainThreadFallback: () => {
+        document.dispatchEvent(new CustomEvent("motebit:webllm-mainthread-fallback"));
+      },
     }) as StreamingProvider;
     this._currentProvider = provider;
     // BYOK auto-router opt-in (per-turn `dispatchByokRouting` consumer


### PR DESCRIPTION
## The bug (valid — not "weak models")

On `motebit.com` plugged into WebLLM, the creature freezes while a prompt processes and unfreezes when it finishes. WebLLM runs inference on **WebGPU**; the creature renders on **WebGL/Three.js** — both hit the one physical GPU, so during an on-device turn the render loop is starved and stutters into a visible freeze. Weak models give slow/bad *answers*, not freezes — this was pure GPU contention, amplified by an O(n²) per-token re-render.

Three causes, fixed cheapest-universal → hardest-real.

### C — render coalescing (universal; helps cloud + BYOK too)
The chat stream re-parsed markdown and rewrote `innerHTML` on **every token** — O(n²) in message length, hundreds of synchronous reflows/sec under a fast burst. New `StreamingRenderer` coalesces all tokens within a frame into one render + one DOM write + one scroll, capping re-renders at display refresh. Wired across all four streaming sites; `flush()` guarantees the final paint at turn end.

### A — GPU-yield (the real fix)
`WebLLMProvider` raises an `isOnDeviceInferenceActive()` gauge for the WebGPU drain (depth-counted, `finally`-lowered even on early break). The render loop reads it and throttles the creature to a calm ~12fps while inference runs — **fewer requested frames means each one actually lands**, so the creature reads as smooth-but-slow ("thinking inward") instead of frozen-then-janky. `deltaTime` tracks real elapsed-since-draw, so motion stays wall-clock-correct at any cadence. Only WebLLM raises it; cloud/BYOK render full-rate.

This is deliberately a **rendering concern, NOT the `responsive | tending | idle` presence machine** — the motebit stays `responsive` (actively answering) throughout; the gauge only governs draw cadence. It converts *accidental GPU starvation into a designed yield*, so it holds when on-device becomes the primary path, not just today's demo (a single-GPU machine physically cannot render a full-fidelity creature while a WebGPU LLM saturates it — so the endgame-correct move is to stop competing, not to try to win).

### B — honest main-thread fallback
When no background worker is available and inference falls back to the main thread (hard-blocks the whole page — the GPU-yield can't help because the thread itself is held), the provider fires `onMainThreadFallback` once → the UI warns the owner and points at cloud/BYOK, rather than leaving an unexplained freeze. *Failures degrade honestly, not gracefully.*

## Not in scope (deliberate)
No bespoke "inward breathing" creature animation in `render-engine` — the ~12fps calm cadence *is* the yield and is the correct shippable fix; a dedicated inward-pose expression is a visual-design follow-on that belongs with design review, not authored unilaterally here.

## Tests
- `StreamingRenderer`: 5 tests (coalescing, latest-wins, single side-effect/frame, flush, fresh-frame-after-paint) via an injected `requestAnimationFrame`.
- GPU gauge: 2 tests (raises mid-stream, lowers on normal completion AND early break).
- Web suite: 551 pass, typecheck + lint clean, changeset-discipline green. Full pre-push gates passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)