### PR TITLE
feat: spend_ceiling on the wire + delegation-revocation cache (money-execution Inc 3a)

### DIFF
--- a/.changeset/spend-ceiling-wire-ignored.md
+++ b/.changeset/spend-ceiling-wire-ignored.md
@@ -1,0 +1,6 @@
+---
+"@motebit/wire-schemas": minor
+"@motebit/policy": minor
+---
+
+standing-delegation@1.2 `spend_ceiling` siblings: `@motebit/wire-schemas` gains `SpendCeilingV1Schema` (+ optional `spend_ceiling` on `StandingDelegationSchema`, parity block, `spend-ceiling-v1.json` emitter); `@motebit/policy` gains `spendCeilingFromGrant`, the only sanctioned wire→enforcer mapping (spec §3.3 rule 2: the enforcer's ceiling MUST come from a VERIFIED grant, never local config).

--- a/.changeset/spend-ceiling-wire.md
+++ b/.changeset/spend-ceiling-wire.md
@@ -1,0 +1,5 @@
+---
+"@motebit/protocol": minor
+---
+
+`SpendCeilingV1` + `StandingDelegation.spend_ceiling` (standing-delegation@1.2) — the delegator's signed autonomous-spend ceiling on the wire, closing the money-execution checkpoint's D3 axis (`docs/proposals/standing-delegation-execution-checkpoint.md`). The ceiling rides in the grant's signed body (spec §3.3; committed schemas `spend-ceiling-v1.json` + regenerated `standing-delegation-v1.json`), making the HOW-MUCH a cryptographic commitment rather than local config. Absence is fail-closed by construction: a @1.0/@1.1 grant verifies unchanged and authorizes NO autonomous money (`ceiling_absent`). Limits are integer micro-units, USD-denominated (pinned by spec prose; a future asset model is a new `schema` literal — an agility-axis append). No crypto changes — JCS signing already covers the new field, proven by tamper/strip/graft tests.

--- a/docs/proposals/standing-delegation-execution-checkpoint.md
+++ b/docs/proposals/standing-delegation-execution-checkpoint.md
@@ -1,0 +1,79 @@
+# CHECKPOINT — Standing-Delegation Money Execution, Inc 1→2 human sign-off
+
+**Status:** SIGNED OFF 2026-07-04 — all four decisions (D1 relay-coordinated v1 / D2 semantics ratified, USD-micro pinned / D3 `spend_ceiling` @1.2 additive field / D4 settlement-time revocation + 7–30d money-grant lifetime) approved by Daniel Hakim as recommended. Inc 3a (wire: `spend_ceiling` @1.2 + relay delegation-revocation cache) shipped same day; Inc 3b (wiring) is next.
+**Author:** motebit PE (grounded audit 2026-07-04, main @ `1a7f7132`)
+**Composes with:** [`standing-delegation-v1.md`](standing-delegation-v1.md) (APPROVED 2026-06-10), `spec/standing-delegation-v1.md` (Draft), [`memory-never-confers-authority.md`](../doctrine/memory-never-confers-authority.md), [`verify-family-fail-closed.md`](../doctrine/verify-family-fail-closed.md)
+
+## 0. Grounded state (what is true on main today)
+
+The R4 autonomous-money pipe is **fully coded, tested end-to-end, and dormant at two independent layers**:
+
+1. `verifyGrantForTurn` (`packages/runtime/src/grant-verifier.ts:46`) — the sole producer of `TurnContext.verifiedGrant` (gate `check-money-authority`) — has **zero production callers**. Policy-gate step 8b (`packages/policy/src/policy-gate.ts:385-402`) therefore forces approval on every R4 call. No config switch exists for this branch; that is the invariant.
+2. Even where the gate would clear, `evaluateBlastRadius` (`packages/policy/src/grant-blast-radius.ts:177`) denies `ceiling_absent` because **no grant carries a spend ceiling** — `GrantSpendCeiling` is not a wire field yet.
+
+The hard-zero dry-run (#225, `packages/runtime/src/__tests__/standing-delegation-dry-run.test.ts`) proves the full chain reachable with real crypto — grant → token → `verifyGrantForTurn` → gate 8b → enforcer — and proves `gate-allow ∧ enforcer-allow = false` today. Frontends cannot assert `verifiedGrant` over the wire (`runtime-host/src/safe-options.ts` strips it structurally).
+
+**What is structurally missing for live money (Inc 3 scope):** (a) a live caller extracting token+grant+revocations at the delegated-task ingress and threading `verifiedGrant` into `sendMessageStreaming`; (b) a persistent grant store + revocation plumbing; (c) a persistent atomic `GrantSpendStore` (only in-memory exists; needs `appendWithClock`-class atomicity); (d) the signed ceiling on the wire (Axis 3); (e) the dispatch AND-composition — `tryConsume` between gate-clear and money-move, with `MoneyAction` extracted from the real tool call; (f) the actual rail execution.
+
+---
+
+## Axis 1 — Threat model
+
+**What the vault protects (as shipped, post external-review correction `ec3959d6`):** the decomposition attack (one large payment salami-sliced across turns) on the **trusted-runtime / online path only** — honest-but-fallible runtime, runaway loop, prompt injection that does not compromise the key or the store.
+
+**What it explicitly does NOT protect:** a malicious **offline** delegate. Minting is a local signature under the grant, so an offline adversary manufactures fresh short-TTL tokens from stale standing authority until `expires_at`, and controls its own `GrantSpendStore` (simply never commits). Offline ceilings are: grant expiry, counterparty-side enforcement, onchain rate caps (`spec/settlement-v1.md`). The freshness staple (OCSP-style) and epoch-root accumulators are designed-deferred in `verify-family-fail-closed.md`.
+
+**DECISION 1: accept trusted-runtime-only scope for v1 live money?**
+
+**Recommendation — yes, with a structural restriction that makes the offline hole moot:** v1 autonomous money executes **only on the relay-coordinated settlement path**, where the relay re-verifies the grant (incl. revocation) at settlement time and is the trusted accumulator. Pure-P2P autonomous money stays behind the freshness-staple trigger. This is not a compromise — it is the clearing-house doctrine executing (coordination lowers risk; that is what the 5% buys). Add the named adversarial test `revoke-then-self-mint-offline` as a permanent red-team fixture in the same increment.
+
+## Axis 2 — Ceiling semantics
+
+**As implemented** (`grant-blast-radius.ts:67-270`): integer micro-USD; cumulative-within-rolling-window (`cumulative_limit_micro` + `window_ms`, forward-only roll, clock-rollback safe) and/or lifetime (`lifetime_limit_micro`, never resets); per-counterparty bucket; per-window action count; monotonic nonce anti-replay; at least one total bound required or deny `ceiling_absent`; a set limit of 0 = deny-all; strict `>` (hitting the ceiling exactly is allowed, exceeding is denied); deny mutates nothing; overflow-guarded; atomic check-and-commit store contract.
+
+**DECISION 2: ratify these semantics as the signed-commitment semantics?**
+
+**Recommendation — ratify as-is, with one spec-text pin and one named future axis:** (a) pin the denomination as **USD-denominated micro-units** in spec prose — the ceiling has no asset tag today, and ambiguity here is a money bug waiting for the first non-USD rail; (b) name `asset` as a future **agility axis** (registry append per [`agility-as-role.md`](../doctrine/agility-as-role.md)), not a v1 field. The exact-hit-allowed strict-exceed convention and deny-all-zero are correct and standard; do not renegotiate them.
+
+## Axis 3 — Wire shape (the load-bearing decision)
+
+**The gap, stated by the source itself** (`grant-blast-radius.ts:48-51`): the enforcer expects the ceiling to be **the delegator's cryptographic commitment**, but `StandingDelegation` (`packages/protocol/src/index.ts:327-375`) carries WHO/WHAT/WHEN (parties, capability scope, cadence, `max_token_ttl_ms`, `expires_at`, revocation handle) and **no HOW-MUCH**. Today a ceiling could only be unsigned local config — which would violate the arc's own honesty floor (authority from signed artifacts only).
+
+**DECISION 3: how does the ceiling reach the wire?**
+
+**Recommendation — additive optional field `spend_ceiling?` on standing-delegation@1.2** (following the @1.1 `subject_binding` precedent):
+
+- Absent ⇒ `ceiling_absent` ⇒ no autonomous money. **Absence is already fail-closed** — the enforcer's existing behavior makes the additive-optional shape safe by construction. Old grants verify fine and simply cannot move money.
+- Inside the signed body (JCS-covered), so the ceiling is the delegator's commitment, not runtime config.
+- The wiring invariant that must ship with it: `evaluateBlastRadius` receives its ceiling **only** from the verified grant — never from config, never model-authored. This is the produced-not-authored discipline applied to money; it wants its own drift gate (working name `check-ceiling-from-grant`), sibling of `check-money-authority`.
+- Sweep: protocol type + crypto sign/verify + `spec/standing-delegation-v1.md` @1.2 section + `spec/schemas/` + wire-schemas + `@motebit/verifier` + drift tests. One increment, one-pass delivery.
+
+Rejected alternative: a separate signed ceiling artifact — splits the authority story across two artifacts with a binding problem between them, for no gain at v1.
+
+## Axis 4 — Revocation latency
+
+**Grounded facts:** revocation is a signed `DelegationRevocation` (terminal, D3), checked via the injected `isRevoked` seam; `verifyGrantForTurn` re-checks per turn against the **held** revocation set, fail-closed. There is **no relay `delegation_revoked` feed** (deferred at N=1 self-issuance per proposal §6b; only the agent-revocation feed exists at `services/relay/src/agent-revocation.ts`). Online latency = freshness of the held set. Offline latency against a malicious delegate = **up to `expires_at`** (the honest post-`ec3959d6` claim; token TTL does not bound this case).
+
+**DECISION 4: what revocation freshness is required before money moves?**
+
+**Recommendation — two-part:**
+
+1. **Relay checks revocation at settlement time.** Since v1 money is relay-coordinated (Decision 1), extend the existing `RevocationEvent` feed with the `delegation_revoked` type (grant_id, same append-only feed + horizon) **in Inc 3**, and the relay refuses settlement under a revoked grant. Online revocation latency then ≈ one settlement round-trip — effectively immediate at the only checkpoint where money finalizes.
+2. **Money-scoped grants get tight lifetimes.** Spec recommends ≤90d for grants generally; for grants carrying `spend_ceiling`, recommend **7–30d renewable** default, `max_token_ttl_ms` 1h. Offline worst-case exposure is then (short grant life × signed ceiling) — a bounded, named, priced risk instead of an open one.
+
+---
+
+## Proposed Inc 3 / Inc 4 sequencing
+
+- **Inc 3a (wire):** `spend_ceiling` @1.2 sweep (Axis 3) + `delegation_revoked` feed type.
+- **Inc 3b (wiring):** ingress caller → `verifyGrantForTurn` → `verifiedGrant` threading; persistent atomic `GrantSpendStore`; dispatch AND-composition (`tryConsume` between gate-clear and rail execution); `check-ceiling-from-grant` gate; `revoke-then-self-mint-offline` adversarial fixture.
+- **Inc 4 (enable):** first live grant is **self-delegation at N=1** — the founder's own motebit paying a real counterparty under the tightest expressible ceiling (e.g. lifetime $5, per-counterparty $5, 7-day grant). Adversarial-onboarding idiom: the first real autonomous dollar moves under the smallest vault, and produces the first genuine autonomous-money `ExecutionReceipt`s — the first dispute-grade rows the clearing-house moat is made of.
+
+## Sign-off
+
+- [ ] **D1** — trusted-runtime threat model accepted; v1 money relay-coordinated only; pure-P2P deferred behind freshness staple
+- [ ] **D2** — ceiling semantics ratified; USD-micro denomination pinned; `asset` named as future agility axis
+- [ ] **D3** — `spend_ceiling?` as signed additive field on standing-delegation@1.2; ceiling-from-verified-grant-only gate
+- [ ] **D4** — settlement-time revocation check + `delegation_revoked` feed in Inc 3; 7–30d money-grant lifetime convention
+
+Signed-off-by: \***\*\_\_\_\_\*\*** Date: \***\*\_\_\_\_\*\***

--- a/packages/crypto/src/__tests__/standing-delegation.test.ts
+++ b/packages/crypto/src/__tests__/standing-delegation.test.ts
@@ -40,6 +40,7 @@ async function makeGrant(
       scope: over.scope ?? "web_search,summarize",
       subject: over.subject ?? "research:thesis=acme",
       ...(over.subject_binding !== undefined ? { subject_binding: over.subject_binding } : {}),
+      ...(over.spend_ceiling !== undefined ? { spend_ceiling: over.spend_ceiling } : {}),
       cadence_ms: over.cadence_ms ?? 24 * HOUR,
       issued_at: over.issued_at ?? now,
       not_before: over.not_before ?? null,
@@ -488,5 +489,66 @@ describe("subject_binding (@1.1)", () => {
     );
     expect(r.valid).toBe(false);
     expect(r.error).toContain("digest_method");
+  });
+});
+
+describe("spend_ceiling (standing-delegation@1.2)", () => {
+  const CEILING: SpendCeilingV1 = {
+    schema: "motebit.spend-ceiling.v1",
+    lifetime_limit_micro: 5_000_000, // $5 lifetime
+    cumulative_limit_micro: 1_000_000, // $1 per window
+    window_ms: 24 * HOUR,
+  };
+
+  it("round-trips a grant carrying a signed spend ceiling", async () => {
+    const alice = await generateKeypair();
+    const bob = await generateKeypair();
+    const grant = await makeGrant(alice, bob, { spend_ceiling: CEILING });
+    expect(grant.spend_ceiling).toEqual(CEILING);
+    expect(await verifyStandingDelegation(grant)).toBe(true);
+  });
+
+  it("rejects a tampered ceiling — the ceiling is the delegator's commitment", async () => {
+    const alice = await generateKeypair();
+    const bob = await generateKeypair();
+    const grant = await makeGrant(alice, bob, { spend_ceiling: CEILING });
+    const widened: StandingDelegation = {
+      ...grant,
+      spend_ceiling: { ...CEILING, lifetime_limit_micro: 5_000_000_000 },
+    };
+    expect(await verifyStandingDelegation(widened)).toBe(false);
+  });
+
+  it("rejects a ceiling STRIPPED from a signed grant (downgrade to no-money is still tamper)", async () => {
+    const alice = await generateKeypair();
+    const bob = await generateKeypair();
+    const grant = await makeGrant(alice, bob, { spend_ceiling: CEILING });
+    const { spend_ceiling: _stripped, ...rest } = grant;
+    expect(await verifyStandingDelegation(rest as StandingDelegation)).toBe(false);
+  });
+
+  it("rejects a ceiling GRAFTED onto a grant signed without one", async () => {
+    const alice = await generateKeypair();
+    const bob = await generateKeypair();
+    const grant = await makeGrant(alice, bob);
+    const grafted: StandingDelegation = { ...grant, spend_ceiling: CEILING };
+    expect(await verifyStandingDelegation(grafted)).toBe(false);
+  });
+
+  it("a @1.0/@1.1 grant (no ceiling) verifies unchanged — the field is additive", async () => {
+    const alice = await generateKeypair();
+    const bob = await generateKeypair();
+    const grant = await makeGrant(alice, bob);
+    expect(grant.spend_ceiling).toBeUndefined();
+    expect(await verifyStandingDelegation(grant)).toBe(true);
+  });
+
+  it("per-tick tokens verify identically against a ceiling-carrying grant", async () => {
+    const alice = await generateKeypair();
+    const bob = await generateKeypair();
+    const grant = await makeGrant(alice, bob, { spend_ceiling: CEILING });
+    const tick = await mintTick(grant, alice, bob);
+    const r = await verifyTokenAgainstGrant(tick, grant);
+    expect(r.valid).toBe(true);
   });
 });

--- a/packages/policy/src/__tests__/grant-blast-radius.test.ts
+++ b/packages/policy/src/__tests__/grant-blast-radius.test.ts
@@ -19,11 +19,13 @@ import {
   evaluateBlastRadius,
   freshGrantSpendState,
   canonicalizeCounterparty,
+  spendCeilingFromGrant,
   InMemoryGrantSpendStore,
   type GrantSpendCeiling,
   type GrantSpendState,
   type MoneyAction,
 } from "../grant-blast-radius";
+import type { SpendCeilingV1 } from "@motebit/protocol";
 
 const M = 1_000_000; // 1 USD in micro-units
 const GID = "grant-1";
@@ -284,5 +286,62 @@ describe("grant blast-radius — atomic store (the decomposition RACE)", () => {
     });
     expect(first.allowed).toBe(true);
     expect(replay.denial).toBe("replay");
+  });
+});
+
+describe("spendCeilingFromGrant — the wire→enforcer seam (@1.2)", () => {
+  const WIRE: SpendCeilingV1 = {
+    schema: "motebit.spend-ceiling.v1",
+    lifetime_limit_micro: 5 * M,
+    cumulative_limit_micro: 1 * M,
+    per_counterparty_limit_micro: 1 * M,
+    max_action_count: 3,
+    window_ms: 86_400_000,
+  };
+
+  it("returns null when the grant carries no ceiling (@1.0/@1.1 ⇒ no autonomous money)", () => {
+    expect(spendCeilingFromGrant({})).toBeNull();
+    expect(spendCeilingFromGrant({ spend_ceiling: undefined })).toBeNull();
+  });
+
+  it("maps every limit field explicitly and drops the wire `schema` tag", () => {
+    const ceiling = spendCeilingFromGrant({ spend_ceiling: WIRE });
+    expect(ceiling).toEqual({
+      lifetime_limit_micro: 5 * M,
+      cumulative_limit_micro: 1 * M,
+      per_counterparty_limit_micro: 1 * M,
+      max_action_count: 3,
+      window_ms: 86_400_000,
+    });
+    expect(ceiling).not.toHaveProperty("schema");
+  });
+
+  it("omits unset dimensions rather than materializing undefined keys", () => {
+    const ceiling = spendCeilingFromGrant({
+      spend_ceiling: { schema: "motebit.spend-ceiling.v1", lifetime_limit_micro: 2 * M },
+    });
+    expect(ceiling).toEqual({ lifetime_limit_micro: 2 * M });
+    expect(Object.keys(ceiling ?? {})).toEqual(["lifetime_limit_micro"]);
+  });
+
+  it("a limit-less wire ceiling maps to {} and the evaluator denies ceiling_absent (fail-closed composition)", () => {
+    const ceiling = spendCeilingFromGrant({
+      spend_ceiling: { schema: "motebit.spend-ceiling.v1" },
+    });
+    expect(ceiling).toEqual({});
+    const r = evaluateBlastRadius(ceiling!, freshGrantSpendState(GID, T0), act(1), 0, T0);
+    expect(r.decision.allowed).toBe(false);
+    expect(r.decision.denial).toBe("ceiling_absent");
+  });
+
+  it("a signed wire ceiling drives real enforcement end-to-end (allow within, deny beyond)", () => {
+    const ceiling = spendCeilingFromGrant({ spend_ceiling: WIRE })!;
+    const s0 = freshGrantSpendState(GID, T0);
+    const first = evaluateBlastRadius(ceiling, s0, act(1), 0, T0);
+    expect(first.decision.allowed).toBe(true);
+    // Second $1 in the same window exceeds cumulative_limit_micro ($1/window).
+    const second = evaluateBlastRadius(ceiling, first.nextState!, act(1), 1, T0 + 1);
+    expect(second.decision.allowed).toBe(false);
+    expect(second.decision.denial).toBe("cumulative_exceeded");
   });
 });

--- a/packages/policy/src/grant-blast-radius.ts
+++ b/packages/policy/src/grant-blast-radius.ts
@@ -51,6 +51,8 @@
  * the wire shape against the published `StandingDelegation` artifact.
  */
 
+import type { StandingDelegation } from "@motebit/protocol";
+
 /**
  * The cumulative ceiling a grant authorizes. Fail-closed: a money grant MUST bound
  * total exposure, so at least one of `cumulative_limit_micro` / `lifetime_limit_micro`
@@ -162,6 +164,40 @@ export function canonicalizeCounterparty(raw: string): string | null {
   if (t.length === 0) return null;
   if (/^0x[0-9a-fA-F]{40}$/.test(t)) return t.toLowerCase();
   return t;
+}
+
+/**
+ * Extract the enforcer ceiling from a grant's signed `spend_ceiling`
+ * (standing-delegation@1.2) — the ONLY sanctioned source of a
+ * `GrantSpendCeiling` (spec §3.3 rule 2: the ceiling MUST come from a VERIFIED
+ * grant, never local config — authority comes only from signed artifacts).
+ *
+ * The caller MUST pass a grant that already verified (`verifyGrantForTurn` /
+ * `verifyStandingDelegation`) — this function maps shape, it does not verify.
+ * Returns `null` when the grant carries no ceiling: a @1.0/@1.1 grant
+ * authorizes NO autonomous money, and callers feed the null through as
+ * `{}` ⇒ `ceiling_absent` denial (or refuse earlier). Fields are mapped
+ * explicitly — a future wire field never leaks into enforcement semantics
+ * silently.
+ */
+export function spendCeilingFromGrant(
+  grant: Pick<StandingDelegation, "spend_ceiling">,
+): GrantSpendCeiling | null {
+  const wire = grant.spend_ceiling;
+  if (wire == null) return null;
+  return {
+    ...(wire.cumulative_limit_micro !== undefined
+      ? { cumulative_limit_micro: wire.cumulative_limit_micro }
+      : {}),
+    ...(wire.per_counterparty_limit_micro !== undefined
+      ? { per_counterparty_limit_micro: wire.per_counterparty_limit_micro }
+      : {}),
+    ...(wire.max_action_count !== undefined ? { max_action_count: wire.max_action_count } : {}),
+    ...(wire.lifetime_limit_micro !== undefined
+      ? { lifetime_limit_micro: wire.lifetime_limit_micro }
+      : {}),
+    ...(wire.window_ms !== undefined ? { window_ms: wire.window_ms } : {}),
+  };
 }
 
 const deny = (denial: BlastRadiusDenial): BlastRadiusEvaluation => ({

--- a/packages/policy/src/index.ts
+++ b/packages/policy/src/index.ts
@@ -7,6 +7,7 @@ export {
   evaluateBlastRadius,
   freshGrantSpendState,
   canonicalizeCounterparty,
+  spendCeilingFromGrant,
   InMemoryGrantSpendStore,
 } from "./grant-blast-radius.js";
 export type {

--- a/packages/protocol/etc/protocol.api.md
+++ b/packages/protocol/etc/protocol.api.md
@@ -3848,6 +3848,16 @@ export interface SovereignWalletRail extends SovereignRail {
 }
 
 // @public
+export interface SpendCeilingV1 {
+    cumulative_limit_micro?: number;
+    lifetime_limit_micro?: number;
+    max_action_count?: number;
+    per_counterparty_limit_micro?: number;
+    schema: "motebit.spend-ceiling.v1";
+    window_ms?: number;
+}
+
+// @public
 export interface StandingDelegation {
     cadence_ms: number;
     // (undocumented)
@@ -3864,6 +3874,7 @@ export interface StandingDelegation {
     not_before: number | null;
     scope: string;
     signature: string;
+    spend_ceiling?: SpendCeilingV1;
     subject: string;
     subject_binding?: SubjectBindingV1;
     suite: "motebit-jcs-ed25519-b64-v1";

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -315,6 +315,47 @@ export interface SubjectBindingV1 {
 }
 
 /**
+ * The delegator's signed autonomous-spend ceiling (standing-delegation@1.2) —
+ * the HOW-MUCH a standing grant authorizes, as a cryptographic commitment.
+ * Rides in the grant's signed body, so the delegator's signature covers it;
+ * an enforcer MUST take its ceiling from a VERIFIED grant, never from local
+ * config (the ceiling is authority, and authority comes only from signed
+ * artifacts — memory-never-confers-authority applied to money).
+ *
+ * Every limit is in integer micro-units, **USD-denominated** (1 USD =
+ * 1,000,000) — the denomination is pinned by spec prose, not a field; a
+ * future non-USD asset is a new agility axis (a new `schema` literal), never
+ * a silent reinterpretation of these numbers. Absent ⇒ the grant authorizes
+ * NO autonomous money (enforcers deny `ceiling_absent`, fail-closed) — so a
+ * @1.0/@1.1 grant cannot move money, and adding this field is additive.
+ *
+ * Semantics (enforced by the blast-radius evaluator, `@motebit/policy`):
+ * at least one of `cumulative_limit_micro` / `lifetime_limit_micro` MUST be
+ * set or the ceiling authorizes nothing; a SET limit of `0` denies all
+ * positive spend on that dimension; per-window limits require `window_ms`.
+ * These ceilings bind the trusted-runtime/online path — offline, the binding
+ * bounds are the grant's `expires_at` and counterparty-side enforcement
+ * (see spec §3.3 threat model).
+ */
+export interface SpendCeilingV1 {
+  /** This ceiling's own type tag (in-body domain separation). A new
+   *  denomination/asset model is a NEW literal, never a silent change. */
+  schema: "motebit.spend-ceiling.v1";
+  /** Max cumulative spend (micro-USD) within one rolling window. Requires `window_ms`. */
+  cumulative_limit_micro?: number;
+  /** Max spend (micro-USD) to any single canonical counterparty within one window. Requires `window_ms`. */
+  per_counterparty_limit_micro?: number;
+  /** Max number of money actions within one window. Requires `window_ms`. */
+  max_action_count?: number;
+  /** Max cumulative spend (micro-USD) over the grant's ENTIRE life — never
+   *  reset by a window roll. The offline-meaningful total bound (paired with
+   *  the grant's `expires_at`). */
+  lifetime_limit_micro?: number;
+  /** Rolling window length in ms. Required (> 0) when any per-window limit is set. */
+  window_ms?: number;
+}
+
+/**
  * A standing (open-ended-feeling, cadence-scoped, revocable) delegation grant.
  * Unlike a {@link DelegationToken} — which authorizes ONE act and is short-lived
  * by invariant — a StandingDelegation authorizes its holder to MINT short-lived
@@ -354,6 +395,15 @@ export interface StandingDelegation {
    * SUBJECTS, the `scope` field names the permitted CAPABILITIES.
    */
   subject_binding?: SubjectBindingV1;
+  /**
+   * Optional (standing-delegation@1.2). The delegator's signed autonomous-spend
+   * ceiling (see {@link SpendCeilingV1}) — the HOW-MUCH this grant authorizes.
+   * Part of the signed body. Absent ⇒ the grant authorizes NO autonomous money
+   * (blast-radius enforcers deny `ceiling_absent`, fail-closed) — which is what
+   * makes this field additive: a @1.0/@1.1 grant verifies unchanged and simply
+   * cannot move money.
+   */
+  spend_ceiling?: SpendCeilingV1;
   /** Authorized minimum firing interval (ms). Enforced at mint/relay time, not by single-token verify. */
   cadence_ms: number;
   issued_at: number;

--- a/packages/wire-schemas/scripts/build-schemas.ts
+++ b/packages/wire-schemas/scripts/build-schemas.ts
@@ -29,6 +29,7 @@ import {
   buildStandingDelegationJsonSchema,
   buildDelegationRevocationJsonSchema,
   buildSubjectBindingV1JsonSchema,
+  buildSpendCeilingV1JsonSchema,
 } from "../src/standing-delegation.js";
 import { buildSignedRequestEnvelopeJsonSchema } from "../src/signed-request-envelope.js";
 import { buildSeedEscrowPayloadJsonSchema } from "../src/seed-escrow-payload.js";
@@ -150,6 +151,7 @@ const SCHEMAS: Array<{ filename: string; build: () => Record<string, unknown> }>
   { filename: "standing-delegation-v1.json", build: buildStandingDelegationJsonSchema },
   { filename: "delegation-revocation-v1.json", build: buildDelegationRevocationJsonSchema },
   { filename: "subject-binding-v1.json", build: buildSubjectBindingV1JsonSchema },
+  { filename: "spend-ceiling-v1.json", build: buildSpendCeilingV1JsonSchema },
   { filename: "cost-attestation-v1.json", build: buildCostAttestationJsonSchema },
   { filename: "invoice-v1.json", build: buildInvoiceJsonSchema },
   {

--- a/packages/wire-schemas/src/__tests__/drift.test.ts
+++ b/packages/wire-schemas/src/__tests__/drift.test.ts
@@ -134,9 +134,11 @@ import {
   STANDING_DELEGATION_SCHEMA_ID,
   DELEGATION_REVOCATION_SCHEMA_ID,
   SUBJECT_BINDING_SCHEMA_ID,
+  SPEND_CEILING_SCHEMA_ID,
   buildStandingDelegationJsonSchema,
   buildDelegationRevocationJsonSchema,
   buildSubjectBindingV1JsonSchema,
+  buildSpendCeilingV1JsonSchema,
 } from "../standing-delegation.js";
 import {
   COST_ATTESTATION_SCHEMA_ID,
@@ -276,6 +278,12 @@ const CASES: SchemaCase[] = [
     filename: "subject-binding-v1.json",
     expectedId: SUBJECT_BINDING_SCHEMA_ID,
     build: buildSubjectBindingV1JsonSchema,
+  },
+  {
+    name: "spend-ceiling-v1",
+    filename: "spend-ceiling-v1.json",
+    expectedId: SPEND_CEILING_SCHEMA_ID,
+    build: buildSpendCeilingV1JsonSchema,
   },
   {
     name: "cost-attestation-v1",

--- a/packages/wire-schemas/src/index.ts
+++ b/packages/wire-schemas/src/index.ts
@@ -42,12 +42,15 @@ export {
   StandingDelegationSchema,
   DelegationRevocationSchema,
   SubjectBindingV1Schema,
+  SpendCeilingV1Schema,
   STANDING_DELEGATION_SCHEMA_ID,
   DELEGATION_REVOCATION_SCHEMA_ID,
   SUBJECT_BINDING_SCHEMA_ID,
+  SPEND_CEILING_SCHEMA_ID,
   buildStandingDelegationJsonSchema,
   buildDelegationRevocationJsonSchema,
   buildSubjectBindingV1JsonSchema,
+  buildSpendCeilingV1JsonSchema,
 } from "./standing-delegation.js";
 export {
   CostAttestationV1Schema,

--- a/packages/wire-schemas/src/standing-delegation.ts
+++ b/packages/wire-schemas/src/standing-delegation.ts
@@ -28,7 +28,12 @@
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-import type { StandingDelegation, DelegationRevocation, SubjectBindingV1 } from "@motebit/protocol";
+import type {
+  StandingDelegation,
+  DelegationRevocation,
+  SubjectBindingV1,
+  SpendCeilingV1,
+} from "@motebit/protocol";
 
 import { assembleJsonSchemaFor } from "./assemble.js";
 import type { ParityForward, ParityReverse } from "./__parity/check.js";
@@ -40,6 +45,8 @@ export const DELEGATION_REVOCATION_SCHEMA_ID =
   "https://raw.githubusercontent.com/motebit/motebit/main/spec/schemas/delegation-revocation-v1.json";
 export const SUBJECT_BINDING_SCHEMA_ID =
   "https://raw.githubusercontent.com/motebit/motebit/main/spec/schemas/subject-binding-v1.json";
+export const SPEND_CEILING_SCHEMA_ID =
+  "https://raw.githubusercontent.com/motebit/motebit/main/spec/schemas/spend-ceiling-v1.json";
 
 const HEX_PUBLIC_KEY_PATTERN = /^[0-9a-f]{64}$/;
 const HEX_SHA256_PATTERN = /^[0-9a-f]{64}$/;
@@ -73,6 +80,61 @@ export const SubjectBindingV1Schema = z
       .describe(
         "`hex(SHA-256(canonicalJson(detached artifact)))`, 64 lowercase. Recompute from the artifact as received so JSON whitespace can't break the match.",
       ),
+  })
+  .strict();
+
+/**
+ * The delegator's signed autonomous-spend ceiling (standing-delegation@1.2).
+ * Rides in the grant's signed body — the HOW-MUCH as a cryptographic
+ * commitment. Limits are integer micro-units, USD-denominated (1 USD =
+ * 1,000,000; pinned by spec prose — a new asset model is a new `schema`
+ * literal). Absent from a grant ⇒ NO autonomous money (`ceiling_absent`,
+ * fail-closed). Semantic sufficiency (at least one total bound; `window_ms`
+ * with per-window limits) is the blast-radius evaluator's law, not a shape
+ * constraint — the schema constrains each field, the enforcer denies
+ * insufficient combinations.
+ */
+export const SpendCeilingV1Schema = z
+  .object({
+    schema: z
+      .literal("motebit.spend-ceiling.v1")
+      .describe("This ceiling's own type tag (in-body domain separation)."),
+    cumulative_limit_micro: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        "Max cumulative spend (integer micro-USD) within one rolling window. Requires `window_ms`. A SET value of 0 denies all positive spend on this dimension.",
+      ),
+    per_counterparty_limit_micro: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        "Max spend (integer micro-USD) to any single canonical counterparty within one window. Requires `window_ms`.",
+      ),
+    max_action_count: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe("Max number of money actions within one window. Requires `window_ms`."),
+    lifetime_limit_micro: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        "Max cumulative spend (integer micro-USD) over the grant's ENTIRE life — never reset by a window roll. The offline-meaningful total bound (paired with the grant's `expires_at`).",
+      ),
+    window_ms: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Rolling window length in ms. Required (> 0) when any per-window limit is set."),
   })
   .strict();
 
@@ -117,6 +179,9 @@ export const StandingDelegationSchema = z
       ),
     subject_binding: SubjectBindingV1Schema.optional().describe(
       "Optional (standing-delegation@1.1). Digest-binds the resolved subject-scope artifact this grant's authority reaches; part of the signed body, so the delegator's signature covers the resolved scope. Absent ⇒ a @1.0 grant with no signed resolved scope (higher-assurance consumers MUST fail closed). NOT the capability `scope`.",
+    ),
+    spend_ceiling: SpendCeilingV1Schema.optional().describe(
+      "Optional (standing-delegation@1.2). The delegator's signed autonomous-spend ceiling — the HOW-MUCH this grant authorizes, as a cryptographic commitment (part of the signed body). Absent ⇒ the grant authorizes NO autonomous money (enforcers deny `ceiling_absent`, fail-closed) — a @1.0/@1.1 grant verifies unchanged and simply cannot move money.",
     ),
     cadence_ms: z
       .number()
@@ -187,6 +252,18 @@ export const DelegationRevocationSchema = z
 type InferredStanding = z.infer<typeof StandingDelegationSchema>;
 type InferredRevocation = z.infer<typeof DelegationRevocationSchema>;
 type InferredSubjectBinding = z.infer<typeof SubjectBindingV1Schema>;
+type InferredSpendCeiling = z.infer<typeof SpendCeilingV1Schema>;
+
+type _SpendCeilingForward = ParityForward<SpendCeilingV1, InferredSpendCeiling>;
+type _SpendCeilingReverse = ParityReverse<SpendCeilingV1, InferredSpendCeiling>;
+
+export const _SPEND_CEILING_TYPE_PARITY: {
+  forward: _SpendCeilingForward;
+  reverse: _SpendCeilingReverse;
+} = {
+  forward: true,
+  reverse: true,
+};
 
 type _SubjectBindingForward = ParityForward<SubjectBindingV1, InferredSubjectBinding>;
 type _SubjectBindingReverse = ParityReverse<SubjectBindingV1, InferredSubjectBinding>;
@@ -249,6 +326,20 @@ export function buildSubjectBindingV1JsonSchema(): Record<string, unknown> {
     title: "SubjectBindingV1 (v1)",
     description:
       "Generic subject-scope binding (standing-delegation@1.1). Digest-binds a detached, vertically-typed scope artifact so a StandingDelegation's delegator signature reaches the EXACT resolved subjects. Unsigned — authority is the enclosing grant's signature over `digest`. `digest_method` is a HASH method (jcs-sha256-hex), NOT a signature suite. See spec/standing-delegation-v1.md §3.2.",
+  });
+}
+
+export function buildSpendCeilingV1JsonSchema(): Record<string, unknown> {
+  const raw = zodToJsonSchema(SpendCeilingV1Schema, {
+    name: "SpendCeilingV1",
+    $refStrategy: "root",
+    target: "jsonSchema7",
+  }) as Record<string, unknown>;
+  return assembleJsonSchemaFor("SpendCeilingV1", raw, {
+    $id: SPEND_CEILING_SCHEMA_ID,
+    title: "SpendCeilingV1 (v1)",
+    description:
+      "The delegator's signed autonomous-spend ceiling (standing-delegation@1.2) — the HOW-MUCH a StandingDelegation authorizes, carried in the grant's signed body as a cryptographic commitment. Integer micro-units, USD-denominated (1 USD = 1,000,000). Absent from a grant ⇒ no autonomous money (fail-closed `ceiling_absent`). See spec/standing-delegation-v1.md §3.3.",
   });
 }
 

--- a/services/relay/src/__tests__/delegation-revocations.test.ts
+++ b/services/relay/src/__tests__/delegation-revocations.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Delegation-revocation cache — ingestion + incremental read (standing-
+ * delegation §5/§6 D2; Inc 3a of the money-execution arc, checkpoint D4).
+ *
+ * The artifact is the security boundary: a validly-signed revocation from ANY
+ * submitter is recorded (revocation propagation is a feature); an invalid
+ * signature is rejected fail-closed; a stored revocation only has authority
+ * over grants whose delegator key matches (the consumer-side
+ * `findGrantRevocation` law, proven in @motebit/crypto's suite — not re-proven
+ * here).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { SyncRelay } from "../index.js";
+import {
+  generateKeypair,
+  bytesToHex,
+  signDelegationRevocation,
+  type DelegationRevocation,
+} from "@motebit/crypto";
+import { listRevokedGrantIds } from "../delegation-revocations.js";
+import { createTestRelay } from "./test-helpers.js";
+
+type Kp = { publicKey: Uint8Array; privateKey: Uint8Array };
+
+async function makeRevocation(
+  delegator: Kp,
+  grantId: string,
+  revokedAt: number = Date.now(),
+): Promise<DelegationRevocation> {
+  return signDelegationRevocation(
+    {
+      grant_id: grantId,
+      delegator_id: "did:motebit:alice",
+      delegator_public_key: bytesToHex(delegator.publicKey),
+      revoked_at: revokedAt,
+    },
+    delegator.privateKey,
+  );
+}
+
+const post = (relay: SyncRelay, body: unknown) =>
+  relay.app.request("/api/v1/delegations/revocations", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+const get = (relay: SyncRelay, since?: number) =>
+  relay.app.request(
+    `/api/v1/delegations/revocations${since !== undefined ? `?since=${since}` : ""}`,
+  );
+
+interface FeedBody {
+  generated_at: number;
+  next_since: number;
+  records: DelegationRevocation[];
+}
+
+describe("delegation-revocation cache", () => {
+  let relay: SyncRelay;
+
+  beforeEach(async () => {
+    relay = await createTestRelay();
+  });
+
+  afterEach(async () => {
+    await relay.close();
+  });
+
+  it("records a validly-signed revocation and serves it back verbatim", async () => {
+    const alice = await generateKeypair();
+    const revocation = await makeRevocation(alice, "grant-1");
+
+    const res = await post(relay, revocation);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, grant_id: "grant-1", status: "recorded" });
+
+    const feed = (await (await get(relay)).json()) as FeedBody;
+    expect(feed.records).toHaveLength(1);
+    // Verbatim: the served record is byte-equivalent to what was signed.
+    expect(feed.records[0]).toEqual(revocation);
+  });
+
+  it("re-submission is idempotent — one row, status already_recorded", async () => {
+    const alice = await generateKeypair();
+    const revocation = await makeRevocation(alice, "grant-1");
+
+    await post(relay, revocation);
+    const second = await post(relay, revocation);
+    expect(((await second.json()) as { status: string }).status).toBe("already_recorded");
+
+    const feed = (await (await get(relay)).json()) as FeedBody;
+    expect(feed.records).toHaveLength(1);
+  });
+
+  it("rejects a tampered revocation fail-closed (422) and stores nothing", async () => {
+    const alice = await generateKeypair();
+    const revocation = await makeRevocation(alice, "grant-1");
+    const tampered = { ...revocation, grant_id: "some-other-grant" };
+
+    const res = await post(relay, tampered);
+    expect(res.status).toBe(422);
+
+    const feed = (await (await get(relay)).json()) as FeedBody;
+    expect(feed.records).toHaveLength(0);
+  });
+
+  it("rejects a malformed body (400) — wire-schema validation, not just shape-sniffing", async () => {
+    const res = await post(relay, { grant_id: "g", signature: "not-a-revocation" });
+    expect(res.status).toBe(400);
+    const bad = await get(relay, -5);
+    expect(bad.status).toBe(400);
+  });
+
+  it("a third party may propagate someone else's valid revocation (feature, not forgery)", async () => {
+    // "Submitter" identity is irrelevant — there is no auth on the route; the
+    // artifact's own signature is the entire security boundary. A revocation
+    // signed by alice is accepted no matter who carries it.
+    const alice = await generateKeypair();
+    const revocation = await makeRevocation(alice, "grant-alice");
+    const res = await post(relay, revocation);
+    expect(res.status).toBe(200);
+  });
+
+  it("`since` is an incremental cursor over the relay receipt clock", async () => {
+    const alice = await generateKeypair();
+    await post(relay, await makeRevocation(alice, "grant-1"));
+
+    const first = (await (await get(relay)).json()) as FeedBody;
+    expect(first.records).toHaveLength(1);
+
+    // Nothing new after the cursor…
+    const empty = (await (await get(relay, first.next_since)).json()) as FeedBody;
+    expect(empty.records).toHaveLength(0);
+    expect(empty.next_since).toBe(first.next_since);
+
+    // …until a second revocation arrives (received_at strictly after cursor).
+    await new Promise((r) => setTimeout(r, 2));
+    await post(relay, await makeRevocation(alice, "grant-2"));
+    const delta = (await (await get(relay, first.next_since)).json()) as FeedBody;
+    expect(delta.records).toHaveLength(1);
+    expect(delta.records[0]!.grant_id).toBe("grant-2");
+  });
+
+  it("listRevokedGrantIds exposes the settlement-time isRevoked seam input", async () => {
+    const alice = await generateKeypair();
+    await post(relay, await makeRevocation(alice, "grant-1"));
+    await post(relay, await makeRevocation(alice, "grant-2"));
+
+    const revoked = listRevokedGrantIds(relay.moteDb.db);
+    expect(revoked).toEqual(new Set(["grant-1", "grant-2"]));
+  });
+});

--- a/services/relay/src/delegation-revocations.ts
+++ b/services/relay/src/delegation-revocations.ts
@@ -1,0 +1,167 @@
+/**
+ * Delegation-revocation cache — the relay half of standing-delegation §5.
+ *
+ * A `DelegationRevocation` is a DELEGATOR-signed sovereign artifact (spec
+ * `standing-delegation-v1.md` §5): the signed revocation is the canonical
+ * source of truth, and this table is a CACHE, never the authority (§6 D2;
+ * self-attesting-system doctrine). That is why this is a separate module from
+ * `agent-revocation.ts` — that feed serves RELAY-signed operator assertions
+ * (the de-list power, a different trust domain); mixing delegator-signed
+ * artifacts into it would blur who is asserting what. Same pattern, sibling
+ * trust root.
+ *
+ * Security is in the ARTIFACT, not the transport (the `POST /bond` class):
+ * ingestion verifies the revocation's own Ed25519 signature
+ * (`verifyDelegationRevocation`), and a stored revocation only ever has
+ * authority over grants whose `delegator_public_key` matches it
+ * (`findGrantRevocation` at the consumer). A third party "propagating" someone
+ * else's valid revocation is a feature — revocation wants to travel; the worst
+ * a hostile submitter can do is store self-signed revocations of grant_ids
+ * nobody issued, which revoke nothing. Invalid signatures are rejected 422.
+ *
+ * Why this exists NOW (Inc 3a of the money-execution arc): before autonomous
+ * money moves under a standing grant, the coordinator at the settlement
+ * checkpoint must be able to LEARN revocations — this cache is what the
+ * settlement-time re-verification (Inc 3b) reads, collapsing online revocation
+ * latency to one settlement round-trip. Checkpoint doc:
+ * `docs/proposals/standing-delegation-execution-checkpoint.md` (D4).
+ *
+ * Pruning: rows for grants past their propagation usefulness (revoked_at far
+ * beyond the D1 90-day max grant lifetime) can be truncated under the same
+ * revocation-horizon discipline as the agent feed — deferred until the table
+ * has real volume; grants self-expire, so an unpruned cache is a size concern,
+ * never a correctness one.
+ */
+
+import type { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import type { DatabaseDriver } from "@motebit/persistence";
+import { canonicalJson } from "@motebit/encryption";
+import { verifyDelegationRevocation, type DelegationRevocation } from "@motebit/crypto";
+import { DelegationRevocationSchema } from "@motebit/wire-schemas";
+import { createLogger } from "./logger.js";
+
+const logger = createLogger({ service: "delegation-revocations" });
+
+/**
+ * Record a verified revocation. Append-only, idempotent on the signature
+ * (Ed25519 is deterministic: same body + same key ⇒ same signature, so a
+ * re-submission is a no-op, not a duplicate row). `record_json` stores the
+ * byte-identical canonical artifact (`relay_receipts.receipt_json`
+ * discipline, CLAUDE.md rule 11) so consumers re-verify exactly what the
+ * delegator signed. Returns `true` when newly recorded, `false` when already
+ * present. The CALLER must have verified the signature first.
+ */
+export function insertDelegationRevocation(
+  db: DatabaseDriver,
+  revocation: DelegationRevocation,
+  receivedAt: number = Date.now(),
+): boolean {
+  const result = db
+    .prepare(
+      `INSERT OR IGNORE INTO relay_delegation_revocations
+         (grant_id, delegator_id, delegator_public_key, revoked_at,
+          suite, signature, record_json, received_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      revocation.grant_id,
+      revocation.delegator_id,
+      revocation.delegator_public_key,
+      revocation.revoked_at,
+      revocation.suite,
+      revocation.signature,
+      canonicalJson(revocation),
+      receivedAt,
+    );
+  return result.changes > 0;
+}
+
+/**
+ * List cached revocations, oldest-received first. `sinceReceivedAt` filters on
+ * the relay's RECEIPT clock, not the signer-asserted `revoked_at` — a
+ * backdated `revoked_at` cannot hide a record from an incremental poller.
+ * Returns verbatim signed records (parsed from `record_json`), each
+ * independently verifiable with no relay trust.
+ */
+export function listDelegationRevocations(
+  db: DatabaseDriver,
+  sinceReceivedAt = 0,
+): { records: DelegationRevocation[]; nextSince: number } {
+  const rows = db
+    .prepare(
+      `SELECT record_json, received_at FROM relay_delegation_revocations
+       WHERE received_at > ?
+       ORDER BY received_at ASC, id ASC`,
+    )
+    .all(sinceReceivedAt) as Array<{ record_json: string; received_at: number }>;
+  const records = rows.map((r) => JSON.parse(r.record_json) as DelegationRevocation);
+  const nextSince = rows.length > 0 ? rows[rows.length - 1]!.received_at : sinceReceivedAt;
+  return { records, nextSince };
+}
+
+/** The set of revoked grant_ids — the relay-side `isRevoked` seam input. */
+export function listRevokedGrantIds(db: DatabaseDriver): Set<string> {
+  const rows = db
+    .prepare(`SELECT DISTINCT grant_id FROM relay_delegation_revocations`)
+    .all() as Array<{ grant_id: string }>;
+  return new Set(rows.map((r) => r.grant_id));
+}
+
+export function registerDelegationRevocationRoutes(deps: { app: Hono; db: DatabaseDriver }): void {
+  const { app, db } = deps;
+
+  // POST /api/v1/delegations/revocations — submit a signed DelegationRevocation.
+  // Fully permissive by the bond-route reasoning (see module header): the
+  // artifact is self-verifying and anyone MAY propagate a revocation.
+  /** @spec motebit/standing-delegation@1.0 */
+  app.post("/api/v1/delegations/revocations", async (c) => {
+    let raw: unknown;
+    try {
+      raw = await c.req.json();
+    } catch {
+      throw new HTTPException(400, { message: "Invalid JSON body" });
+    }
+    const parsed = DelegationRevocationSchema.safeParse(raw);
+    if (!parsed.success) {
+      throw new HTTPException(400, {
+        message: "Body is not a well-formed DelegationRevocation",
+      });
+    }
+    const revocation = parsed.data as DelegationRevocation;
+
+    if (!(await verifyDelegationRevocation(revocation))) {
+      // Fail-closed: parsed shape but the Ed25519 signature does not verify
+      // against its own delegator_public_key — not a signed statement.
+      throw new HTTPException(422, { message: "Revocation signature invalid" });
+    }
+
+    const recorded = insertDelegationRevocation(db, revocation);
+    if (recorded) {
+      logger.info("delegation.revocation.recorded", {
+        grant_id: revocation.grant_id,
+        delegator_id: revocation.delegator_id,
+      });
+    }
+    return c.json({
+      ok: true,
+      grant_id: revocation.grant_id,
+      status: recorded ? "recorded" : "already_recorded",
+    });
+  });
+
+  // GET /api/v1/delegations/revocations?since=<received_at ms> — the cache
+  // read. Public: revocations want maximum reach. Each record is
+  // delegator-signed and offline-verifiable; the response body is a cache
+  // projection, not a relay assertion (§6 D2), so no relay envelope signature.
+  /** @spec motebit/standing-delegation@1.0 */
+  app.get("/api/v1/delegations/revocations", (c) => {
+    const sinceRaw = c.req.query("since");
+    const since = sinceRaw !== undefined ? Number(sinceRaw) : 0;
+    if (!Number.isFinite(since) || since < 0) {
+      throw new HTTPException(400, { message: "Invalid `since` — expected non-negative ms" });
+    }
+    const { records, nextSince } = listDelegationRevocations(db, since);
+    return c.json({ generated_at: Date.now(), next_since: nextSince, records });
+  });
+}

--- a/services/relay/src/index.ts
+++ b/services/relay/src/index.ts
@@ -166,6 +166,7 @@ import { registerTaskRoutes, TASK_TTL_MS } from "./tasks.js";
 import { ExpoPushAdapter } from "./push-adapter.js";
 import { TaskQueue } from "./task-queue.js";
 import { registerCommandRoutes, handleCommandResponse } from "./command-route.js";
+import { registerDelegationRevocationRoutes } from "./delegation-revocations.js";
 import Stripe from "stripe";
 import {
   SettlementRailRegistry,
@@ -1301,6 +1302,10 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
 
   // --- Command endpoint (unified remote execution) ---
   registerCommandRoutes({ app, db: moteDb.db, connections, logger });
+
+  // --- Delegation-revocation cache (standing-delegation §5; signed artifacts,
+  // relay is cache-not-authority) ---
+  registerDelegationRevocationRoutes({ app, db: moteDb.db });
 
   // --- Federation background loops ---
 

--- a/services/relay/src/middleware.ts
+++ b/services/relay/src/middleware.ts
@@ -286,6 +286,11 @@ export function registerMiddleware(deps: MiddlewareDeps): MiddlewareResult {
   // artifact-verified class as credentials/submit — no new audience.
   app.use("/api/v1/agents/:motebitId/bond", rl(writeLimiter));
 
+  // Delegation-revocation cache: submit is write-rate (signed-artifact
+  // ingestion, the bond class); the cache read shares the same path, so the
+  // stricter write tier covers both methods.
+  app.use("/api/v1/delegations/revocations", rl(writeLimiter));
+
   // Read endpoints: discover, credentials, capabilities, listings (60 req/min)
   app.use("/api/v1/agents/discover", rl(readLimiter));
   app.use("/api/v1/agents/:motebitId/credentials", rl(readLimiter));
@@ -513,7 +518,14 @@ export function registerMiddleware(deps: MiddlewareDeps): MiddlewareResult {
         // signature on submit, public-read on discover/resolve. The submit
         // handler verifies the envelope signature itself — that IS the auth
         // (mirrors /api/v1/devices/register-self above).
-        c.req.path.startsWith("/api/v1/skills/")
+        c.req.path.startsWith("/api/v1/skills/") ||
+        // Delegation-revocation cache (standing-delegation §5/§6 D2):
+        // permissive-by-signature on submit — the DelegationRevocation is a
+        // delegator-signed sovereign artifact and the handler verifies it
+        // (that IS the auth; anyone MAY propagate a revocation) — and
+        // public-read on the cache, same anchor-proof-class rationale: a
+        // consumer building its `isRevoked` seam holds no relay token.
+        c.req.path === "/api/v1/delegations/revocations"
       ) {
         await next();
         return;

--- a/services/relay/src/migrations.ts
+++ b/services/relay/src/migrations.ts
@@ -1812,4 +1812,42 @@ export const relayMigrations: Migration[] = [
       );
     },
   },
+  {
+    version: 39,
+    name: "delegation_revocations",
+    up: (db) => {
+      // Delegation-revocation CACHE (standing-delegation@1.0 §5/§6 D2) — the
+      // relay half of grant revocation, needed before autonomous money moves
+      // under a standing grant (Inc 3a of the money-execution arc; checkpoint
+      // D4). Each row is a DELEGATOR-signed `DelegationRevocation` — a
+      // sovereign artifact, unlike `relay_agent_revocations` whose records the
+      // RELAY signs (the operator de-list power; different trust domain,
+      // sibling table on purpose).
+      //
+      // The signed artifact is canonical; this table is a cache, never the
+      // authority. `record_json` stores the byte-identical canonical record
+      // (the relay_receipts.receipt_json discipline) so consumers re-verify
+      // exactly what the delegator signed. Idempotent on `signature` (Ed25519
+      // is deterministic — same body + key ⇒ same signature). `received_at`
+      // is the relay's receipt clock: incremental pollers filter on it, so a
+      // backdated signer-asserted `revoked_at` cannot hide a record.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS relay_delegation_revocations (
+          id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+          grant_id             TEXT NOT NULL,
+          delegator_id         TEXT NOT NULL,
+          delegator_public_key TEXT NOT NULL,
+          revoked_at           INTEGER NOT NULL,
+          suite                TEXT NOT NULL,
+          signature            TEXT NOT NULL UNIQUE,
+          record_json          TEXT NOT NULL,
+          received_at          INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_delegation_revocations_grant
+          ON relay_delegation_revocations(grant_id);
+        CREATE INDEX IF NOT EXISTS idx_delegation_revocations_received
+          ON relay_delegation_revocations(received_at);
+      `);
+    },
+  },
 ];

--- a/spec/schemas/spend-ceiling-v1.json
+++ b/spec/schemas/spend-ceiling-v1.json
@@ -1,0 +1,81 @@
+{
+  "$comment": "SPDX-License-Identifier: Apache-2.0",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/motebit/motebit/main/spec/schemas/spend-ceiling-v1.json",
+  "title": "SpendCeilingV1 (v1)",
+  "description": "The delegator's signed autonomous-spend ceiling (standing-delegation@1.2) — the HOW-MUCH a StandingDelegation authorizes, carried in the grant's signed body as a cryptographic commitment. Integer micro-units, USD-denominated (1 USD = 1,000,000). Absent from a grant ⇒ no autonomous money (fail-closed `ceiling_absent`). See spec/standing-delegation-v1.md §3.3.",
+  "type": "object",
+  "properties": {
+    "schema": {
+      "type": "string",
+      "const": "motebit.spend-ceiling.v1",
+      "description": "This ceiling's own type tag (in-body domain separation)."
+    },
+    "cumulative_limit_micro": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Max cumulative spend (integer micro-USD) within one rolling window. Requires `window_ms`. A SET value of 0 denies all positive spend on this dimension."
+    },
+    "per_counterparty_limit_micro": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Max spend (integer micro-USD) to any single canonical counterparty within one window. Requires `window_ms`."
+    },
+    "max_action_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Max number of money actions within one window. Requires `window_ms`."
+    },
+    "lifetime_limit_micro": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Max cumulative spend (integer micro-USD) over the grant's ENTIRE life — never reset by a window roll. The offline-meaningful total bound (paired with the grant's `expires_at`)."
+    },
+    "window_ms": {
+      "type": "integer",
+      "exclusiveMinimum": 0,
+      "description": "Rolling window length in ms. Required (> 0) when any per-window limit is set."
+    }
+  },
+  "required": ["schema"],
+  "additionalProperties": false,
+  "definitions": {
+    "SpendCeilingV1": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "type": "string",
+          "const": "motebit.spend-ceiling.v1",
+          "description": "This ceiling's own type tag (in-body domain separation)."
+        },
+        "cumulative_limit_micro": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Max cumulative spend (integer micro-USD) within one rolling window. Requires `window_ms`. A SET value of 0 denies all positive spend on this dimension."
+        },
+        "per_counterparty_limit_micro": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Max spend (integer micro-USD) to any single canonical counterparty within one window. Requires `window_ms`."
+        },
+        "max_action_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Max number of money actions within one window. Requires `window_ms`."
+        },
+        "lifetime_limit_micro": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Max cumulative spend (integer micro-USD) over the grant's ENTIRE life — never reset by a window roll. The offline-meaningful total bound (paired with the grant's `expires_at`)."
+        },
+        "window_ms": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "description": "Rolling window length in ms. Required (> 0) when any per-window limit is set."
+        }
+      },
+      "required": ["schema"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/spec/schemas/standing-delegation-v1.json
+++ b/spec/schemas/standing-delegation-v1.json
@@ -68,6 +68,44 @@
       "additionalProperties": false,
       "description": "Optional (standing-delegation@1.1). Digest-binds the resolved subject-scope artifact this grant's authority reaches; part of the signed body, so the delegator's signature covers the resolved scope. Absent ⇒ a @1.0 grant with no signed resolved scope (higher-assurance consumers MUST fail closed). NOT the capability `scope`."
     },
+    "spend_ceiling": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "type": "string",
+          "const": "motebit.spend-ceiling.v1",
+          "description": "This ceiling's own type tag (in-body domain separation)."
+        },
+        "cumulative_limit_micro": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Max cumulative spend (integer micro-USD) within one rolling window. Requires `window_ms`. A SET value of 0 denies all positive spend on this dimension."
+        },
+        "per_counterparty_limit_micro": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Max spend (integer micro-USD) to any single canonical counterparty within one window. Requires `window_ms`."
+        },
+        "max_action_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Max number of money actions within one window. Requires `window_ms`."
+        },
+        "lifetime_limit_micro": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Max cumulative spend (integer micro-USD) over the grant's ENTIRE life — never reset by a window roll. The offline-meaningful total bound (paired with the grant's `expires_at`)."
+        },
+        "window_ms": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "description": "Rolling window length in ms. Required (> 0) when any per-window limit is set."
+        }
+      },
+      "required": ["schema"],
+      "additionalProperties": false,
+      "description": "Optional (standing-delegation@1.2). The delegator's signed autonomous-spend ceiling — the HOW-MUCH this grant authorizes, as a cryptographic commitment (part of the signed body). Absent ⇒ the grant authorizes NO autonomous money (enforcers deny `ceiling_absent`, fail-closed) — a @1.0/@1.1 grant verifies unchanged and simply cannot move money."
+    },
     "cadence_ms": {
       "type": "number",
       "description": "Authorized minimum firing interval, milliseconds. A per-tick rate limit enforced at mint/relay time — NOT a single-token verification rule."
@@ -181,6 +219,44 @@
           "required": ["schema", "artifact_schema", "digest_method", "digest"],
           "additionalProperties": false,
           "description": "Optional (standing-delegation@1.1). Digest-binds the resolved subject-scope artifact this grant's authority reaches; part of the signed body, so the delegator's signature covers the resolved scope. Absent ⇒ a @1.0 grant with no signed resolved scope (higher-assurance consumers MUST fail closed). NOT the capability `scope`."
+        },
+        "spend_ceiling": {
+          "type": "object",
+          "properties": {
+            "schema": {
+              "type": "string",
+              "const": "motebit.spend-ceiling.v1",
+              "description": "This ceiling's own type tag (in-body domain separation)."
+            },
+            "cumulative_limit_micro": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Max cumulative spend (integer micro-USD) within one rolling window. Requires `window_ms`. A SET value of 0 denies all positive spend on this dimension."
+            },
+            "per_counterparty_limit_micro": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Max spend (integer micro-USD) to any single canonical counterparty within one window. Requires `window_ms`."
+            },
+            "max_action_count": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Max number of money actions within one window. Requires `window_ms`."
+            },
+            "lifetime_limit_micro": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Max cumulative spend (integer micro-USD) over the grant's ENTIRE life — never reset by a window roll. The offline-meaningful total bound (paired with the grant's `expires_at`)."
+            },
+            "window_ms": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "description": "Rolling window length in ms. Required (> 0) when any per-window limit is set."
+            }
+          },
+          "required": ["schema"],
+          "additionalProperties": false,
+          "description": "Optional (standing-delegation@1.2). The delegator's signed autonomous-spend ceiling — the HOW-MUCH this grant authorizes, as a cryptographic commitment (part of the signed body). Absent ⇒ the grant authorizes NO autonomous money (enforcers deny `ceiling_absent`, fail-closed) — a @1.0/@1.1 grant verifies unchanged and simply cannot move money."
         },
         "cadence_ms": {
           "type": "number",

--- a/spec/standing-delegation-v1.md
+++ b/spec/standing-delegation-v1.md
@@ -40,6 +40,7 @@ StandingDelegation {
   scope:                string   // Comma-separated capability CEILING, or "*". Per-tick tokens narrow within. Grammar per market-v1 §12.3.
   subject:              string   // Human-meaningful binding (e.g. "research:thesis=acme-q3"). Opaque to verify.
   subject_binding?:     SubjectBindingV1  // OPTIONAL (@1.1). Digest-binds the resolved subject-scope artifact (§3.2). Part of the signed body. NOT the capability `scope`.
+  spend_ceiling?:       SpendCeilingV1    // OPTIONAL (@1.2). The delegator's signed autonomous-spend ceiling (§3.3). Part of the signed body. Absent ⇒ NO autonomous money (fail-closed).
   cadence_ms:           number   // Authorized minimum firing interval (ms). A mint/relay rate limit; NOT a single-token verify rule.
   issued_at:            number   // Unix ms
   not_before:           number | null  // Optional activation delay. Null ⇒ active from issued_at.
@@ -100,6 +101,38 @@ The `SubjectBindingV1` type in `@motebit/protocol` is the binding machine-readab
 
 **Authority vs. completeness — a layer boundary.** This binding is AUTHORITY only: it proves which subjects the delegator authorized. It does NOT assert that every authorized subject was _evaluated_. Generic delegation is subset-shaped — an executed act narrows within the authorized ceiling (`executed ⊆ authorized`). A _monitor promise_, by contrast, means "evaluate every named leg," which is equality (`attempted == signed`). That completeness rule is **NOT** a property of this generic binding; it belongs to the monitor receipt profile built on top (the `motebit.monitor-scope.v1` consumer profile), which MUST require every signed subject be attempted before emitting a `revalidated`/`revised` verdict, with per-subject coverage deciding `verified` vs `incomplete`. Keeping completeness out of the generic primitive is what lets a non-monitoring vertical reuse `subject_binding` unchanged.
 
+### 3.3 — SpendCeiling (autonomous-money ceiling, @1.2)
+
+A grant's `scope` names WHAT capabilities the delegate may exercise; nothing in @1.0/@1.1 names HOW MUCH money those capabilities may move autonomously. An enforcer whose ceiling comes from local configuration proves only "the runtime was configured thus," never "the delegator authorized this exposure" — the same gap `subject_binding` closed for resolved subjects, applied to money. `standing-delegation@1.2` closes it with an OPTIONAL `spend_ceiling` that rides in the signed body, making the ceiling the delegator's cryptographic commitment.
+
+#### Wire format (foundation law)
+
+```
+SpendCeilingV1 {
+  schema:                        string  // "motebit.spend-ceiling.v1" — this ceiling's own type tag (in-body domain separation)
+  cumulative_limit_micro?:       number  // Max cumulative spend within one rolling window. Requires window_ms.
+  per_counterparty_limit_micro?: number  // Max spend to any single canonical counterparty within one window. Requires window_ms.
+  max_action_count?:             number  // Max number of money actions within one window. Requires window_ms.
+  lifetime_limit_micro?:         number  // Max cumulative spend over the grant's ENTIRE life — never reset by a window roll.
+  window_ms?:                    number  // Rolling window length in ms. Required (> 0) when any per-window limit is set.
+}
+```
+
+All `*_micro` limits are integer micro-units, **USD-denominated** (1 USD = 1,000,000; zero floating point on the money path). The denomination is pinned by this prose: a future non-USD asset model is a NEW `schema` literal (an agility-axis append), never a silent reinterpretation of these numbers. Non-negative integers only; a SET limit of `0` denies all positive spend on that dimension (deny-all, not allow-all).
+
+The `SpendCeilingV1` type in `@motebit/protocol` is the binding machine-readable form; `StandingDelegationSchema` in `@motebit/wire-schemas` carries it as the optional `spend_ceiling` and `spec/schemas/spend-ceiling-v1.json` is the committed standalone schema.
+
+#### Verification and enforcement (foundation law)
+
+`spend_ceiling`, when present, is signature-covered by §3.1 item 4 (the body canonicalization includes it) — AUTHORITY over the ceiling needs no extra verification step. Enforcement is the consumer's runtime law:
+
+1. **Absence is fail-closed.** A grant with no `spend_ceiling` authorizes NO autonomous money movement (`ceiling_absent`). A @1.0/@1.1 grant therefore verifies unchanged and simply cannot move money — which is what makes this field additive.
+2. **The ceiling MUST be taken from a VERIFIED grant, never from local configuration.** A runtime that evaluates spend against any ceiling other than the one in the delegator-signed body has substituted its own authority for the delegator's (memory-never-confers-authority, applied to money).
+3. **Sufficiency: at least one total bound.** A ceiling setting neither `cumulative_limit_micro` nor `lifetime_limit_micro` authorizes nothing (denied `ceiling_absent`) — a money grant MUST bound total exposure.
+4. **Accumulation is cumulative, never per-turn.** Enforcers MUST evaluate the running sum across all actions under the grant (windowed and lifetime), or a large payment decomposes into many small ones.
+
+**Threat model (honest scope).** These ceilings bind the **trusted-runtime / online path**: an honest-but-fallible runtime (bug, runaway loop, prompt injection that does not compromise the signing key or the spend accumulator), or a trusted coordinator holding the accumulator at the settlement checkpoint. They are **NOT an offline guarantee** — a key- or store-compromised delegate tallies its own accumulator and simply does not commit. Offline, the binding bounds are the grant's `expires_at` (§6 D1/D4), what each counterparty independently enforces against tokens it sees, and rail-level rate caps (`settlement-v1` § Onchain spending limits). Deployments SHOULD therefore route autonomous money through a coordinator that re-verifies the grant (including revocation, §5) at settlement time.
+
 ## 4. Per-tick tokens
 
 A `DelegationToken` (delegation@1.0) gains two OPTIONAL fields, `grant_id` and `not_before`. `grant_id` absent ⇒ a standalone single-act delegation (today's semantics — backward compatible); present ⇒ this token is one tick of a `StandingDelegation`. `not_before` (Unix ms) absent ⇒ active from `issued_at`; present ⇒ the token is invalid before it (verifiers reject when `now < not_before`). Both are additive and replay-compatible; 1.0 tokens verify identically.
@@ -147,12 +180,20 @@ The `DelegationRevocation` type in `@motebit/protocol` is the binding machine-re
 - A `DelegationRevocation` is **authoritative over a grant** only when `grant_id` matches AND `delegator_public_key` equals that grant's `delegator_public_key`. A well-formed signature alone proves the statement, not the authority — `verifyDelegationRevocation` checks the signature; the caller checks the grant binding. `@motebit/crypto` `findGrantRevocation` does all three (grant_id match, key match, signature) over a candidate set and is the canonical consumer-side check; matching `grant_id` alone is the foot-gun it forecloses.
 - The signed revocation is the **canonical source of truth**. Relays MAY maintain a deny-list cache (analogous to the `auth-token-v1 §8.1` jti deny-list) and SHOULD propagate revocations on the same signed, append-only feed as agent/credential revocations, under the same revocation horizon — but a relay-asserted boolean is never the authority (self-attesting-system doctrine).
 
+#### Routes (foundation law)
+
+The relay-cache routes below are the binding cross-implementation contract for revocation propagation. The artifact is the security boundary on both: submission verifies the revocation's own signature (that IS the auth — anyone MAY propagate a revocation), and the cache read is public (a consumer building its `isRevoked` seam holds no relay token).
+
+- `POST /api/v1/delegations/revocations` — submit a signed `DelegationRevocation` (the §5.1 artifact verbatim). Recorded only after `verifyDelegationRevocation` passes; idempotent on the signature. An invalid signature is rejected fail-closed.
+- `GET /api/v1/delegations/revocations` — read the cache incrementally via the optional `since=<ms>` query parameter. `since` filters on the relay's receipt clock (`received_at`, returned as `next_since`), never the signer-asserted `revoked_at`, so a backdated revocation cannot hide from a poller. Records are served verbatim; the response is a cache projection (§6 D2), not a relay assertion.
+
 ## 6. Conventions
 
 - **D1 — Grant lifetime.** `expires_at` is long-but-finite and renewable; implementations SHOULD NOT issue open-ended grants. Recommended max: 90 days; the delegate renews by re-signing before expiry. Rationale: revocation propagation is bounded (a feed horizon), so authority that outlives revocation reachability is unsafe — a finite grant auto-dies if propagation ever fails, while preserving an "until revoked" experience via silent renewal.
 - **D2 — Revocation source of truth** is the signed `DelegationRevocation` (offline-verifiable); the relay deny-list is a cache, not the authority.
 - **D3 — Revocation is terminal** in v1 (no unrevoke). Pausing a standing monitor is a scheduler concern (stop firing ticks), not a grant-state change.
 - **Token lifetime** (`max_token_ttl_ms`): SHOULD be ≤ the delegation@1.0 token maximum (24h); 1h recommended.
+- **D4 — Money-grant lifetime.** A grant carrying a `spend_ceiling` SHOULD use a lifetime well below the D1 maximum: 7–30 days renewable recommended, `max_token_ttl_ms` 1h. Rationale: against a malicious offline delegate the real revocation ceiling is `expires_at`, not token TTL (a local signer manufactures fresh short-TTL ticks from stale standing authority) — so a money grant's worst-case offline exposure is deliberately (short lifetime × signed ceiling): a bounded, priced number.
 
 ## 7. Relationship to Other Specs
 


### PR DESCRIPTION
## What

Inc 3a of the standing-delegation money-execution arc — the wire increment, executing the signed-off checkpoint (`docs/proposals/standing-delegation-execution-checkpoint.md`, D1–D4 approved 2026-07-04). Two halves:

### D3 — the ceiling becomes the delegator's cryptographic commitment (`standing-delegation@1.2`)

- `SpendCeilingV1` in `@motebit/protocol`, carried as optional `spend_ceiling` in the `StandingDelegation` **signed body** (the `subject_binding` @1.1 precedent). The HOW-MUCH is now a signed artifact field, never local config.
- **Fail-closed by construction:** absence ⇒ the blast-radius enforcer's existing `ceiling_absent` denial ⇒ a @1.0/@1.1 grant verifies unchanged and cannot move money. That is what makes the field additive.
- USD-micro denomination pinned by spec prose (§3.3); a future asset model is a new `schema` literal — an agility-axis append, never a silent reinterpretation.
- **Zero crypto-code change:** JCS signing already covers the field. Proven by negative tests: tampered ceiling, widened ceiling, ceiling *stripped* from a signed grant, ceiling *grafted* onto an unsigned-for grant — all fail verification.
- `@motebit/policy` gains `spendCeilingFromGrant` — the only sanctioned wire→enforcer mapping (spec §3.3 rule 2), the seam Inc 3b's `check-ceiling-from-grant` gate will lock.
- Full sweep: spec §3.3 + §6 D4 (7–30d money-grant lifetime convention), committed `spend-ceiling-v1.json`, regenerated `standing-delegation-v1.json`, zod schema + live parity block, drift-test entry, protocol API baseline.

### D4 — the relay learns revocations before money moves

- New `relay_delegation_revocations` cache (migration 39) + `POST`/`GET /api/v1/delegations/revocations`, declared as spec §5 **Routes (foundation law)**.
- Security is in the ARTIFACT (the bond-route class): ingestion verifies the delegator-signed `DelegationRevocation`'s own Ed25519 signature; anyone MAY propagate a revocation (that's the point); invalid signatures rejected 422 fail-closed; idempotent on signature.
- Deliberately a **sibling** of the relay-signed agent-revocation feed, not a new type inside it — sovereign artifact vs operator assertion are different trust domains. The relay is cache-not-authority (spec §6 D2); records served verbatim.
- Incremental polling cursors on the relay's `received_at` clock, so a backdated `revoked_at` cannot hide from a poller. `listRevokedGrantIds` is the settlement-time `isRevoked` seam input Inc 3b wires.

## Verification

- All **126 drift gates** pass (4 caught real gaps during development and self-repaired via their instructions: spec-routes block, wire-schemas index export, changeset split, API baseline).
- Tests: protocol 446 / crypto 691 / wire-schemas 531 / policy 464 / relay 1404 (+7 new delegation-revocation route tests, incl. tamper-rejection and third-party propagation).
- Typecheck + lint clean across touched packages.

## What this does NOT do

No live money path changes: `verifyGrantForTurn` still has zero production callers, policy-gate step 8b still forces approval on every R4 call, and no dispatch consumes the enforcer. Production behavior is byte-identical. Inc 3b (ingress wiring, persistent `GrantSpendStore`, dispatch AND-composition, `check-ceiling-from-grant` gate, `revoke-then-self-mint-offline` fixture) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)