### PR TITLE
fix: spend-ceiling schema learns its own prose (agency @1.2 review)

### DIFF
--- a/.changeset/spend-ceiling-shape-law-ignored.md
+++ b/.changeset/spend-ceiling-shape-law-ignored.md
@@ -1,0 +1,5 @@
+---
+"@motebit/wire-schemas": minor
+---
+
+SpendCeilingV1 learns its own prose (agency @1.2 review, 2026-07-05): the §3.3 "Requires `window_ms`" clauses are now SHAPE law in both validators — zod `superRefine` + draft-07 `dependencies` injected into the committed `spend-ceiling-v1.json` AND the embedded copies in `standing-delegation-v1.json` — and every numeric carries `maximum: 9007199254740991` (2^53−1) so a delegator-chosen limit can never produce JCS-unfaithful signed bytes. Rule 3 (at-least-one-total-bound) deliberately stays enforcement law: a bare ceiling remains well-formed-but-authorizes-nothing. Spec §3.3 additionally pins "canonical counterparty" as consumer-local runtime law (reference: `canonicalizeCounterparty`), never cross-runtime-comparable interop.

--- a/packages/wire-schemas/src/__tests__/spend-ceiling-shape-law.test.ts
+++ b/packages/wire-schemas/src/__tests__/spend-ceiling-shape-law.test.ts
@@ -1,0 +1,97 @@
+/**
+ * §3.3 shape law, enforced identically in BOTH validators (agency review,
+ * 2026-07-05): the zod schema (this suite) and the committed JSON Schema
+ * (drift.test.ts regenerates it from the same source, and the emitter
+ * injects draft-07 `dependencies`) must refuse what the wire format
+ * forbids — a per-window limit without `window_ms`, and any numeric above
+ * 2^53−1 (JCS/ECMAScript number fidelity). Rule 3 (at-least-one-total-
+ * bound) is deliberately NOT shape law: a bare ceiling is well-formed and
+ * authorizes nothing.
+ */
+import { describe, it, expect } from "vitest";
+import { SpendCeilingV1Schema, StandingDelegationSchema } from "../standing-delegation.js";
+
+const BASE = { schema: "motebit.spend-ceiling.v1" as const };
+const MAX_SAFE = 9_007_199_254_740_991;
+
+describe("SpendCeilingV1 shape law", () => {
+  it("refuses each per-window limit without window_ms", () => {
+    for (const field of [
+      "cumulative_limit_micro",
+      "per_counterparty_limit_micro",
+      "max_action_count",
+    ]) {
+      const r = SpendCeilingV1Schema.safeParse({ ...BASE, [field]: 5_000_000 });
+      expect(r.success).toBe(false);
+      if (!r.success) {
+        expect(JSON.stringify(r.error.issues)).toContain("window_ms");
+      }
+    }
+  });
+
+  it("accepts per-window limits WITH window_ms, and lifetime alone", () => {
+    expect(
+      SpendCeilingV1Schema.safeParse({
+        ...BASE,
+        cumulative_limit_micro: 1_000_000,
+        window_ms: 86_400_000,
+      }).success,
+    ).toBe(true);
+    expect(
+      SpendCeilingV1Schema.safeParse({ ...BASE, lifetime_limit_micro: 5_000_000 }).success,
+    ).toBe(true);
+  });
+
+  it("a bare ceiling is well-formed (authorizes nothing — enforcement law, not shape law)", () => {
+    expect(SpendCeilingV1Schema.safeParse(BASE).success).toBe(true);
+  });
+
+  it("caps every numeric at 2^53−1 (JCS number fidelity)", () => {
+    expect(
+      SpendCeilingV1Schema.safeParse({ ...BASE, lifetime_limit_micro: MAX_SAFE }).success,
+    ).toBe(true);
+    for (const field of [
+      "lifetime_limit_micro",
+      "cumulative_limit_micro",
+      "per_counterparty_limit_micro",
+      "max_action_count",
+      "window_ms",
+    ]) {
+      const value = MAX_SAFE + 2; // +1 is not representable distinctly
+      const candidate =
+        field === "lifetime_limit_micro" || field === "window_ms"
+          ? { ...BASE, [field]: value }
+          : { ...BASE, [field]: value, window_ms: 1000 };
+      expect(SpendCeilingV1Schema.safeParse(candidate).success).toBe(false);
+    }
+  });
+
+  it("the embedded copy in StandingDelegationSchema enforces the same law", () => {
+    const grantShape = {
+      grant_id: "g",
+      delegator_id: "d",
+      delegator_public_key: "a".repeat(64),
+      delegate_id: "d",
+      delegate_public_key: "a".repeat(64),
+      scope: "pay_invoice",
+      subject: "s",
+      cadence_ms: 1,
+      issued_at: 1,
+      not_before: null,
+      expires_at: 2,
+      max_token_ttl_ms: 1,
+      suite: "motebit-jcs-ed25519-b64-v1" as const,
+      signature: "sig",
+    };
+    const bad = StandingDelegationSchema.safeParse({
+      ...grantShape,
+      spend_ceiling: { ...BASE, cumulative_limit_micro: 1 },
+    });
+    expect(bad.success).toBe(false);
+    const good = StandingDelegationSchema.safeParse({
+      ...grantShape,
+      spend_ceiling: { ...BASE, cumulative_limit_micro: 1, window_ms: 1000 },
+    });
+    expect(good.success).toBe(true);
+  });
+});

--- a/packages/wire-schemas/src/__tests__/spend-ceiling-shape-law.test.ts
+++ b/packages/wire-schemas/src/__tests__/spend-ceiling-shape-law.test.ts
@@ -9,7 +9,11 @@
  * authorizes nothing.
  */
 import { describe, it, expect } from "vitest";
-import { SpendCeilingV1Schema, StandingDelegationSchema } from "../standing-delegation.js";
+import {
+  SpendCeilingV1Schema,
+  StandingDelegationSchema,
+  injectWindowDependencies,
+} from "../standing-delegation.js";
 
 const BASE = { schema: "motebit.spend-ceiling.v1" as const };
 const MAX_SAFE = 9_007_199_254_740_991;
@@ -93,5 +97,23 @@ describe("SpendCeilingV1 shape law", () => {
       spend_ceiling: { ...BASE, cumulative_limit_micro: 1, window_ms: 1000 },
     });
     expect(good.success).toBe(true);
+  });
+});
+
+describe("injectWindowDependencies — the structure-drift alarm", () => {
+  it("injects at a ceiling-shaped node", () => {
+    const node: Record<string, unknown> = { properties: { window_ms: {} } };
+    injectWindowDependencies(node, "test");
+    expect(node["dependencies"]).toEqual({
+      cumulative_limit_micro: ["window_ms"],
+      per_counterparty_limit_micro: ["window_ms"],
+      max_action_count: ["window_ms"],
+    });
+  });
+
+  it("fails loud on every non-ceiling-shaped input (null, non-object, missing properties)", () => {
+    for (const bad of [null, undefined, "x", 42, {}]) {
+      expect(() => injectWindowDependencies(bad, "somewhere")).toThrow(/somewhere/);
+    }
   });
 });

--- a/packages/wire-schemas/src/standing-delegation.ts
+++ b/packages/wire-schemas/src/standing-delegation.ts
@@ -52,6 +52,50 @@ const HEX_PUBLIC_KEY_PATTERN = /^[0-9a-f]{64}$/;
 const HEX_SHA256_PATTERN = /^[0-9a-f]{64}$/;
 
 /**
+ * JCS interop ceiling on every SpendCeilingV1 numeric (agency review,
+ * 2026-07-05): RFC 8785 serializes numbers per ECMAScript, so an integer
+ * above 2^53−1 does not survive canonicalization faithfully — a larger
+ * delegator-chosen limit could produce different signed bytes across
+ * implementations. Pinning `maximum` costs nothing (a $9-billion ceiling
+ * is not a bound anyone meets honestly) and buys byte-stable signatures.
+ */
+const MAX_SAFE_JCS_INT = 9_007_199_254_740_991;
+
+/**
+ * §3.3 wire-format shape law, enforced in BOTH validators (agency review):
+ * every per-window limit "Requires `window_ms`". The zod side enforces it
+ * here (superRefine); the committed JSON Schema enforces it via draft-07
+ * `dependencies` injected by the emitters below — the two validators must
+ * never disagree about what the wire format forbids. Deliberately NOT
+ * enforced: rule 3's at-least-one-total-bound — that is enforcement law
+ * (a bare ceiling is well-formed-but-authorizes-nothing), not shape law.
+ */
+const PER_WINDOW_FIELDS = [
+  "cumulative_limit_micro",
+  "per_counterparty_limit_micro",
+  "max_action_count",
+] as const;
+
+const SPEND_CEILING_WINDOW_DEPENDENCIES: Record<string, string[]> = Object.fromEntries(
+  PER_WINDOW_FIELDS.map((f) => [f, ["window_ms"]]),
+);
+
+/** Inject the window `dependencies` at a ceiling-shaped schema node,
+ *  failing loud if the emitter's structure drifted from expectation. */
+function injectWindowDependencies(node: unknown, where: string): void {
+  if (
+    node == null ||
+    typeof node !== "object" ||
+    (node as Record<string, unknown>)["properties"] == null
+  ) {
+    throw new Error(
+      `spend-ceiling dependencies injection: no ceiling-shaped node at ${where} — the zod-to-json-schema output shape changed, fix the emitter in packages/wire-schemas/src/standing-delegation.ts`,
+    );
+  }
+  (node as Record<string, unknown>)["dependencies"] = SPEND_CEILING_WINDOW_DEPENDENCIES;
+}
+
+/**
  * Generic subject-scope binding (standing-delegation@1.1). Digest-binds a
  * detached, vertically-typed scope artifact so the delegator's signature reaches
  * the EXACT resolved subjects. Unsigned by construction — authority is the
@@ -103,40 +147,59 @@ export const SpendCeilingV1Schema = z
       .number()
       .int()
       .nonnegative()
+      .max(MAX_SAFE_JCS_INT)
       .optional()
       .describe(
-        "Max cumulative spend (integer micro-USD) within one rolling window. Requires `window_ms`. A SET value of 0 denies all positive spend on this dimension.",
+        "Max cumulative spend (integer micro-USD, ≤ 2^53−1 for JCS number fidelity) within one rolling window. Requires `window_ms`. A SET value of 0 denies all positive spend on this dimension.",
       ),
     per_counterparty_limit_micro: z
       .number()
       .int()
       .nonnegative()
+      .max(MAX_SAFE_JCS_INT)
       .optional()
       .describe(
-        "Max spend (integer micro-USD) to any single canonical counterparty within one window. Requires `window_ms`.",
+        "Max spend (integer micro-USD, ≤ 2^53−1) to any single canonical counterparty within one window. Requires `window_ms`. Counterparty canonicalization is consumer-local runtime law (spec §3.3).",
       ),
     max_action_count: z
       .number()
       .int()
       .nonnegative()
+      .max(MAX_SAFE_JCS_INT)
       .optional()
-      .describe("Max number of money actions within one window. Requires `window_ms`."),
+      .describe("Max number of money actions within one window (≤ 2^53−1). Requires `window_ms`."),
     lifetime_limit_micro: z
       .number()
       .int()
       .nonnegative()
+      .max(MAX_SAFE_JCS_INT)
       .optional()
       .describe(
-        "Max cumulative spend (integer micro-USD) over the grant's ENTIRE life — never reset by a window roll. The offline-meaningful total bound (paired with the grant's `expires_at`).",
+        "Max cumulative spend (integer micro-USD, ≤ 2^53−1) over the grant's ENTIRE life — never reset by a window roll. The offline-meaningful total bound (paired with the grant's `expires_at`).",
       ),
     window_ms: z
       .number()
       .int()
       .positive()
+      .max(MAX_SAFE_JCS_INT)
       .optional()
-      .describe("Rolling window length in ms. Required (> 0) when any per-window limit is set."),
+      .describe(
+        "Rolling window length in ms (≤ 2^53−1). Required (> 0) when any per-window limit is set.",
+      ),
   })
-  .strict();
+  .strict()
+  .superRefine((ceiling, ctx) => {
+    if (ceiling.window_ms !== undefined) return;
+    for (const field of PER_WINDOW_FIELDS) {
+      if (ceiling[field] !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [field],
+          message: `${field} requires window_ms (spec/standing-delegation-v1.md §3.3 wire format)`,
+        });
+      }
+    }
+  });
 
 export const StandingDelegationSchema = z
   .object({
@@ -307,12 +370,29 @@ export function buildStandingDelegationJsonSchema(): Record<string, unknown> {
     $refStrategy: "root",
     target: "jsonSchema7",
   }) as Record<string, unknown>;
-  return assembleJsonSchemaFor("StandingDelegation", raw, {
+  const assembled = assembleJsonSchemaFor("StandingDelegation", raw, {
     $id: STANDING_DELEGATION_SCHEMA_ID,
     title: "StandingDelegation (v1)",
     description:
       "Signed, revocable standing grant authorizing minting short-lived per-tick DelegationTokens within a fixed scope ceiling and cadence. Canonicalization: JCS (RFC 8785). Signature: Ed25519 over canonicalJson(body minus signature), base64url. See spec/standing-delegation-v1.md.",
   });
+  // The embedded spend_ceiling copies carry the same §3.3 window
+  // dependencies as the standalone schema — the grant schema must refuse
+  // what the wire format forbids, same as spend-ceiling-v1.json.
+  const props = assembled["properties"] as Record<string, unknown> | undefined;
+  injectWindowDependencies(
+    props?.["spend_ceiling"],
+    "standing-delegation-v1.json properties.spend_ceiling",
+  );
+  const defs = assembled["definitions"] as Record<string, unknown> | undefined;
+  const defProps = (defs?.["StandingDelegation"] as Record<string, unknown> | undefined)?.[
+    "properties"
+  ] as Record<string, unknown> | undefined;
+  injectWindowDependencies(
+    defProps?.["spend_ceiling"],
+    "standing-delegation-v1.json definitions.StandingDelegation.properties.spend_ceiling",
+  );
+  return assembled;
 }
 
 export function buildSubjectBindingV1JsonSchema(): Record<string, unknown> {
@@ -335,12 +415,16 @@ export function buildSpendCeilingV1JsonSchema(): Record<string, unknown> {
     $refStrategy: "root",
     target: "jsonSchema7",
   }) as Record<string, unknown>;
-  return assembleJsonSchemaFor("SpendCeilingV1", raw, {
+  const assembled = assembleJsonSchemaFor("SpendCeilingV1", raw, {
     $id: SPEND_CEILING_SCHEMA_ID,
     title: "SpendCeilingV1 (v1)",
     description:
-      "The delegator's signed autonomous-spend ceiling (standing-delegation@1.2) — the HOW-MUCH a StandingDelegation authorizes, carried in the grant's signed body as a cryptographic commitment. Integer micro-units, USD-denominated (1 USD = 1,000,000). Absent from a grant ⇒ no autonomous money (fail-closed `ceiling_absent`). See spec/standing-delegation-v1.md §3.3.",
+      "The delegator's signed autonomous-spend ceiling (standing-delegation@1.2) — the HOW-MUCH a StandingDelegation authorizes, carried in the grant's signed body as a cryptographic commitment. Integer micro-units, USD-denominated (1 USD = 1,000,000), each ≤ 2^53−1 for JCS number fidelity. Per-window limits require `window_ms` (enforced via `dependencies`). Absent from a grant ⇒ no autonomous money (fail-closed `ceiling_absent`). See spec/standing-delegation-v1.md §3.3.",
   });
+  injectWindowDependencies(assembled, "spend-ceiling-v1.json root");
+  const defs = assembled["definitions"] as Record<string, unknown> | undefined;
+  injectWindowDependencies(defs?.["SpendCeilingV1"], "spend-ceiling-v1.json definitions");
+  return assembled;
 }
 
 export function buildDelegationRevocationJsonSchema(): Record<string, unknown> {

--- a/packages/wire-schemas/src/standing-delegation.ts
+++ b/packages/wire-schemas/src/standing-delegation.ts
@@ -81,8 +81,10 @@ const SPEND_CEILING_WINDOW_DEPENDENCIES: Record<string, string[]> = Object.fromE
 );
 
 /** Inject the window `dependencies` at a ceiling-shaped schema node,
- *  failing loud if the emitter's structure drifted from expectation. */
-function injectWindowDependencies(node: unknown, where: string): void {
+ *  failing loud if the emitter's structure drifted from expectation.
+ *  Exported for the shape-law test suite (the throw arms are the
+ *  structure-drift alarm and must stay covered). */
+export function injectWindowDependencies(node: unknown, where: string): void {
   if (
     node == null ||
     typeof node !== "object" ||

--- a/spec/schemas/spend-ceiling-v1.json
+++ b/spec/schemas/spend-ceiling-v1.json
@@ -3,7 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/motebit/motebit/main/spec/schemas/spend-ceiling-v1.json",
   "title": "SpendCeilingV1 (v1)",
-  "description": "The delegator's signed autonomous-spend ceiling (standing-delegation@1.2) — the HOW-MUCH a StandingDelegation authorizes, carried in the grant's signed body as a cryptographic commitment. Integer micro-units, USD-denominated (1 USD = 1,000,000). Absent from a grant ⇒ no autonomous money (fail-closed `ceiling_absent`). See spec/standing-delegation-v1.md §3.3.",
+  "description": "The delegator's signed autonomous-spend ceiling (standing-delegation@1.2) — the HOW-MUCH a StandingDelegation authorizes, carried in the grant's signed body as a cryptographic commitment. Integer micro-units, USD-denominated (1 USD = 1,000,000), each ≤ 2^53−1 for JCS number fidelity. Per-window limits require `window_ms` (enforced via `dependencies`). Absent from a grant ⇒ no autonomous money (fail-closed `ceiling_absent`). See spec/standing-delegation-v1.md §3.3.",
   "type": "object",
   "properties": {
     "schema": {
@@ -14,27 +14,32 @@
     "cumulative_limit_micro": {
       "type": "integer",
       "minimum": 0,
-      "description": "Max cumulative spend (integer micro-USD) within one rolling window. Requires `window_ms`. A SET value of 0 denies all positive spend on this dimension."
+      "maximum": 9007199254740991,
+      "description": "Max cumulative spend (integer micro-USD, ≤ 2^53−1 for JCS number fidelity) within one rolling window. Requires `window_ms`. A SET value of 0 denies all positive spend on this dimension."
     },
     "per_counterparty_limit_micro": {
       "type": "integer",
       "minimum": 0,
-      "description": "Max spend (integer micro-USD) to any single canonical counterparty within one window. Requires `window_ms`."
+      "maximum": 9007199254740991,
+      "description": "Max spend (integer micro-USD, ≤ 2^53−1) to any single canonical counterparty within one window. Requires `window_ms`. Counterparty canonicalization is consumer-local runtime law (spec §3.3)."
     },
     "max_action_count": {
       "type": "integer",
       "minimum": 0,
-      "description": "Max number of money actions within one window. Requires `window_ms`."
+      "maximum": 9007199254740991,
+      "description": "Max number of money actions within one window (≤ 2^53−1). Requires `window_ms`."
     },
     "lifetime_limit_micro": {
       "type": "integer",
       "minimum": 0,
-      "description": "Max cumulative spend (integer micro-USD) over the grant's ENTIRE life — never reset by a window roll. The offline-meaningful total bound (paired with the grant's `expires_at`)."
+      "maximum": 9007199254740991,
+      "description": "Max cumulative spend (integer micro-USD, ≤ 2^53−1) over the grant's ENTIRE life — never reset by a window roll. The offline-meaningful total bound (paired with the grant's `expires_at`)."
     },
     "window_ms": {
       "type": "integer",
       "exclusiveMinimum": 0,
-      "description": "Rolling window length in ms. Required (> 0) when any per-window limit is set."
+      "maximum": 9007199254740991,
+      "description": "Rolling window length in ms (≤ 2^53−1). Required (> 0) when any per-window limit is set."
     }
   },
   "required": ["schema"],
@@ -51,31 +56,46 @@
         "cumulative_limit_micro": {
           "type": "integer",
           "minimum": 0,
-          "description": "Max cumulative spend (integer micro-USD) within one rolling window. Requires `window_ms`. A SET value of 0 denies all positive spend on this dimension."
+          "maximum": 9007199254740991,
+          "description": "Max cumulative spend (integer micro-USD, ≤ 2^53−1 for JCS number fidelity) within one rolling window. Requires `window_ms`. A SET value of 0 denies all positive spend on this dimension."
         },
         "per_counterparty_limit_micro": {
           "type": "integer",
           "minimum": 0,
-          "description": "Max spend (integer micro-USD) to any single canonical counterparty within one window. Requires `window_ms`."
+          "maximum": 9007199254740991,
+          "description": "Max spend (integer micro-USD, ≤ 2^53−1) to any single canonical counterparty within one window. Requires `window_ms`. Counterparty canonicalization is consumer-local runtime law (spec §3.3)."
         },
         "max_action_count": {
           "type": "integer",
           "minimum": 0,
-          "description": "Max number of money actions within one window. Requires `window_ms`."
+          "maximum": 9007199254740991,
+          "description": "Max number of money actions within one window (≤ 2^53−1). Requires `window_ms`."
         },
         "lifetime_limit_micro": {
           "type": "integer",
           "minimum": 0,
-          "description": "Max cumulative spend (integer micro-USD) over the grant's ENTIRE life — never reset by a window roll. The offline-meaningful total bound (paired with the grant's `expires_at`)."
+          "maximum": 9007199254740991,
+          "description": "Max cumulative spend (integer micro-USD, ≤ 2^53−1) over the grant's ENTIRE life — never reset by a window roll. The offline-meaningful total bound (paired with the grant's `expires_at`)."
         },
         "window_ms": {
           "type": "integer",
           "exclusiveMinimum": 0,
-          "description": "Rolling window length in ms. Required (> 0) when any per-window limit is set."
+          "maximum": 9007199254740991,
+          "description": "Rolling window length in ms (≤ 2^53−1). Required (> 0) when any per-window limit is set."
         }
       },
       "required": ["schema"],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "dependencies": {
+        "cumulative_limit_micro": ["window_ms"],
+        "per_counterparty_limit_micro": ["window_ms"],
+        "max_action_count": ["window_ms"]
+      }
     }
+  },
+  "dependencies": {
+    "cumulative_limit_micro": ["window_ms"],
+    "per_counterparty_limit_micro": ["window_ms"],
+    "max_action_count": ["window_ms"]
   }
 }

--- a/spec/schemas/standing-delegation-v1.json
+++ b/spec/schemas/standing-delegation-v1.json
@@ -79,32 +79,42 @@
         "cumulative_limit_micro": {
           "type": "integer",
           "minimum": 0,
-          "description": "Max cumulative spend (integer micro-USD) within one rolling window. Requires `window_ms`. A SET value of 0 denies all positive spend on this dimension."
+          "maximum": 9007199254740991,
+          "description": "Max cumulative spend (integer micro-USD, ≤ 2^53−1 for JCS number fidelity) within one rolling window. Requires `window_ms`. A SET value of 0 denies all positive spend on this dimension."
         },
         "per_counterparty_limit_micro": {
           "type": "integer",
           "minimum": 0,
-          "description": "Max spend (integer micro-USD) to any single canonical counterparty within one window. Requires `window_ms`."
+          "maximum": 9007199254740991,
+          "description": "Max spend (integer micro-USD, ≤ 2^53−1) to any single canonical counterparty within one window. Requires `window_ms`. Counterparty canonicalization is consumer-local runtime law (spec §3.3)."
         },
         "max_action_count": {
           "type": "integer",
           "minimum": 0,
-          "description": "Max number of money actions within one window. Requires `window_ms`."
+          "maximum": 9007199254740991,
+          "description": "Max number of money actions within one window (≤ 2^53−1). Requires `window_ms`."
         },
         "lifetime_limit_micro": {
           "type": "integer",
           "minimum": 0,
-          "description": "Max cumulative spend (integer micro-USD) over the grant's ENTIRE life — never reset by a window roll. The offline-meaningful total bound (paired with the grant's `expires_at`)."
+          "maximum": 9007199254740991,
+          "description": "Max cumulative spend (integer micro-USD, ≤ 2^53−1) over the grant's ENTIRE life — never reset by a window roll. The offline-meaningful total bound (paired with the grant's `expires_at`)."
         },
         "window_ms": {
           "type": "integer",
           "exclusiveMinimum": 0,
-          "description": "Rolling window length in ms. Required (> 0) when any per-window limit is set."
+          "maximum": 9007199254740991,
+          "description": "Rolling window length in ms (≤ 2^53−1). Required (> 0) when any per-window limit is set."
         }
       },
       "required": ["schema"],
       "additionalProperties": false,
-      "description": "Optional (standing-delegation@1.2). The delegator's signed autonomous-spend ceiling — the HOW-MUCH this grant authorizes, as a cryptographic commitment (part of the signed body). Absent ⇒ the grant authorizes NO autonomous money (enforcers deny `ceiling_absent`, fail-closed) — a @1.0/@1.1 grant verifies unchanged and simply cannot move money."
+      "description": "Optional (standing-delegation@1.2). The delegator's signed autonomous-spend ceiling — the HOW-MUCH this grant authorizes, as a cryptographic commitment (part of the signed body). Absent ⇒ the grant authorizes NO autonomous money (enforcers deny `ceiling_absent`, fail-closed) — a @1.0/@1.1 grant verifies unchanged and simply cannot move money.",
+      "dependencies": {
+        "cumulative_limit_micro": ["window_ms"],
+        "per_counterparty_limit_micro": ["window_ms"],
+        "max_action_count": ["window_ms"]
+      }
     },
     "cadence_ms": {
       "type": "number",
@@ -231,32 +241,42 @@
             "cumulative_limit_micro": {
               "type": "integer",
               "minimum": 0,
-              "description": "Max cumulative spend (integer micro-USD) within one rolling window. Requires `window_ms`. A SET value of 0 denies all positive spend on this dimension."
+              "maximum": 9007199254740991,
+              "description": "Max cumulative spend (integer micro-USD, ≤ 2^53−1 for JCS number fidelity) within one rolling window. Requires `window_ms`. A SET value of 0 denies all positive spend on this dimension."
             },
             "per_counterparty_limit_micro": {
               "type": "integer",
               "minimum": 0,
-              "description": "Max spend (integer micro-USD) to any single canonical counterparty within one window. Requires `window_ms`."
+              "maximum": 9007199254740991,
+              "description": "Max spend (integer micro-USD, ≤ 2^53−1) to any single canonical counterparty within one window. Requires `window_ms`. Counterparty canonicalization is consumer-local runtime law (spec §3.3)."
             },
             "max_action_count": {
               "type": "integer",
               "minimum": 0,
-              "description": "Max number of money actions within one window. Requires `window_ms`."
+              "maximum": 9007199254740991,
+              "description": "Max number of money actions within one window (≤ 2^53−1). Requires `window_ms`."
             },
             "lifetime_limit_micro": {
               "type": "integer",
               "minimum": 0,
-              "description": "Max cumulative spend (integer micro-USD) over the grant's ENTIRE life — never reset by a window roll. The offline-meaningful total bound (paired with the grant's `expires_at`)."
+              "maximum": 9007199254740991,
+              "description": "Max cumulative spend (integer micro-USD, ≤ 2^53−1) over the grant's ENTIRE life — never reset by a window roll. The offline-meaningful total bound (paired with the grant's `expires_at`)."
             },
             "window_ms": {
               "type": "integer",
               "exclusiveMinimum": 0,
-              "description": "Rolling window length in ms. Required (> 0) when any per-window limit is set."
+              "maximum": 9007199254740991,
+              "description": "Rolling window length in ms (≤ 2^53−1). Required (> 0) when any per-window limit is set."
             }
           },
           "required": ["schema"],
           "additionalProperties": false,
-          "description": "Optional (standing-delegation@1.2). The delegator's signed autonomous-spend ceiling — the HOW-MUCH this grant authorizes, as a cryptographic commitment (part of the signed body). Absent ⇒ the grant authorizes NO autonomous money (enforcers deny `ceiling_absent`, fail-closed) — a @1.0/@1.1 grant verifies unchanged and simply cannot move money."
+          "description": "Optional (standing-delegation@1.2). The delegator's signed autonomous-spend ceiling — the HOW-MUCH this grant authorizes, as a cryptographic commitment (part of the signed body). Absent ⇒ the grant authorizes NO autonomous money (enforcers deny `ceiling_absent`, fail-closed) — a @1.0/@1.1 grant verifies unchanged and simply cannot move money.",
+          "dependencies": {
+            "cumulative_limit_micro": ["window_ms"],
+            "per_counterparty_limit_micro": ["window_ms"],
+            "max_action_count": ["window_ms"]
+          }
         },
         "cadence_ms": {
           "type": "number",

--- a/spec/standing-delegation-v1.md
+++ b/spec/standing-delegation-v1.md
@@ -120,6 +120,10 @@ SpendCeilingV1 {
 
 All `*_micro` limits are integer micro-units, **USD-denominated** (1 USD = 1,000,000; zero floating point on the money path). The denomination is pinned by this prose: a future non-USD asset model is a NEW `schema` literal (an agility-axis append), never a silent reinterpretation of these numbers. Non-negative integers only; a SET limit of `0` denies all positive spend on that dimension (deny-all, not allow-all).
 
+Every numeric field is bounded at **2^53 − 1** (`maximum: 9007199254740991` in the committed schema): JCS (RFC 8785) serializes numbers per ECMAScript, so a larger integer does not survive canonicalization faithfully — a delegator-chosen limit above the bound could produce different signed bytes across implementations. The "Requires `window_ms`" clauses above are SHAPE law, enforced by the committed schema via draft-07 `dependencies` (a per-window limit without `window_ms` is malformed, not merely inert); rule 3's at-least-one-total-bound below remains ENFORCEMENT law (a bare ceiling is well-formed and authorizes nothing).
+
+**"Canonical counterparty" is consumer-local runtime law, by design.** `per_counterparty_limit_micro` buckets spend by a canonicalized destination, and the canonicalization is deliberately NOT interop law: under the trusted-runtime threat model the spend accumulator is runtime-local, so cross-runtime comparability of per-counterparty buckets would be a false import — two enforcers holding separate accumulators already enforce separately. Each consumer MUST canonicalize consistently with itself (or an adversary mints sub-limits by varying encodings of one destination); the reference canonicalization is `canonicalizeCounterparty` in `@motebit/policy` (EVM hex lowercased per EIP-55 case-insensitivity; case-sensitive forms such as base58 trimmed only; empty ⇒ invalid, denied).
+
 The `SpendCeilingV1` type in `@motebit/protocol` is the binding machine-readable form; `StandingDelegationSchema` in `@motebit/wire-schemas` carries it as the optional `spend_ceiling` and `spec/schemas/spend-ceiling-v1.json` is the committed standalone schema.
 
 #### Verification and enforcement (foundation law)


### PR DESCRIPTION
Agency.computer's verification of standing-delegation@1.2 came back with two schema asks, one definition question, zero blockers. All three land here, before the protocol minor goes to npm — the schema learns its prose first.

1. **Window dependencies are shape law in both validators.** §3.3 says "Requires `window_ms`" three times; the committed schema accepted a per-window limit without one. Now: zod `superRefine` + draft-07 `dependencies` injected into `spend-ceiling-v1.json` (root + definitions) AND both embedded copies inside `standing-delegation-v1.json`. A validator-parity suite proves the two can't disagree. Rule 3 (at-least-one-total-bound) deliberately stays enforcement law — a bare ceiling remains well-formed-but-authorizes-nothing, exactly as agency's review distinguished.
2. **Every numeric capped at 2^53−1** (`maximum: 9007199254740991`). JCS serializes per ECMAScript; a larger delegator-chosen limit could produce different signed bytes across implementations. Costs nothing, pins interop.
3. **"Canonical counterparty" defined in §3.3** as consumer-local runtime law, by design: under the trusted-runtime threat model the spend accumulator is runtime-local, so cross-runtime comparability of per-counterparty buckets would be a false import. Reference canonicalization named (`canonicalizeCounterparty`, `@motebit/policy`).

Gates 127/127; wire-schemas 536 (5 new shape-law tests); typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)