### PR TITLE
feat: wallet homeostasis + provider↔model pre-flight — two founder-forced coherence fixes

### DIFF
--- a/.changeset/model-coherence.md
+++ b/.changeset/model-coherence.md
@@ -1,0 +1,5 @@
+---
+"@motebit/sdk": minor
+---
+
+`modelVendorHint` + `providerAcceptsModel` — provider ↔ model pre-flight admission in the canonical model registry (intelligence-pluggability contract, commitment 1). Born live 2026-07-06: `--provider anthropic` with a config-resident `default_model: llama3.2:latest` composed an illegal pairing that failed opaquely at the first API call. The predicate refuses ONLY known cross-vendor mismatches (registry membership + naming signatures); unknown ids stay permissive so new releases never brick startup; `local-server` accepts anything; the proxy accepts its routed cloud vendors. The CLI consumes it two ways: config residue yields politely (stale `default_model` from a previous provider era auto-resolves to the chosen provider's default, with a visible note), and explicit `--provider`/`--model` contradictions fail loud at startup naming both.

--- a/.changeset/wallet-metabolism.md
+++ b/.changeset/wallet-metabolism.md
@@ -1,0 +1,5 @@
+---
+"motebit": minor
+---
+
+`motebit wallet swap <sol-amount>` — owner-invoked SOL → USDC normalization (wallet homeostasis, funding side; born from the first live funding: the founder sent SOL expecting the wallet to normalize). A deterministic affordance: the owner's passphrase is the authorization; the Jupiter adapter enforces a fail-closed gas floor (0.005 SOL — the wallet never metabolizes its last fuel) with the refusal naming the max swappable amount. `motebit wallet` now teaches its own funding posture (USDC on the SOLANA network; SOL is auto-managed gas). Autonomous posture normalization stays deferred-with-trigger — it would ride the standing-grant meter like any autonomous money.

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -416,6 +416,7 @@ Commands:
   wallet                    Show your sovereign Solana wallet (address, USDC balance)
     --solana-rpc-url <url>    Solana RPC endpoint (default: mainnet-beta public RPC)
     --address-only            Skip the balance query (address-only)
+  wallet swap <sol>         Convert SOL → USDC working capital (Jupiter; gas floor enforced)
   doctor                    Check system readiness (Node, SQLite, config)
   export [--output <dir>]   Export identity bundle (motebit.md, credentials, budget, gradient)
     --all                   Include sensitive memories (medical/financial/secret) in export

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -3,6 +3,7 @@ import type { MotebitPersonalityConfig } from "@motebit/ai-core";
 import { deriveSyncEncryptionKey, createSignedToken } from "@motebit/encryption";
 import { connectMcpServers } from "@motebit/mcp-client";
 import { formatBodyAwareness } from "@motebit/ai-core";
+import { providerAcceptsModel } from "@motebit/sdk";
 import { parseCliArgs, printHelp, printVersion, printBanner, trimHistory } from "./args.js";
 import type { CliConfig } from "./args.js";
 import { loadFullConfig, extractPersonality, persistMotebitPublicKeys } from "./config.js";
@@ -437,7 +438,30 @@ async function main(): Promise<void> {
     personalityConfig.default_model !== "" &&
     !process.argv.includes("--model")
   ) {
-    config.model = personalityConfig.default_model;
+    // Config residue yields politely: a default_model from a previous
+    // provider era must not ride along onto a different provider (the
+    // 2026-07-06 "anthropic · llama3.2:latest" pairing — pre-flight
+    // admission per intelligence-pluggability-contract). The per-provider
+    // parse-time default already sits on config.model; keep it and say so.
+    if (providerAcceptsModel(config.provider, personalityConfig.default_model)) {
+      config.model = personalityConfig.default_model;
+    } else {
+      console.log(
+        dim(
+          `  [config default_model "${personalityConfig.default_model}" belongs to another provider; using ${config.model} for ${config.provider}]`,
+        ),
+      );
+    }
+  }
+  // An EXPLICIT contradiction fails loud at startup, naming both — never
+  // deferred to an opaque first-call API error.
+  if (process.argv.includes("--model") && !providerAcceptsModel(config.provider, config.model)) {
+    console.error(
+      `Model "${config.model}" does not belong to provider "${config.provider}" — ` +
+        `pick a matching pair (e.g. --provider anthropic --model claude-sonnet-4-6), ` +
+        `or drop --model to use the provider's default.`,
+    );
+    process.exit(1);
   }
   if (fullConfig.max_tokens != null && !process.argv.includes("--max-tokens")) {
     config.maxTokens = fullConfig.max_tokens;

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -83,6 +83,7 @@ import {
   handleMigrateKeyring,
   handleWithdraw,
   handleWallet,
+  handleWalletSwap,
   handleSkillsInstall,
   handleSkillsAudit,
   handleSkillsList,
@@ -162,6 +163,10 @@ async function main(): Promise<void> {
   }
 
   if (subcommand === "wallet") {
+    if (config.positionals[1] === "swap") {
+      await handleWalletSwap(config.positionals[2], { rpcUrl: config.solanaRpcUrl });
+      return;
+    }
     await handleWallet({
       rpcUrl: config.solanaRpcUrl,
       addressOnly: config.walletAddressOnly,

--- a/apps/cli/src/subcommands/index.ts
+++ b/apps/cli/src/subcommands/index.ts
@@ -77,4 +77,4 @@ export {
 } from "./skills.js";
 export { handleVerify } from "./verify.js";
 export { handleVerifyWire, isVerifyKind } from "./verify-wire.js";
-export { handleWallet } from "./wallet.js";
+export { handleWallet, handleWalletSwap } from "./wallet.js";

--- a/apps/cli/src/subcommands/wallet.ts
+++ b/apps/cli/src/subcommands/wallet.ts
@@ -91,6 +91,83 @@ export async function handleWallet(options: WalletOptions = {}): Promise<void> {
 
   console.log();
   console.log(`  This address IS your Ed25519 identity public key, base58-encoded.`);
-  console.log(`  Send USDC directly to fund your motebit. Sovereign — no relay, no custody.`);
+  console.log(`  Fund with USDC on the SOLANA network (not Base/Ethereum — same asset,`);
+  console.log(`  different chains). SOL received here is gas, auto-managed; convert extra`);
+  console.log(`  SOL to working capital with \`motebit wallet swap <sol-amount>\`.`);
+  console.log(`  Sovereign — no relay, no custody.`);
   console.log();
+}
+
+/**
+ * `motebit wallet swap <sol-amount>` — owner-invoked SOL → USDC
+ * normalization (wallet homeostasis, funding side). A deterministic
+ * affordance: the owner's passphrase IS the authorization; the Jupiter
+ * adapter's gas floor refuses fail-closed to metabolize the last fuel.
+ * Born 2026-07-05: the founder funded the first live motebit with SOL
+ * from an exchange, and the wallet had no way to normalize it.
+ */
+export async function handleWalletSwap(
+  amountArg: string | undefined,
+  options: WalletOptions = {},
+): Promise<void> {
+  if (amountArg == null || amountArg.trim() === "") {
+    console.error("Usage: motebit wallet swap <sol-amount>   e.g. motebit wallet swap 0.01");
+    process.exit(1);
+  }
+  // Decimal SOL → lamports without float drift: split on the point.
+  const m = amountArg.trim().match(/^(\d+)(?:\.(\d{1,9}))?$/);
+  if (m == null) {
+    console.error(`Invalid SOL amount "${amountArg}" — up to 9 decimal places.`);
+    process.exit(1);
+  }
+  const lamports = BigInt(m[1]!) * 1_000_000_000n + BigInt((m[2] ?? "").padEnd(9, "0"));
+  if (lamports <= 0n) {
+    console.error("Amount must be positive.");
+    process.exit(1);
+  }
+
+  const config = loadFullConfig();
+  if (!config.motebit_id) {
+    console.error(NO_IDENTITY_MESSAGE);
+    process.exit(1);
+  }
+
+  let privateKey: Uint8Array;
+  try {
+    const loaded = await loadActiveSigningKey(config, {
+      promptLabel: "Passphrase (to sign swap): ",
+    });
+    privateKey = loaded.privateKey;
+  } catch (err) {
+    if (err instanceof IdentityKeyError) {
+      console.error(`Swap unavailable: ${err.message}`);
+      console.error(`  → ${err.remedy}`);
+    } else {
+      console.error(`Swap unavailable: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    process.exit(1);
+  }
+
+  const rpcUrl = options.rpcUrl ?? "https://api.mainnet-beta.solana.com";
+  let rail;
+  try {
+    rail = createSolanaWalletRail({ rpcUrl, identitySeed: privateKey });
+  } finally {
+    secureErase(privateKey);
+  }
+
+  console.log(`Swapping ${amountArg} SOL → USDC via Jupiter (1% slippage bound)…`);
+  try {
+    const result = await rail.swapSolToUsdc(lamports);
+    console.log(
+      `  swapped   ${amountArg} SOL → ${fromMicro(Number(result.outputAmount)).toFixed(2)} USDC`,
+    );
+    console.log(`  tx        https://explorer.solana.com/tx/${result.signature}`);
+    console.log();
+    console.log(`Run \`motebit wallet\` to see the updated balance.`);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`Swap refused or failed: ${msg}`);
+    process.exit(1);
+  }
 }

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -587,6 +587,9 @@ export interface MlxProviderSpec {
 }
 
 // @public
+export function modelVendorHint(model: string): "anthropic" | "openai" | "google" | "deepseek" | "groq" | "local" | "unknown";
+
+// @public
 export interface MotebitCloudProviderConfig {
     baseUrl?: string;
     // (undocumented)
@@ -678,6 +681,9 @@ export interface PrecisionWeights {
     retrievalPrecision: number;
     selfTrust: number;
 }
+
+// @public
+export function providerAcceptsModel(provider: string, model: string): boolean;
 
 // @public
 export type ProviderMode = "on-device" | "motebit-cloud" | "byok";

--- a/packages/sdk/src/__tests__/model-coherence.test.ts
+++ b/packages/sdk/src/__tests__/model-coherence.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Provider ↔ model pre-flight admission (intelligence-pluggability
+ * contract, commitment 1). Born live 2026-07-06: `--provider anthropic`
+ * + config-resident `default_model: llama3.2:latest` composed an
+ * illegal pairing the banner printed and the API rejected opaquely.
+ * The predicate refuses ONLY known cross-vendor mismatches — unknown
+ * ids stay permissive so new model releases never brick startup.
+ */
+import { describe, it, expect } from "vitest";
+import { modelVendorHint, providerAcceptsModel } from "../models.js";
+
+describe("modelVendorHint", () => {
+  it("attributes registry members and naming signatures", () => {
+    expect(modelVendorHint("claude-sonnet-4-6")).toBe("anthropic");
+    expect(modelVendorHint("claude-sonnet-9-1")).toBe("anthropic"); // future id, prefix
+    expect(modelVendorHint("gpt-5.4-mini")).toBe("openai");
+    expect(modelVendorHint("gemini-2.5-flash")).toBe("google");
+    expect(modelVendorHint("deepseek-chat")).toBe("deepseek");
+    expect(modelVendorHint("llama3.2:latest")).toBe("local"); // the incident's id
+    expect(modelVendorHint("qwen2.5-coder")).toBe("local");
+    expect(modelVendorHint("totally-new-thing")).toBe("unknown");
+  });
+});
+
+describe("providerAcceptsModel — refuses only KNOWN cross-vendor mismatches", () => {
+  it("rejects the incident pairing", () => {
+    expect(providerAcceptsModel("anthropic", "llama3.2:latest")).toBe(false);
+  });
+  it("accepts matched pairs and future same-vendor ids", () => {
+    expect(providerAcceptsModel("anthropic", "claude-sonnet-4-6")).toBe(true);
+    expect(providerAcceptsModel("anthropic", "claude-sonnet-9-1")).toBe(true);
+    expect(providerAcceptsModel("openai", "gpt-5.4")).toBe(true);
+  });
+  it("unknown ids never block (registry lags releases)", () => {
+    expect(providerAcceptsModel("anthropic", "totally-new-thing")).toBe(true);
+  });
+  it("local-server runs whatever the user's server hosts", () => {
+    expect(providerAcceptsModel("local-server", "claude-sonnet-4-6")).toBe(true);
+    expect(providerAcceptsModel("local-server", "anything:tag")).toBe(true);
+  });
+  it("proxy routes the cloud vendors, not local tags", () => {
+    expect(providerAcceptsModel("proxy", "claude-sonnet-4-6")).toBe(true);
+    expect(providerAcceptsModel("proxy", "llama3.2:latest")).toBe(false);
+  });
+  it("groq serves open-family models", () => {
+    expect(providerAcceptsModel("groq", "llama-3.3-70b-versatile")).toBe(true);
+    expect(providerAcceptsModel("groq", "claude-sonnet-4-6")).toBe(false);
+  });
+});

--- a/packages/sdk/src/models.ts
+++ b/packages/sdk/src/models.ts
@@ -164,3 +164,53 @@ export type LocalServerSuggestedModel = (typeof LOCAL_SERVER_SUGGESTED_MODELS)[n
  */
 export type OllamaSuggestedModel = LocalServerSuggestedModel;
 export type ProxyModel = (typeof PROXY_MODELS)[number];
+
+// === Provider ↔ model coherence ===
+//
+// Born live, 2026-07-06: `--provider anthropic` with a config-resident
+// `default_model: llama3.2:latest` composed an Anthropic provider around
+// an Ollama model id — the banner printed the illegal pairing and the
+// failure deferred to the first API call. The intelligence-pluggability
+// contract's first commitment is PRE-FLIGHT admission: the selected
+// model must fit the selected provider BEFORE any turn runs. These two
+// helpers are that check's canonical home (the registry already knows
+// the vendors).
+
+/** Best-effort vendor attribution for a model id. Registry membership
+ *  first, then naming-signature heuristics for ids the registry hasn't
+ *  caught up to (new dated releases must not brick startup — an
+ *  `"unknown"` verdict is deliberately permissive). */
+export function modelVendorHint(
+  model: string,
+): "anthropic" | "openai" | "google" | "deepseek" | "groq" | "local" | "unknown" {
+  const m = model.trim().toLowerCase();
+  if ((ANTHROPIC_MODELS as readonly string[]).includes(m)) return "anthropic";
+  if ((OPENAI_MODELS as readonly string[]).includes(m)) return "openai";
+  if ((GOOGLE_MODELS as readonly string[]).includes(m)) return "google";
+  if ((DEEPSEEK_MODELS as readonly string[]).includes(m)) return "deepseek";
+  if ((GROQ_MODELS as readonly string[]).includes(m)) return "groq";
+  if (m.startsWith("claude")) return "anthropic";
+  if (m.startsWith("gpt-") || /^o[0-9]/.test(m)) return "openai";
+  if (m.startsWith("gemini")) return "google";
+  if (m.startsWith("deepseek")) return "deepseek";
+  // Ollama-style tags and the common local families.
+  if (m.includes(":") || /^(llama|mistral|qwen|phi|gemma|smollm)/.test(m)) return "local";
+  return "unknown";
+}
+
+/**
+ * Pre-flight admission: may `model` be served by `provider`?
+ * Permissive where honesty demands it — `local-server` runs whatever the
+ * user's server hosts, the proxy routes multiple vendors, and an
+ * `"unknown"` vendor hint never blocks (the registry lags new releases).
+ * It answers `false` only for a KNOWN cross-vendor mismatch — exactly
+ * the class that fails opaquely at the API otherwise.
+ */
+export function providerAcceptsModel(provider: string, model: string): boolean {
+  if (provider === "local-server" || provider === "ollama") return true;
+  const hint = modelVendorHint(model);
+  if (hint === "unknown") return true;
+  if (provider === "proxy") return hint === "anthropic" || hint === "openai" || hint === "google";
+  if (provider === "groq") return hint === "groq" || hint === "local"; // groq serves open models
+  return hint === provider;
+}

--- a/packages/wallet-solana/src/__tests__/jupiter.test.ts
+++ b/packages/wallet-solana/src/__tests__/jupiter.test.ts
@@ -12,7 +12,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { Keypair, Connection, VersionedTransaction } from "@solana/web3.js";
 
-import { swapUsdcToSol } from "../jupiter.js";
+import { swapUsdcToSol, swapSolToUsdc } from "../jupiter.js";
 
 const ZERO_SEED = new Uint8Array(32);
 
@@ -164,5 +164,80 @@ describe("swapUsdcToSol", () => {
     const { keypair, connection } = makeKeypairAndConnection();
     await expect(swapUsdcToSol(20_000n, keypair, connection)).rejects.toThrow();
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("swapSolToUsdc — the funding-side mirror", () => {
+  it("REFUSES a swap that would breach the gas floor — the wallet never metabolizes its last fuel", async () => {
+    const { keypair, connection } = makeKeypairAndConnection();
+    // Wallet holds 0.006 SOL; swapping 0.002 would leave 0.004 < floor.
+    vi.spyOn(connection, "getBalance").mockResolvedValue(6_000_000);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(swapSolToUsdc(2_000_000n, keypair, connection)).rejects.toThrow(/gas floor/);
+    expect(fetchMock).not.toHaveBeenCalled(); // refused BEFORE any quote — no side effects
+  });
+
+  it("names the max swappable amount in the refusal (a refusal that teaches)", async () => {
+    const { keypair, connection } = makeKeypairAndConnection();
+    vi.spyOn(connection, "getBalance").mockResolvedValue(6_000_000);
+    vi.stubGlobal("fetch", vi.fn());
+
+    await expect(swapSolToUsdc(2_000_000n, keypair, connection)).rejects.toThrow(
+      /max swappable 1000000 lamports/,
+    );
+  });
+
+  it("quotes SOL→USDC with the 1% slippage bound and surfaces quote failures", async () => {
+    const { keypair, connection } = makeKeypairAndConnection();
+    vi.spyOn(connection, "getBalance").mockResolvedValue(100_000_000); // 0.1 SOL — plenty
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(swapSolToUsdc(10_000_000n, keypair, connection)).rejects.toThrow(
+      /Jupiter quote failed: HTTP 503/,
+    );
+    const quoteUrl = new URL(fetchMock.mock.calls[0]![0] as string);
+    expect(quoteUrl.searchParams.get("inputMint")).toBe(
+      "So11111111111111111111111111111111111111112",
+    );
+    expect(quoteUrl.searchParams.get("outputMint")).toBe(
+      "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    );
+    expect(quoteUrl.searchParams.get("amount")).toBe("10000000");
+    expect(quoteUrl.searchParams.get("slippageBps")).toBe("100");
+  });
+
+  it("signs and submits the Jupiter transaction, returning amounts both ways", async () => {
+    const { keypair, connection } = makeKeypairAndConnection();
+    vi.spyOn(connection, "getBalance").mockResolvedValue(100_000_000);
+    const fakeTx = { sign: vi.fn(), serialize: vi.fn().mockReturnValue(new Uint8Array([1])) };
+    vi.spyOn(VersionedTransaction, "deserialize").mockReturnValue(fakeTx as never);
+    vi.spyOn(connection, "sendRawTransaction").mockResolvedValue("sig-mirror");
+    vi.spyOn(connection, "getLatestBlockhash").mockResolvedValue({
+      blockhash: "h",
+      lastValidBlockHeight: 1,
+    } as never);
+    vi.spyOn(connection, "confirmTransaction").mockResolvedValue({ value: { err: null } } as never);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ outAmount: "1500000" }), // $1.50 out
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ swapTransaction: Buffer.from([1, 2, 3]).toString("base64") }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await swapSolToUsdc(10_000_000n, keypair, connection);
+    expect(fakeTx.sign).toHaveBeenCalledWith([keypair]);
+    expect(result).toEqual({
+      signature: "sig-mirror",
+      inputAmount: 10_000_000n,
+      outputAmount: 1_500_000n,
+    });
   });
 });

--- a/packages/wallet-solana/src/__tests__/rail.test.ts
+++ b/packages/wallet-solana/src/__tests__/rail.test.ts
@@ -18,6 +18,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const { swapUsdcToSolMock } = vi.hoisted(() => ({ swapUsdcToSolMock: vi.fn() }));
 vi.mock("../jupiter.js", () => ({
   swapUsdcToSol: swapUsdcToSolMock,
+  // rail.ts statically imports the gas-floor constant from the same
+  // module (single-source since the swapSolToUsdc mirror landed) — the
+  // mock must carry it or every rail test fails at import time.
+  GAS_FLOOR_LAMPORTS: 5_000_000n,
 }));
 
 import {

--- a/packages/wallet-solana/src/__tests__/rail.test.ts
+++ b/packages/wallet-solana/src/__tests__/rail.test.ts
@@ -423,3 +423,15 @@ describe("SolanaWalletRail.buildP2pPayment", () => {
     expect(sendUsdcBatch).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("SolanaWalletRail.swapSolToUsdc — the owner-invoked funding-side swap", () => {
+  it("throws honestly when the rail has no web3 adapter", async () => {
+    const adapter: SolanaRpcAdapter = {
+      getSolBalance: async () => 0n,
+      getUsdcBalance: async () => 0n,
+      sendUsdc: async () => ({ signature: "x" }) as never,
+    } as never;
+    const rail = new SolanaWalletRail(adapter, { autoGas: false });
+    await expect(rail.swapSolToUsdc(1_000_000n)).rejects.toThrow(/without a web3 adapter/);
+  });
+});

--- a/packages/wallet-solana/src/index.ts
+++ b/packages/wallet-solana/src/index.ts
@@ -46,7 +46,12 @@ export {
   InvalidSolanaAddressError,
 } from "./constants.js";
 
-export { swapUsdcToSol, type JupiterSwapResult } from "./jupiter.js";
+export {
+  swapUsdcToSol,
+  swapSolToUsdc,
+  GAS_FLOOR_LAMPORTS,
+  type JupiterSwapResult,
+} from "./jupiter.js";
 
 export {
   SolanaMemoSubmitter,

--- a/packages/wallet-solana/src/jupiter.ts
+++ b/packages/wallet-solana/src/jupiter.ts
@@ -21,8 +21,15 @@ const SOL_MINT = "So11111111111111111111111111111111111111112";
 /** USDC mint (mainnet). */
 const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 
-/** Jupiter V6 API base URL. */
-const JUPITER_API = "https://quote-api.jup.ag/v6";
+/**
+ * Jupiter Swap API base URL. The original `quote-api.jup.ag/v6` was
+ * sunset by Jupiter (connection-refused as of 2026-07 — discovered when
+ * the first LIVE swap failed with "fetch failed"; the ensureGas
+ * direction had the same dead URL, dormant because its failures are
+ * swallowed by design). `lite-api.jup.ag/swap/v1` is the current free
+ * tier; same quote/swap shapes.
+ */
+const JUPITER_API = "https://lite-api.jup.ag/swap/v1";
 
 export interface JupiterSwapResult {
   /** Transaction signature. */

--- a/packages/wallet-solana/src/jupiter.ts
+++ b/packages/wallet-solana/src/jupiter.ts
@@ -101,3 +101,100 @@ export async function swapUsdcToSol(
     outputAmount: BigInt((quote as { outAmount?: string }).outAmount ?? "0"),
   };
 }
+
+/**
+ * The gas floor — SOL the wallet must NEVER swap away. An organism does
+ * not metabolize its last fuel: converting the final lamports to USDC
+ * would leave the agent unable to sign ANY transaction (including the
+ * swap that could undo the mistake). 0.005 SOL ≈ thousands of standard
+ * transfers of headroom. `swapSolToUsdc` fail-closes below it.
+ */
+export const GAS_FLOOR_LAMPORTS = 5_000_000n;
+
+/**
+ * Swap SOL → USDC via Jupiter — the mirror of `swapUsdcToSol`, and the
+ * funding-side half of wallet homeostasis: the owner may fund with
+ * whatever asset is convenient (2026-07-05: the founder funded the first
+ * live motebit with SOL from an exchange, expecting the wallet to
+ * normalize — this primitive is that expectation honored). Governance
+ * note: a swap is a money action; this primitive is invoked today only
+ * by the OWNER's deterministic `wallet swap` affordance (passphrase-
+ * signed). Autonomous posture normalization is deferred-with-trigger and
+ * would ride the standing-grant meter like any autonomous money.
+ *
+ * Fail-closed guards:
+ *  - refuses to leave the wallet below GAS_FLOOR_LAMPORTS after the swap
+ *    (the balance is read live; the caller cannot override the floor);
+ *  - 1% slippage bound on the quote, same as the gas-floor direction.
+ *
+ * @param solLamports — SOL to swap, in lamports (9 decimals).
+ */
+export async function swapSolToUsdc(
+  solLamports: bigint,
+  keypair: Keypair,
+  connection: Connection,
+  commitment: Commitment = "confirmed",
+  usdcMint: string = USDC_MINT,
+): Promise<JupiterSwapResult> {
+  const walletAddress = keypair.publicKey.toBase58();
+
+  // Gas-floor guard — live balance read, fail-closed.
+  const balanceLamports = BigInt(await connection.getBalance(keypair.publicKey, commitment));
+  if (balanceLamports - solLamports < GAS_FLOOR_LAMPORTS) {
+    const maxSwappable = balanceLamports - GAS_FLOOR_LAMPORTS;
+    throw new Error(
+      `swap refused: would leave the wallet below its gas floor ` +
+        `(${GAS_FLOOR_LAMPORTS} lamports = 0.005 SOL). Balance ${balanceLamports} lamports; ` +
+        `max swappable ${maxSwappable > 0n ? maxSwappable : 0n} lamports. ` +
+        `The wallet never metabolizes its last fuel.`,
+    );
+  }
+
+  // 1. Get quote (SOL → USDC)
+  const quoteUrl = new URL(`${JUPITER_API}/quote`);
+  quoteUrl.searchParams.set("inputMint", SOL_MINT);
+  quoteUrl.searchParams.set("outputMint", usdcMint);
+  quoteUrl.searchParams.set("amount", solLamports.toString());
+  quoteUrl.searchParams.set("slippageBps", "100"); // 1% slippage, mirrors the gas-floor direction
+
+  const quoteRes = await fetch(quoteUrl.toString());
+  if (!quoteRes.ok) {
+    throw new Error(`Jupiter quote failed: HTTP ${quoteRes.status}`);
+  }
+  const quote = await quoteRes.json();
+
+  // 2. Get swap transaction
+  const swapRes = await fetch(`${JUPITER_API}/swap`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      quoteResponse: quote,
+      userPublicKey: walletAddress,
+      wrapAndUnwrapSol: true,
+    }),
+  });
+  if (!swapRes.ok) {
+    throw new Error(`Jupiter swap failed: HTTP ${swapRes.status}`);
+  }
+  const { swapTransaction } = (await swapRes.json()) as { swapTransaction: string };
+
+  // 3. Deserialize, sign, submit
+  const txBuffer = Buffer.from(swapTransaction, "base64");
+  const tx = VersionedTransaction.deserialize(txBuffer);
+  tx.sign([keypair]);
+
+  const signature = await connection.sendRawTransaction(tx.serialize(), {
+    skipPreflight: false,
+    preflightCommitment: commitment,
+  });
+
+  // 4. Confirm
+  const latestBlockhash = await connection.getLatestBlockhash(commitment);
+  await connection.confirmTransaction({ signature, ...latestBlockhash }, commitment);
+
+  return {
+    signature,
+    inputAmount: solLamports,
+    outputAmount: BigInt((quote as { outAmount?: string }).outAmount ?? "0"),
+  };
+}

--- a/packages/wallet-solana/src/rail.ts
+++ b/packages/wallet-solana/src/rail.ts
@@ -31,7 +31,7 @@ export type SendResult = SendUsdcResult;
  * Minimum SOL balance in lamports to consider gas sufficient.
  * 5_000_000 lamports = 0.005 SOL ≈ enough for ~1000 transactions.
  */
-const GAS_FLOOR_LAMPORTS = 5_000_000n;
+import { GAS_FLOOR_LAMPORTS } from "./jupiter.js";
 
 /**
  * Amount of USDC micro-units to swap for gas when the floor is breached.
@@ -122,6 +122,31 @@ export class SolanaWalletRail implements SovereignWalletRail {
       // (it will fail with insufficient gas, but that's the honest state)
       return false;
     }
+  }
+
+  /**
+   * Owner-invoked SOL → USDC swap — the funding-side half of wallet
+   * homeostasis (the owner may fund with whatever asset landed; the
+   * wallet normalizes toward working capital). Delegates to the Jupiter
+   * adapter, which enforces the gas floor fail-closed. Exposed for the
+   * `wallet swap` deterministic affordance; NOT called autonomously
+   * (autonomous posture normalization is deferred-with-trigger and
+   * would ride the standing-grant meter).
+   */
+  async swapSolToUsdc(solLamports: bigint): Promise<import("./jupiter.js").JupiterSwapResult> {
+    if (!this.web3Adapter) {
+      throw new Error(
+        "swap unavailable: this rail was constructed without a web3 adapter (createSolanaWalletRail provides one).",
+      );
+    }
+    const { swapSolToUsdc } = await import("./jupiter.js");
+    return swapSolToUsdc(
+      solLamports,
+      this.web3Adapter.getKeypair(),
+      this.web3Adapter.getConnection(),
+      this.web3Adapter.getCommitment(),
+      this.web3Adapter.getUsdcMint(),
+    );
   }
 
   /**


### PR DESCRIPTION
Two coherence gaps, both discovered live on 2026-07-06/07 by the founder walking the first-metered-dollar runbook — the most legitimate way features get forced.

## 1. Wallet homeostasis — SOL → USDC normalization with a gas floor
The founder funded the first live motebit with SOL, expecting normalization; the metabolism only ran the other way (`swapUsdcToSol` gas top-up). Shipped: `swapSolToUsdc` (Jupiter, 1% slippage) with a fail-closed `GAS_FLOOR_LAMPORTS` guard (refusal fires before any quote and names the max swappable — the wallet never metabolizes its last fuel); `SolanaWalletRail.swapSolToUsdc`; `motebit wallet swap <sol>`; posture legibility on `motebit wallet` (fund with USDC **on Solana**; SOL is auto-managed gas). Autonomous normalization stays deferred-with-trigger (it would ride the standing-grant meter).
**Live-found second bug:** Jupiter sunset `quote-api.jup.ag/v6`; the dormant `ensureGas` path carried the same dead URL invisibly (failures swallowed by design). Migrated to `lite-api.jup.ag/swap/v1`.
**Live-verified:** first real execution funded the founder's own runbook step — 0.02 SOL → 1.63 USDC, tx `3gDzSN7wUDvoRKnv9rnUTJxFQBF5YbWhQoY3pXFcZ77fEK5JiRTmydfFmSgbDBGndh8hXrNsNja5eXjHAfWkKhtu`.

## 2. Provider ↔ model pre-flight admission
`--provider anthropic` + config-resident `default_model: llama3.2:latest` composed an illegal pairing the banner printed proudly and the API rejected opaquely. Shipped in the canonical registry (`sdk/models.ts`): `modelVendorHint` + `providerAcceptsModel` — refuses ONLY known cross-vendor mismatches (unknown ids stay permissive so new releases never brick startup; local-server accepts anything; proxy accepts its routed vendors). CLI: config residue **yields politely** (visible note, provider default stands — live-verified on the founder's screen); explicit contradictions **fail loud at startup** naming both (smoke-verified against the incident pairing, pre-passphrase).

## Verification
Gates 127/127; wallet-solana 168 / sdk 143 (7 new) / cli 250; typecheck + lint clean; sdk API + cli-surface baselines regenerated; `motebit` + `@motebit/sdk` minor changesets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)