### PR TITLE
feat: wire the rail — sovereign wallet + pinned relay key reach the runtime

### DIFF
--- a/.changeset/wire-the-rail.md
+++ b/.changeset/wire-the-rail.md
@@ -1,0 +1,5 @@
+---
+"motebit": minor
+---
+
+The last seam of the first-metered-dollar path: the CLI now wires the sovereign Solana rail and the PINNED relay key into the runtime. (1) `createRuntime` accepts and threads `solanaWallet`; the REPL constructs the rail from the decrypted identity seed — its presence is what makes `delegate_to_agent` a real money tool (R4 hint, late-bound metering, wrapped P2P payment builder). (2) `motebit register` pins the relay operator's public key trust-on-first-use from the SIGNED transparency declaration, verified via the canonical `@motebit/state-export-client` verifier; a later mismatch fails loud (a relay that changes identity is never silently re-trusted); fetch failure warns without failing registration. (3) The REPL threads the pinned key into the delegation config — the treasury address derives FROM the pin, never from a fetched response at payment time. Discovered live 2026-07-07: every layer of the metering stack was sound and unreachable — delegation registered as R2 (no rail ⇒ no R4 hint), and relay-mode paid delegation 402'd in a retry loop.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -60,6 +60,7 @@
     "@hono/node-server": "^1.19.12",
     "@hono/node-ws": "^1.3.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@motebit/state-export-client": "workspace:*",
     "@noble/curves": "^2.2.0",
     "@noble/ed25519": "~3.1.0",
     "@noble/hashes": "^2.2.0",

--- a/apps/cli/src/__tests__/register-pin.test.ts
+++ b/apps/cli/src/__tests__/register-pin.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Relay-key pinning (trust-on-first-use) — the trust root of the P2P
+ * fee leg. Born 2026-07-07 wiring the rail: the CLI had no pinned
+ * relay key, so the P2P delegation path was unreachable from the REPL
+ * and the treasury address had no verified source. Three outcomes,
+ * deliberately asymmetric: pin-on-first-verify / fail-loud-on-mismatch /
+ * warn-only-on-fetch-failure.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { saveFullConfigMock, verifyMock } = vi.hoisted(() => ({
+  saveFullConfigMock: vi.fn(),
+  verifyMock: vi.fn(),
+}));
+vi.mock("../config.js", () => ({
+  loadFullConfig: vi.fn(),
+  saveFullConfig: saveFullConfigMock,
+}));
+vi.mock("@motebit/state-export-client", () => ({
+  verifyTransparencyDeclaration: verifyMock,
+}));
+vi.mock("@motebit/encryption", () => ({
+  createSignedToken: vi.fn(),
+  secureErase: vi.fn(),
+}));
+vi.mock("../identity.js", () => ({
+  loadActiveSigningKey: vi.fn(),
+  IdentityKeyError: class extends Error {},
+}));
+
+import { pinRelayKey } from "../subcommands/register.js";
+
+const DECLARATION = {
+  relay_public_key: "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",
+  signature: "sig",
+  hash: "h",
+  suite: "ed25519-jcs-sha256-v1",
+};
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => DECLARATION }));
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("pinRelayKey", () => {
+  it("pins on first verified contact and persists to config", async () => {
+    verifyMock.mockResolvedValue({ ok: true, anchor: {} });
+    const cfg = {} as never;
+    await pinRelayKey("https://relay.example", cfg);
+    expect((cfg as { relay_public_key?: string }).relay_public_key).toBe(
+      DECLARATION.relay_public_key,
+    );
+    expect(saveFullConfigMock).toHaveBeenCalledWith(cfg);
+  });
+
+  it("FAILS LOUD on pin mismatch — a relay that changed identity is never silently re-trusted", async () => {
+    verifyMock.mockResolvedValue({ ok: true, anchor: {} });
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("exit-called");
+    }) as never);
+    const cfg = { relay_public_key: "1111111111111111111111111111111111111111" } as never;
+    await expect(pinRelayKey("https://relay.example", cfg)).rejects.toThrow("exit-called");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(saveFullConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT pin when the declaration fails verification", async () => {
+    verifyMock.mockResolvedValue({ ok: false, reason: "signature_invalid" });
+    const cfg = {} as never;
+    await pinRelayKey("https://relay.example", cfg);
+    expect((cfg as { relay_public_key?: string }).relay_public_key).toBeUndefined();
+    expect(saveFullConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("warns without failing when the declaration is unreachable (registration already succeeded)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+    const cfg = {} as never;
+    await expect(pinRelayKey("https://relay.example", cfg)).resolves.toBeUndefined();
+    expect(saveFullConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("re-verified same pin is a quiet no-op (no rewrite)", async () => {
+    verifyMock.mockResolvedValue({ ok: true, anchor: {} });
+    const cfg = { relay_public_key: DECLARATION.relay_public_key } as never;
+    await pinRelayKey("https://relay.example", cfg);
+    expect(saveFullConfigMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -49,6 +49,17 @@ export interface FullConfig {
   default_provider?: PersistedPersonalityProvider;
   default_model?: string;
   /**
+   * The relay operator's Ed25519 public key (hex), PINNED at `motebit
+   * register` after self-consistency verification of the relay's signed
+   * transparency declaration (trust-on-first-use — the same TOFU root
+   * `@motebit/state-export-client` uses). Consumed by the P2P delegation
+   * path (treasury derived FROM this pin, never from a fetched response)
+   * and by receipt/anchor verification. A later mismatch at register
+   * time fails loud: a relay that changes identity must be re-pinned
+   * deliberately, never silently.
+   */
+  relay_public_key?: string;
+  /**
    * Canonical three-mode provider config. Populated on load from legacy fields
    * if missing. Persisted alongside `default_provider` so older CLI versions
    * still understand the file.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -4,6 +4,7 @@ import { deriveSyncEncryptionKey, createSignedToken } from "@motebit/encryption"
 import { connectMcpServers } from "@motebit/mcp-client";
 import { formatBodyAwareness } from "@motebit/ai-core";
 import { providerAcceptsModel } from "@motebit/sdk";
+import { createSolanaWalletRail } from "@motebit/wallet-solana";
 import { parseCliArgs, printHelp, printVersion, printBanner, trimHistory } from "./args.js";
 import type { CliConfig } from "./args.js";
 import { loadFullConfig, extractPersonality, persistMotebitPublicKeys } from "./config.js";
@@ -668,6 +669,22 @@ async function main(): Promise<void> {
       : {}),
   }));
 
+  // The sovereign Solana rail — identity key IS the wallet. Constructed
+  // here (the one place the decrypted seed exists) and injected; the
+  // runtime wraps its payment builder in the money meter at delegation
+  // enable. Without the seed (unsigned/degraded sessions) the rail is
+  // absent and paid delegation degrades to relay-mode honestly.
+  const solanaWallet =
+    privateKeyBytes !== undefined
+      ? createSolanaWalletRail({
+          rpcUrl:
+            config.solanaRpcUrl ??
+            process.env["SOLANA_RPC_URL"] ??
+            "https://api.mainnet-beta.solana.com",
+          identitySeed: privateKeyBytes,
+        })
+      : undefined;
+
   // Create runtime with tools, policy, MCP config
   const { runtime, moteDb } = await createRuntime(
     config,
@@ -676,6 +693,7 @@ async function main(): Promise<void> {
     mcpServers,
     personalityConfig,
     syncEncKey,
+    solanaWallet,
   );
   runtimeRef.current = runtime;
 
@@ -785,6 +803,11 @@ async function main(): Promise<void> {
           // to a no-history worker (else relay-mode). Shared by both the chat
           // (delegate_to_agent) and deterministic (invokeCapability) paths.
           ...(config.payNewAgents ? { acknowledgeNoHistoryRisk: true } : {}),
+          // The PINNED relay operator key (motebit register, TOFU over the
+          // signed transparency declaration). With the sovereign rail
+          // present, this is what unlocks the P2P path — the treasury
+          // address derives FROM the pin, never from a fetched response.
+          ...(fullConfig.relay_public_key ? { relayPublicKey: fullConfig.relay_public_key } : {}),
         };
         runtime.enableInteractiveDelegation(delegationCfg);
         runtime.enableInvokeCapability(delegationCfg);
@@ -798,6 +821,7 @@ async function main(): Promise<void> {
               ? { routingStrategy: config.routingStrategy }
               : {}),
             ...(config.payNewAgents ? { acknowledgeNoHistoryRisk: true } : {}),
+            ...(fullConfig.relay_public_key ? { relayPublicKey: fullConfig.relay_public_key } : {}),
           };
           runtime.enableInteractiveDelegation(delegationCfg);
           runtime.enableInvokeCapability(delegationCfg);

--- a/apps/cli/src/runtime-factory.ts
+++ b/apps/cli/src/runtime-factory.ts
@@ -742,6 +742,7 @@ export async function createRuntime(
   mcpServers: McpServerConfig[],
   personalityConfig?: MotebitPersonalityConfig,
   encKey?: Uint8Array,
+  solanaWallet?: import("@motebit/runtime").RuntimeConfig["solanaWallet"],
 ): Promise<{ runtime: MotebitRuntime; moteDb: MotebitDatabase }> {
   const dbPath = getDbPath(config.dbPath);
   const moteDb = await openMotebitDatabase(dbPath);
@@ -774,6 +775,13 @@ export async function createRuntime(
       // delegator's total bound on every restart). The CLI hosts the
       // canonical local runtime, so it always wires the durable store.
       grantSpendStore: moteDb.grantSpendStore,
+      // The sovereign Solana rail, constructed by the caller from the
+      // decrypted identity seed. Its presence is what makes
+      // delegate_to_agent a REAL money tool: R4 risk hint, late-bound
+      // metering, and the wrapped P2P payment builder all key on it
+      // (enableInteractiveDelegation). Absent ⇒ delegation degrades to
+      // relay-mode honestly.
+      ...(solanaWallet ? { solanaWallet } : {}),
       policy: {
         operatorMode: config.operator,
         pathAllowList: config.allowedPaths,

--- a/apps/cli/src/subcommands/register.ts
+++ b/apps/cli/src/subcommands/register.ts
@@ -11,6 +11,7 @@
  */
 
 import { createSignedToken, secureErase } from "@motebit/encryption";
+import { verifyTransparencyDeclaration } from "@motebit/state-export-client";
 import type { CliConfig } from "../args.js";
 import { loadFullConfig, saveFullConfig } from "../config.js";
 import { loadActiveSigningKey, IdentityKeyError } from "../identity.js";
@@ -139,6 +140,79 @@ export async function handleRegister(config: CliConfig): Promise<void> {
     );
   }
 
+  await pinRelayKey(syncUrl, fullConfig);
+
   // Erase temporary private key bytes
   if (privateKeyBytes) secureErase(privateKeyBytes);
+}
+
+/**
+ * Pin the relay operator's public key (trust-on-first-use). The P2P
+ * delegation path derives the treasury address FROM this pin — never
+ * from a fetched response at payment time — so the pin is the trust
+ * root for every fee leg this motebit ever pays. Source: the relay's
+ * SIGNED transparency declaration, self-consistency-verified via the
+ * canonical `@motebit/state-export-client` verifier (hash + signature
+ * against the key the declaration itself carries).
+ *
+ * Three outcomes, deliberately asymmetric:
+ *  - unpinned + verified  → pin + say so
+ *  - pinned + MISMATCH    → FAIL LOUD (exit 1): a relay that changed
+ *    identity must be re-pinned deliberately (verify out-of-band,
+ *    remove relay_public_key from config, re-register) — never silently
+ *  - fetch/verify failure → warn only; registration already succeeded,
+ *    but P2P delegation stays unavailable until pinned
+ *
+ * Exported for tests.
+ */
+export async function pinRelayKey(
+  syncUrl: string,
+  fullConfig: ReturnType<typeof loadFullConfig>,
+): Promise<void> {
+  // The mismatch exit lives OUTSIDE the try: the catch below exists to
+  // soften NETWORK failures only — a pin mismatch must never be
+  // swallowed by the same net (found by the fail-loud test, whose
+  // simulated exit was caught here in v1).
+  let mismatch: { declared: string; pinned: string } | null = null;
+  try {
+    const declRes = await fetch(`${syncUrl}/.well-known/motebit-transparency.json`);
+    if (!declRes.ok) throw new Error(`HTTP ${declRes.status}`);
+    const declaration = (await declRes.json()) as Parameters<
+      typeof verifyTransparencyDeclaration
+    >[0];
+    const verdict = await verifyTransparencyDeclaration(declaration);
+    if (!verdict.ok) {
+      console.warn(
+        `Warning: relay transparency declaration failed verification (${verdict.reason}) — ` +
+          `relay key NOT pinned; P2P delegation unavailable until it verifies.`,
+      );
+      return;
+    }
+    const declaredKey = declaration.relay_public_key;
+    const pinned = fullConfig.relay_public_key;
+    if (pinned != null && pinned !== "" && pinned !== declaredKey) {
+      mismatch = { declared: declaredKey, pinned };
+    } else if (pinned == null || pinned === "") {
+      fullConfig.relay_public_key = declaredKey;
+      saveFullConfig(fullConfig);
+      console.log(
+        `Pinned relay key ${declaredKey.slice(0, 12)}… (verified signed transparency declaration)`,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `Warning: could not fetch the relay transparency declaration ` +
+        `(${err instanceof Error ? err.message : String(err)}) — relay key not pinned; ` +
+        `re-run \`motebit register\` online to enable P2P delegation.`,
+    );
+  }
+  if (mismatch != null) {
+    console.error(
+      `PIN MISMATCH: this relay now declares key ${mismatch.declared.slice(0, 12)}… but your ` +
+        `config pins ${mismatch.pinned.slice(0, 12)}…. A relay that changes identity must be ` +
+        `re-pinned deliberately: verify out-of-band, then remove relay_public_key from ` +
+        `~/.motebit/config.json and re-run register. Refusing to overwrite.`,
+    );
+    process.exit(1);
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@3.25.76)
+      '@motebit/state-export-client':
+        specifier: workspace:*
+        version: link:../../packages/state-export-client
       '@noble/curves':
         specifier: ^2.2.0
         version: 2.2.0


### PR DESCRIPTION
## What

The last unwired seam of the first-metered-dollar path, found live 2026-07-07 at the founder's first delegation attempt: the CLI never handed the runtime its wallet or a relay key, so `delegate_to_agent` registered as R2 (no rail ⇒ no R4 hint, no late-binding), the P2P branch was unreachable, and paid relay-mode delegation 402'd (`TASK_P2P_PROOF_REQUIRED`) in an approval retry loop. Every layer of the metering stack (#258/#260/#263) was sound — and unreachable.

- **runtime-factory**: `createRuntime` accepts `solanaWallet` (typed as `RuntimeConfig["solanaWallet"]` — the field it feeds) and threads it next to the durable `grantSpendStore`.
- **REPL**: the rail is constructed at the one place the decrypted identity seed exists (`createSolanaWalletRail`; rpcUrl from `--solana-rpc-url` / `SOLANA_RPC_URL` / mainnet default). No seed ⇒ no rail ⇒ delegation degrades to relay-mode honestly.
- **`motebit register` pins the relay key** trust-on-first-use over the relay's SIGNED transparency declaration, verified with the canonical `@motebit/state-export-client` verifier (protocol-primitives rule: consumed, not re-inlined). Three deliberately asymmetric outcomes: pin-on-first-verify / **FAIL LOUD on mismatch** (a relay that changes identity is never silently re-trusted; the exit lives outside the network-softening try — found by the fail-loud test) / warn-only on fetch failure (registration already succeeded; P2P stays unavailable until pinned).
- **Delegation config threads the pinned key** (both construction sites) — the P2P treasury derives FROM the pin, never from a fetched response at payment time.

Pre-flighted live: the prod relay's declaration verifies (key `11c266f2749a…`).

## Verification
Gates 127/127; cli 255 (5 new pin tests incl. the fail-loud mismatch path); typecheck + lint clean; `motebit` minor changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)