### PR TITLE
feat: step 8c — a verified in-scope grant IS the R4 authorizer (+ quit exits explicitly)

### DIFF
--- a/.changeset/quit-exits.md
+++ b/.changeset/quit-exits.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+Typed `quit`/`exit` now exits the process explicitly, mirroring the Ctrl+C path. Previously "Goodbye!" printed but the process survived on any live handle (the sovereign rail's RPC connection, an MCP socket), leaving a zombie REPL holding the terminal.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -948,7 +948,12 @@ async function main(): Promise<void> {
     if (trimmed === "quit" || trimmed === "exit") {
       writeOutput("Goodbye!\n");
       await shutdown();
-      return;
+      // Mirror the SIGINT path: exit explicitly. Waiting for the event
+      // loop to drain leaves a zombie REPL holding the terminal whenever
+      // any live handle remains (the sovereign rail's RPC connection, an
+      // MCP socket) — observed 2026-07-07: "Goodbye!" printed, process
+      // survived, terminal unusable until a new window.
+      process.exit(0);
     }
 
     if (trimmed === "") {

--- a/packages/ai-core/src/loop.ts
+++ b/packages/ai-core/src/loop.ts
@@ -336,7 +336,10 @@ function pixelOmittedDirective(
  * through structural typing.
  */
 export interface LoopPolicyGate {
-  filterTools(tools: ToolDefinition[]): ToolDefinition[];
+  filterTools(
+    tools: ToolDefinition[],
+    ctx?: { verifiedGrant?: unknown; delegationScope?: string },
+  ): ToolDefinition[];
   validate(tool: ToolDefinition, args: Record<string, unknown>, ctx: TurnContext): PolicyDecision;
   classify(tool: ToolDefinition): ToolRiskProfile;
   sanitizeResult(result: ToolResult, toolName: string): ToolResult;
@@ -966,8 +969,6 @@ export async function* runTurnStreaming(
   // 3. Pack context and stream from provider (agentic loop)
   const currentState = stateEngine.getState();
   const rawToolDefs = deps.tools ? deps.tools.list() : undefined;
-  const toolDefs =
-    rawToolDefs && deps.policyGate ? deps.policyGate.filterTools(rawToolDefs) : rawToolDefs;
 
   let turnCtx = deps.policyGate?.createTurnContext(options?.runId);
   if (turnCtx && options?.delegationScope !== undefined) {
@@ -976,6 +977,15 @@ export async function* runTurnStreaming(
   if (turnCtx && options?.verifiedGrant !== undefined) {
     turnCtx = { ...turnCtx, verifiedGrant: options.verifiedGrant };
   }
+
+  // Offering is filtered AFTER the turn context is final: a verified
+  // in-scope grant extends the offering to R4_MONEY (policy-gate
+  // filterTools, decided 2026-07-07) — filtering before the grant landed
+  // in ctx made grant-covered money tools invisible to the model.
+  const toolDefs =
+    rawToolDefs && deps.policyGate
+      ? deps.policyGate.filterTools(rawToolDefs, turnCtx)
+      : rawToolDefs;
 
   const conversationHistory: ConversationMessage[] = [...(options?.conversationHistory ?? [])];
 

--- a/packages/policy/src/__tests__/grant-authorizes-r4.test.ts
+++ b/packages/policy/src/__tests__/grant-authorizes-r4.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Step 8c + grant-aware offering — the disjunct's other half, decided
+ * 2026-07-07 after the first live ceremony found the R4 tool INVISIBLE
+ * to the model (offering filtered by max risk) and the approval band
+ * unmoved by a verified $1 grant. "Money authorization = a signed
+ * verified standing grant OR a live human approval"
+ * (memory-never-confers-authority.md) — this suite pins the OR, and
+ * every bound that keeps it narrow:
+ *   - verified grant + in-scope R4  → offered + auto-executes
+ *   - grant, OUT-of-scope tool      → still filtered / still fenced
+ *   - grantless R4                  → 8b re-raises (unchanged invariant)
+ *   - denyAbove < R4                → hard ceiling; grant NEVER overrides
+ *   - deny-list                     → grant never overrides
+ */
+import { describe, it, expect } from "vitest";
+import { PolicyGate } from "../policy-gate.js";
+import { RiskLevel } from "../index.js";
+import type { ToolDefinition } from "@motebit/sdk";
+
+const MONEY_TOOL = {
+  name: "delegate_to_agent",
+  description: "delegate",
+  parameters: { type: "object", properties: {} },
+  riskHint: { risk: RiskLevel.R4_MONEY },
+} as unknown as ToolDefinition;
+const READ_TOOL = {
+  name: "recall_self",
+  description: "recall",
+  parameters: { type: "object", properties: {} },
+  riskHint: { risk: RiskLevel.R0_READ },
+} as unknown as ToolDefinition;
+
+const GRANT = { grant_id: "g-1", scope: "delegate_to_agent" } as never;
+
+function gate(config: Record<string, unknown> = {}): PolicyGate {
+  return new PolicyGate({ maxRiskLevel: RiskLevel.R3_EXECUTE, ...config } as never);
+}
+
+function grantCtx(g: PolicyGate, scope = "delegate_to_agent") {
+  return { ...g.createTurnContext(), delegationScope: scope, verifiedGrant: GRANT };
+}
+
+describe("offering (filterTools)", () => {
+  it("R4 tool is INVISIBLE without a grant (the ceremony blocker, preserved for grantless turns)", () => {
+    const g = gate();
+    const offered = g.filterTools([MONEY_TOOL, READ_TOOL], g.createTurnContext());
+    expect(offered.map((t) => t.name)).toEqual(["recall_self"]);
+  });
+
+  it("verified in-scope grant makes the R4 tool visible", () => {
+    const g = gate();
+    const offered = g.filterTools([MONEY_TOOL, READ_TOOL], grantCtx(g));
+    expect(offered.map((t) => t.name)).toContain("delegate_to_agent");
+  });
+
+  it("grant does NOT offer an R4 tool outside its scope", () => {
+    const g = gate();
+    const otherMoney = { ...MONEY_TOOL, name: "pay_invoice" } as unknown as ToolDefinition;
+    const offered = g.filterTools([otherMoney], grantCtx(g, "delegate_to_agent"));
+    expect(offered).toHaveLength(0);
+  });
+
+  it("denyAbove is a hard ceiling the grant never lifts", () => {
+    const g = gate({ requireApprovalAbove: RiskLevel.R1_DRAFT, denyAbove: RiskLevel.R3_EXECUTE });
+    const offered = g.filterTools([MONEY_TOOL], grantCtx(g));
+    expect(offered).toHaveLength(0);
+  });
+
+  it("deny-list beats the grant", () => {
+    const g = gate({ toolDenyList: ["delegate_to_agent"] });
+    const offered = g.filterTools([MONEY_TOOL], grantCtx(g));
+    expect(offered).toHaveLength(0);
+  });
+});
+
+describe("approval (validate step 8c)", () => {
+  it("verified in-scope grant auto-executes R4 — no human prompt", () => {
+    const g = gate({ requireApprovalAbove: RiskLevel.R1_DRAFT, denyAbove: RiskLevel.R4_MONEY });
+    const d = g.validate(MONEY_TOOL, {}, grantCtx(g));
+    expect(d.allowed).toBe(true);
+    expect(d.requiresApproval).toBe(false);
+  });
+
+  it("grantless R4 still requires approval (8b unchanged)", () => {
+    const g = gate({ requireApprovalAbove: RiskLevel.R1_DRAFT, denyAbove: RiskLevel.R4_MONEY });
+    const d = g.validate(MONEY_TOOL, {}, g.createTurnContext());
+    expect(d.requiresApproval).toBe(true);
+  });
+
+  it("grant with a DIFFERENT scope does not clear the tool (fence at step 2)", () => {
+    const g = gate({ requireApprovalAbove: RiskLevel.R1_DRAFT, denyAbove: RiskLevel.R4_MONEY });
+    const d = g.validate(MONEY_TOOL, {}, grantCtx(g, "pay_invoice"));
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toMatch(/outside delegated scope/);
+  });
+
+  it("denyAbove < R4 hard-denies even WITH a verified grant", () => {
+    const g = gate({ requireApprovalAbove: RiskLevel.R1_DRAFT, denyAbove: RiskLevel.R3_EXECUTE });
+    const d = g.validate(MONEY_TOOL, {}, grantCtx(g));
+    expect(d.allowed).toBe(false);
+    expect(d.requiresApproval).toBe(false);
+  });
+});

--- a/packages/policy/src/policy-gate.ts
+++ b/packages/policy/src/policy-gate.ts
@@ -175,7 +175,10 @@ export class PolicyGate {
    * Filter tools to only those visible in the current mode.
    * This is what gets sent to the model in the ContextPack.
    */
-  filterTools(tools: ToolDefinition[]): ToolDefinition[] {
+  filterTools(
+    tools: ToolDefinition[],
+    ctx?: Pick<TurnContext, "verifiedGrant" | "delegationScope">,
+  ): ToolDefinition[] {
     const maxRisk = this.getEffectiveMaxRisk();
 
     return tools.filter((tool) => {
@@ -187,8 +190,39 @@ export class PolicyGate {
 
       // Risk check
       const profile = this.classify(tool);
-      return isToolAllowed(profile, maxRisk);
+      if (isToolAllowed(profile, maxRisk)) return true;
+
+      // Standing-authority extension of the OFFERING (decided 2026-07-07,
+      // the ceremony blocker: with the payment rail wired,
+      // delegate_to_agent classifies R4_MONEY and default governance
+      // filtered it out of the model's tool list entirely — the signed
+      // grant changed nothing about what could even be SEEN). A turn
+      // carrying a VERIFIED grant offers grant-covered tools up to
+      // R4_MONEY. Bounds that still hold: deny/allow lists above,
+      // `denyAbove` (a hard ceiling the grant never overrides), the
+      // scope fence at validate step 2, and the meter at the rail.
+      // Doctrine: docs/doctrine/memory-never-confers-authority.md —
+      // "a signed grant or a live human tap"; the grant IS the signed
+      // artifact.
+      return (
+        ctx?.verifiedGrant != null &&
+        this.grantCoversTool(ctx, tool.name) &&
+        profile.risk <= RiskLevel.R4_MONEY &&
+        (this.config.denyAbove === undefined || profile.risk <= this.config.denyAbove)
+      );
     });
+  }
+
+  /**
+   * Is `toolName` inside the turn's delegated scope? The scope string is
+   * set BY the runtime FROM the verified grant's signed `scope` field at
+   * presentation (never model output) — same set semantics as the
+   * validate-step-2 fence.
+   */
+  private grantCoversTool(ctx: Pick<TurnContext, "delegationScope">, toolName: string): boolean {
+    if (ctx.delegationScope === undefined) return false;
+    const scopeSet = parseScopeSet(ctx.delegationScope);
+    return scopeSet.has("*") || scopeSet.has(toolName);
   }
 
   // === Validation ===
@@ -399,6 +433,28 @@ export class PolicyGate {
     // Gate: check-money-authority.
     if (profile.risk >= RiskLevel.R4_MONEY && !needsApproval && ctx.verifiedGrant == null) {
       needsApproval = true;
+    }
+
+    // 8c. The disjunct's other half (decided 2026-07-07): a VERIFIED
+    // in-scope standing grant IS the R4 authorizer — "a signed grant or
+    // a live human tap" (memory-never-confers-authority.md), implemented
+    // as an OR at last. Strictly narrower than every lowering path 8b
+    // subordinates: it requires the cryptographically verified grant
+    // (produced only by the dispatch-layer verifier from signed
+    // artifacts) AND the tool inside the grant's SIGNED scope. It runs
+    // AFTER the denyAbove hard-deny (which already returned — the grant
+    // never overrides a hard ceiling) and cannot be reached by trust
+    // levels, memory, or config alone. Enforcement downstream is
+    // unchanged: the blast-radius meter + rail wrapper bound every
+    // spend to the grant's signed ceiling; the tick nonce bounds
+    // frequency; revocation is terminal.
+    if (
+      needsApproval &&
+      profile.risk >= RiskLevel.R4_MONEY &&
+      ctx.verifiedGrant != null &&
+      this.grantCoversTool(ctx, tool.name)
+    ) {
+      needsApproval = false;
     }
 
     // 9. Multi-party approval quorum — attach quorum metadata when configured


### PR DESCRIPTION
## What

The final semantic of the standing-delegation arc, decided by the founder live 2026-07-07: with the rail wired (#268), `delegate_to_agent` correctly classified R4_MONEY — and was **invisible to the model** (offering filtered by max risk) while the approval band ignored the verified grant (8b only re-raises). The doctrine sentence "money authorization = a signed verified standing grant OR a live human approval" had one disjunct implemented.

- `filterTools(tools, ctx?)`: a turn carrying a VERIFIED grant offers grant-covered tools up to R4_MONEY. Deny/allow lists win; **`denyAbove` is a hard ceiling the grant never lifts** (live-proven: under the `balanced` preset, R4 stayed structurally impossible until the founder deliberately flipped his governance posture to `autonomous`).
- Step 8c (after 8b, before quorum): approval clears for R4 only with `ctx.verifiedGrant` present AND the tool inside the grant's SIGNED scope. 8b unchanged; no config can disable either branch.
- ai-core loop: turn context assembled BEFORE the offering filter and passed through.
- Plus: typed `quit`/`exit` now exits explicitly (mirror of SIGINT) — a zombie REPL held the founder's terminal whenever any live handle (the rail's RPC connection) remained.

## Live verification — the first metered payment and its refusal
Executed by the founder on prod, same night:
- **Payment**: atomic 3-leg mainnet tx `2RJg2Yzj…baNS` — worker +0.050000 USDC, treasury fee leg +0.002632, delegator −0.052632 — reconciling to the micro with the durable meter row (`lifetime_spent_micro=52632`, count 1, tick nonce armed). No approval prompt; the signed grant was the authorizer.
- **Refusal**: a second delegation in the same hourly tick was declined BEFORE broadcast — meter row and on-chain balance byte-identical after.

policy 473 (9 new) / ai-core 557 / cli 255; `check-money-authority` green; gates 127/127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)