### PR TITLE
feat: grant pre-flight — the refusal that teaches, in the product

### DIFF
--- a/.changeset/grant-preflight.md
+++ b/.changeset/grant-preflight.md
@@ -1,0 +1,5 @@
+---
+"motebit": minor
+---
+
+Grant pre-flight — the refusal that teaches, applied to the product. `motebit --grant <id>` now walks the entire authorization chain the first money turn will need (grant artifact → due tick → governance posture → payment rail → relay pin → working capital) and prints either one calm armed-line or each blocker with its exact remedy — the gate-repair-instructions contract extended from CI to the sovereign user. Born from the first-metered-dollar ceremony (2026-07-06/07), where five correct-but-silent boundary refusals cost a night of debugging that a launch-time verdict would have collapsed into minutes. Advisory only: the verifier, gate, and meter remain the authorities — the pre-flight predicts, the boundary decides.

--- a/apps/cli/src/__tests__/grant-preflight.test.ts
+++ b/apps/cli/src/__tests__/grant-preflight.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Grant pre-flight — the refusal that teaches, applied to the product.
+ * Each check mirrors a REAL silent boundary from the first-metered-dollar
+ * ceremony (2026-07-06/07); the suite pins that every blocker carries a
+ * remedy (the repair-instruction contract) and that the pre-flight is
+ * advisory (it never throws, never blocks).
+ */
+import { describe, it, expect } from "vitest";
+import { preflightGrant, renderPreflight } from "../grant-preflight.js";
+import type { StoredGrant } from "../subcommands/grant.js";
+
+const NOW = 1_783_400_000_000;
+const HOUR = 3_600_000;
+
+function stored(overrides: Partial<StoredGrant> = {}): StoredGrant {
+  return {
+    grant: {
+      grant_id: "019f0000-0000-7000-8000-000000000000",
+      scope: "delegate_to_agent",
+      expires_at: NOW + 7 * 24 * HOUR,
+    },
+    ticks: [{ issued_at: NOW - HOUR, not_before: NOW - HOUR, expires_at: NOW + HOUR }],
+    ...overrides,
+  } as never;
+}
+
+const ARMED_CONFIG = {
+  governance: { approvalPreset: "autonomous" },
+  relay_public_key: "11c266f2749a00aa",
+} as never;
+
+describe("preflightGrant", () => {
+  it("all-green chain reports armed", async () => {
+    const pf = await preflightGrant({
+      stored: stored(),
+      now: NOW,
+      fullConfig: ARMED_CONFIG,
+      hasRail: true,
+      getBalanceMicro: async () => 1_578_590n,
+    });
+    expect(pf.armed).toBe(true);
+    expect(pf.checks.every((c) => c.ok)).toBe(true);
+    const [line] = renderPreflight(pf, (s) => s);
+    expect(line).toContain("grant armed");
+  });
+
+  it("every blocker carries a remedy — the repair-instruction contract", async () => {
+    const pf = await preflightGrant({
+      stored: stored({ ticks: [] }), // no tick
+      now: NOW,
+      fullConfig: { governance: { approvalPreset: "balanced" } } as never, // denies R4, no pin
+      hasRail: false, // no rail
+      getBalanceMicro: async () => 0n, // unfunded
+    });
+    expect(pf.armed).toBe(false);
+    const failing = pf.checks.filter((c) => !c.ok);
+    expect(failing.length).toBeGreaterThanOrEqual(4);
+    for (const c of failing) {
+      expect(c.remedy, `check "${c.name}" must teach its remedy`).toBeTruthy();
+    }
+    const lines = renderPreflight(pf, (s) => s).join("\n");
+    expect(lines).toContain("NOT armed");
+    expect(lines).toContain("autonomous"); // the exact governance fix
+    expect(lines).toContain("motebit register"); // the exact pin fix
+  });
+
+  it("balanced preset is named as the R4 blocker (the ceremony's silent boundary)", async () => {
+    const pf = await preflightGrant({
+      stored: stored(),
+      now: NOW,
+      fullConfig: {
+        relay_public_key: "11c266f2749a00aa",
+        governance: { approvalPreset: "balanced" },
+      } as never,
+      hasRail: true,
+    });
+    const gov = pf.checks.find((c) => c.name === "governance")!;
+    expect(gov.ok).toBe(false);
+    expect(gov.remedy).toContain("hard ceiling");
+  });
+
+  it("undue tick names the unlock time — the schedule is the cadence", async () => {
+    const pf = await preflightGrant({
+      stored: stored({
+        ticks: [{ issued_at: NOW, not_before: NOW + HOUR, expires_at: NOW + 2 * HOUR }],
+      } as never),
+      now: NOW,
+      fullConfig: ARMED_CONFIG,
+      hasRail: true,
+    });
+    const tick = pf.checks.find((c) => c.name === "tick")!;
+    expect(tick.ok).toBe(false);
+    expect(tick.remedy).toContain("next tick unlocks");
+  });
+
+  it("revoked grant is terminal and says so", async () => {
+    const pf = await preflightGrant({
+      stored: stored({ revocation: { revoked_at: NOW } } as never),
+      now: NOW,
+      fullConfig: ARMED_CONFIG,
+      hasRail: true,
+    });
+    const g = pf.checks.find((c) => c.name === "grant")!;
+    expect(g.ok).toBe(false);
+    expect(g.detail).toContain("REVOKED");
+    expect(g.remedy).toContain("terminal");
+  });
+
+  it("RPC failure on the balance check soft-passes — advisory, never blocking", async () => {
+    const pf = await preflightGrant({
+      stored: stored(),
+      now: NOW,
+      fullConfig: ARMED_CONFIG,
+      hasRail: true,
+      getBalanceMicro: async () => {
+        throw new Error("rpc down");
+      },
+    });
+    expect(pf.armed).toBe(true);
+    expect(pf.checks.find((c) => c.name === "wallet")!.detail).toContain("meter still bounds");
+  });
+});

--- a/apps/cli/src/grant-preflight.ts
+++ b/apps/cli/src/grant-preflight.ts
@@ -1,0 +1,180 @@
+/**
+ * Grant pre-flight — the refusal that teaches, applied to the product.
+ *
+ * Born from the first-metered-dollar ceremony (2026-07-06/07): the
+ * founder walked `motebit --grant` into five silent boundaries in one
+ * night — unwired rail, unpinned relay key, a governance preset that
+ * hard-denies R4, an unfunded wallet, an undue tick. Every refusal was
+ * CORRECT and every refusal was ILLEGIBLE: the model said "done", the
+ * banner promised "R4 money clears within its signed ceiling" while
+ * governance made that structurally impossible, and the truth lived in
+ * an audit table only a debugger read.
+ *
+ * The repo already holds the doctrine for this — gate-repair-instructions:
+ * a failing gate must emit the canonical source and the exact fix. This
+ * module extends that contract from CI to the sovereign user: at grant
+ * presentation, walk the ENTIRE authorization chain the turn will need
+ * (artifact → tick → governance → rail → relay pin → working capital)
+ * and print either one calm armed-line or each blocker with its exact
+ * remedy. The checks are advisory legibility — the runtime's verifier,
+ * gate, and meter remain the only authorities (a pre-flight pass never
+ * grants anything; a pre-flight failure never blocks the session; it
+ * predicts, the boundary decides).
+ */
+
+import { APPROVAL_PRESET_CONFIGS } from "@motebit/sdk";
+import type { FullConfig } from "./config.js";
+import { selectDueTick, type StoredGrant } from "./subcommands/grant.js";
+
+export interface PreflightCheck {
+  name: string;
+  ok: boolean;
+  detail: string;
+  /** The exact next step when not ok — the repair-instruction contract. */
+  remedy?: string;
+}
+
+export interface GrantPreflight {
+  armed: boolean;
+  checks: PreflightCheck[];
+}
+
+const R4 = 4;
+
+export async function preflightGrant(deps: {
+  stored: StoredGrant;
+  now: number;
+  fullConfig: FullConfig;
+  /** Whether the sovereign rail was constructed this session (seed decrypted). */
+  hasRail: boolean;
+  /** Live USDC balance in micro-units; undefined = RPC unavailable (soft-skip). */
+  getBalanceMicro?: () => Promise<bigint>;
+}): Promise<GrantPreflight> {
+  const { stored, now, fullConfig, hasRail } = deps;
+  const checks: PreflightCheck[] = [];
+
+  // 1. Grant artifact — revoked / expired are terminal states.
+  if (stored.revocation != null) {
+    checks.push({
+      name: "grant",
+      ok: false,
+      detail: `grant ${stored.grant.grant_id.slice(0, 8)}… is REVOKED`,
+      remedy: "revocation is terminal — mint a new grant: motebit grant create …",
+    });
+  } else if (stored.grant.expires_at <= now) {
+    checks.push({
+      name: "grant",
+      ok: false,
+      detail: `grant expired ${new Date(stored.grant.expires_at).toISOString()}`,
+      remedy: "mint a new grant: motebit grant create …",
+    });
+  } else {
+    checks.push({
+      name: "grant",
+      ok: true,
+      detail: `scope=${stored.grant.scope}, expires ${new Date(stored.grant.expires_at).toISOString()}`,
+    });
+  }
+
+  // 2. Tick due — the pre-minted schedule IS the cadence.
+  const due = selectDueTick(stored, now);
+  if (due != null) {
+    checks.push({ name: "tick", ok: true, detail: "a pre-minted tick is due now" });
+  } else {
+    const next = stored.ticks
+      .map((t) => t.not_before ?? t.issued_at)
+      .filter((t) => t > now)
+      .sort((a, b) => a - b)[0];
+    checks.push({
+      name: "tick",
+      ok: false,
+      detail: "no tick is due in the current slot",
+      remedy:
+        next != null
+          ? `next tick unlocks ${new Date(next).toISOString()} — the signed schedule is the cadence; waiting is the remedy`
+          : "all ticks consumed or expired — mint a new grant",
+    });
+  }
+
+  // 3. Governance posture — denyAbove is a hard ceiling no grant overrides.
+  const presetName = fullConfig.governance?.approvalPreset ?? "balanced";
+  const preset = APPROVAL_PRESET_CONFIGS[presetName];
+  const permitsMoney = preset != null && preset.denyAbove >= R4;
+  checks.push({
+    name: "governance",
+    ok: permitsMoney,
+    detail: `preset "${presetName}" (denyAbove=${preset?.denyAbove ?? "?"})`,
+    ...(permitsMoney
+      ? {}
+      : {
+          remedy:
+            `your posture hard-denies R4 money — the grant never overrides a hard ceiling. ` +
+            `To permit governed money: set governance.approvalPreset to "autonomous" in ~/.motebit/config.json`,
+        }),
+  });
+
+  // 4. Sovereign rail — no seed, no payments.
+  checks.push({
+    name: "rail",
+    ok: hasRail,
+    detail: hasRail ? "sovereign Solana rail constructed" : "no payment rail this session",
+    ...(hasRail
+      ? {}
+      : { remedy: "the identity seed was not decrypted — relaunch and enter the passphrase" }),
+  });
+
+  // 5. Relay pin — the P2P treasury derives FROM the pin.
+  const pinned = fullConfig.relay_public_key;
+  checks.push({
+    name: "relay-pin",
+    ok: pinned != null && pinned !== "",
+    detail:
+      pinned != null && pinned !== ""
+        ? `relay key pinned (${pinned.slice(0, 12)}…)`
+        : "relay operator key not pinned — P2P payment path unavailable",
+    ...(pinned != null && pinned !== ""
+      ? {}
+      : { remedy: "run `motebit register` online to pin the relay's verified key" }),
+  });
+
+  // 6. Working capital — soft check; quotes vary, the meter decides.
+  if (deps.getBalanceMicro != null) {
+    try {
+      const micro = await deps.getBalanceMicro();
+      const usd = Number(micro) / 1_000_000;
+      checks.push({
+        name: "wallet",
+        ok: micro > 0n,
+        detail: `${usd.toFixed(2)} USDC working capital`,
+        ...(micro > 0n
+          ? {}
+          : {
+              remedy:
+                "fund with USDC on the SOLANA network, or convert gas: motebit wallet swap <sol-amount>",
+            }),
+      });
+    } catch {
+      checks.push({
+        name: "wallet",
+        ok: true,
+        detail: "balance unavailable (RPC) — the meter still bounds every spend",
+      });
+    }
+  }
+
+  return { armed: checks.every((c) => c.ok), checks };
+}
+
+/** Render the verdict in the calm register: one line armed, blockers taught. */
+export function renderPreflight(pf: GrantPreflight, dim: (s: string) => string): string[] {
+  if (pf.armed) {
+    const brief = pf.checks.map((c) => c.detail.split(",")[0]).join(" · ");
+    return [dim(`  [grant armed — ${brief}]`)];
+  }
+  const lines = [dim(`  [grant presented, NOT armed — the boundary will refuse:]`)];
+  for (const c of pf.checks.filter((c) => !c.ok)) {
+    lines.push(dim(`    ✗ ${c.name}: ${c.detail}`));
+    if (c.remedy != null) lines.push(dim(`      → ${c.remedy}`));
+  }
+  return lines;
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -5,6 +5,7 @@ import { connectMcpServers } from "@motebit/mcp-client";
 import { formatBodyAwareness } from "@motebit/ai-core";
 import { providerAcceptsModel } from "@motebit/sdk";
 import { createSolanaWalletRail } from "@motebit/wallet-solana";
+import { preflightGrant, renderPreflight } from "./grant-preflight.js";
 import { parseCliArgs, printHelp, printVersion, printBanner, trimHistory } from "./args.js";
 import type { CliConfig } from "./args.js";
 import { loadFullConfig, extractPersonality, persistMotebitPublicKeys } from "./config.js";
@@ -47,6 +48,7 @@ import {
   handleGrantShow,
   handleGrantRevoke,
   createGrantPresenter,
+  loadStoredGrant,
   handleGoalAdd,
   handleGoalList,
   handleGoalOutcomes,
@@ -933,6 +935,21 @@ async function main(): Promise<void> {
         `  [standing grant ${grantPresenter.grantId} presented per turn — R4 money clears only within its signed ceiling]`,
       ),
     );
+    // Pre-flight: walk the whole authorization chain the first money turn
+    // will need and TEACH any blocker now (gate-repair-instructions
+    // extended to the product). Advisory only — the verifier/gate/meter
+    // remain the authorities; this predicts, the boundary decides.
+    const storedForPreflight = loadStoredGrant(grantPresenter.grantId);
+    if (storedForPreflight != null) {
+      const pf = await preflightGrant({
+        stored: storedForPreflight,
+        now: Date.now(),
+        fullConfig,
+        hasRail: solanaWallet !== undefined,
+        ...(solanaWallet !== undefined ? { getBalanceMicro: () => solanaWallet.getBalance() } : {}),
+      });
+      for (const line of renderPreflight(pf, dim)) console.log(line);
+    }
   }
 
   const prompt = (): void => {

--- a/apps/cli/src/subcommands/index.ts
+++ b/apps/cli/src/subcommands/index.ts
@@ -45,6 +45,7 @@ export {
   handleGrantShow,
   handleGrantRevoke,
   createGrantPresenter,
+  loadStoredGrant,
 } from "./grant.js";
 export { handleId } from "./id.js";
 export { handleInit } from "./init.js";

--- a/packages/render-engine/src/spec.ts
+++ b/packages/render-engine/src/spec.ts
@@ -630,7 +630,13 @@ export const EMBODIMENT_MODE_CONTRACTS = {
     source: "peer-receipt",
     consent: "signed-delegation",
     sensitivity: "tier-bounded-by-source",
-    lifecycleDefaults: ["resting", "detached"],
+    // "dissolving" added 2026-07-07: a completed delegation dissolves —
+    // dissolution is one of the slab's three end states (dissolve /
+    // rest / detach, docs/doctrine/motebit-computer.md) and the FIRST
+    // live metered delegation logged the contract warning on every
+    // completion (the warning's own "contract-widening candidate" was
+    // right). A peer's finished work has no claim to rest on the slab.
+    lifecycleDefaults: ["dissolving", "resting", "detached"],
   },
 } as const satisfies Record<EmbodimentMode, EmbodimentModeContract>;
 

--- a/packages/runtime/src/__tests__/slab-controller.test.ts
+++ b/packages/runtime/src/__tests__/slab-controller.test.ts
@@ -626,20 +626,33 @@ describe("SlabController — mode contract anomaly detection", () => {
     expect(contractWarns).toHaveLength(0);
   });
 
-  it("warns on peer_viewport dissolution (typical lifecycle is rest → detach)", () => {
+  it("peer_viewport dissolution is contract-legal — a completed delegation dissolves (widened 2026-07-07)", () => {
+    // The first live metered delegation logged this exact warning on
+    // every completion; the warning's own "contract-widening candidate"
+    // hypothesis was correct (dissolve is one of the slab's three end
+    // states — motebit-computer.md). The anomaly detector's coverage
+    // moves to a mode whose contract still excludes dissolution below.
     const { ctrl, warns } = makeWithSpy();
     ctrl.openItem({ id: "p1", kind: "delegation", payload: {} }); // delegation → peer_viewport mode
-    ctrl.dismissItem("p1"); // → dissolving (force-dissolve via dismiss bypasses detach policy)
+    ctrl.dismissItem("p1"); // → dissolving
+    const contractWarns = warns.filter((w) => w.message.includes("contract lifecycleDefaults"));
+    expect(contractWarns).toHaveLength(0);
+  });
+
+  it("warns on virtual_browser dissolution (its contract admits rest → detach only)", () => {
+    const { ctrl, warns } = makeWithSpy();
+    ctrl.openItem({ id: "p1v", kind: "fetch", mode: "virtual_browser", payload: {} });
+    ctrl.dismissItem("p1v"); // → dissolving, outside virtual_browser's defaults
     const contractWarns = warns.filter((w) => w.message.includes("contract lifecycleDefaults"));
     expect(contractWarns).toHaveLength(1);
     const warning = contractWarns[0]!;
-    expect(warning.message).toContain("peer_viewport");
+    expect(warning.message).toContain("virtual_browser");
     expect(warning.message).toContain("dissolving");
     expect(warning.context).toMatchObject({
-      itemId: "p1",
-      mode: "peer_viewport",
+      itemId: "p1v",
+      mode: "virtual_browser",
       phase: "dissolving",
-      kind: "delegation",
+      kind: "fetch",
     });
     expect(warning.context?.allowedDefaults).toEqual(["resting", "detached"]);
   });
@@ -686,10 +699,10 @@ describe("SlabController — mode contract anomaly detection", () => {
     // phases the mode actually admits per contract — without it, the
     // warning is "you did something wrong" without context.
     const { ctrl, warns } = makeWithSpy();
-    ctrl.openItem({ id: "p3", kind: "delegation", payload: {} });
+    ctrl.openItem({ id: "p3", kind: "fetch", mode: "virtual_browser", payload: {} });
     ctrl.dismissItem("p3");
     const warning = warns.find((w) => w.message.includes("contract lifecycleDefaults"));
     expect(warning?.context?.allowedDefaults).toEqual(["resting", "detached"]);
-    expect(warning?.context?.mode).toBe("peer_viewport");
+    expect(warning?.context?.mode).toBe("virtual_browser");
   });
 });


### PR DESCRIPTION
Bird's-eye synthesis of the first-metered-dollar ceremony: all five of the night's defects were ONE defect — boundaries that refused correctly and silently. `grant-preflight.ts` walks the full authorization chain at `motebit --grant` presentation (grant → tick → governance → rail → pin → capital) and prints one calm armed-line or each blocker WITH its exact remedy (gate-repair-instructions extended from CI to the sovereign user). Advisory by construction: the verifier/gate/meter remain the authorities. Plus: `peer_viewport.lifecycleDefaults` gains `"dissolving"` (a completed delegation dissolves; the slab warning's own "contract-widening candidate" was right).

cli 261 (6 new) / render-engine 457; gates 127/127; `motebit` minor changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)