### PR TITLE
feat: AuthorityDelta — every refusal a typed, owner-facing repair instruction

### DIFF
--- a/.changeset/authority-delta.md
+++ b/.changeset/authority-delta.md
@@ -1,0 +1,6 @@
+---
+"@motebit/protocol": minor
+"motebit": minor
+---
+
+`AuthorityDelta` — every refusal a typed, owner-facing repair instruction. The protocol gains the closed residual type (missing scope, required-vs-posture risk, requires-verified-grant, spend overage in micro, window unlock time, quorum shortfall, terminal states) with two load-bearing invariants documented on the type: ASYMMETRY (owner surfaces get precision; model-visible channels carry only the coarse reason — a precise residual is a boundary oracle aimed at the one party who can mint the difference) and PREDICTOR-NEVER-AUTHORITY (the delta describes refusals; the gate and meter remain the sole enforcers). `PolicyDecision.missing_authority` extends additively. The policy gate populates it at every deny/raise site from a single producer module; the blast-radius evaluator emits exact spend overages and window-unlock times; the ai-core tool_status stream chunk (surface channel) carries it while the conversation-history push stays coarse — pinned by a leak test over every context pack the model receives; the CLI renders the exact repair owner-side. Constructors, not an algebra: composition helpers wait for a third consumer needing to compose authorities, per rule-of-three.

--- a/apps/cli/src/__tests__/authority-delta-render.test.ts
+++ b/apps/cli/src/__tests__/authority-delta-render.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Owner-side AuthorityDelta rendering — every residual class produces a
+ * repair line (the gate-repair-instructions contract; sibling of the
+ * grant pre-flight renderer).
+ */
+import { describe, it, expect } from "vitest";
+import { renderAuthorityDelta } from "../authority-delta-render.js";
+import { RiskLevel } from "@motebit/sdk";
+
+describe("renderAuthorityDelta", () => {
+  it("scope residual names the missing scope and the mint command", () => {
+    const out = renderAuthorityDelta("delegate_to_agent", {
+      missing_scope: ["delegate_to_agent"],
+    }).join("\n");
+    expect(out).toContain("does not cover delegate_to_agent");
+    expect(out).toContain("--scope delegate_to_agent");
+  });
+
+  it("grant-required residual teaches the grant-or-tap disjunction", () => {
+    const out = renderAuthorityDelta("delegate_to_agent", {
+      required_risk: RiskLevel.R4_MONEY,
+      requires_verified_grant: true,
+    }).join("\n");
+    expect(out).toContain("verified grant or your live approval");
+    expect(out).toContain("motebit grant create");
+  });
+
+  it("posture residual names both risk levels and the deliberate change", () => {
+    const out = renderAuthorityDelta("delegate_to_agent", {
+      required_risk: RiskLevel.R4_MONEY,
+      posture_ceiling: RiskLevel.R3_EXECUTE,
+    }).join("\n");
+    expect(out).toContain("R4_MONEY");
+    expect(out).toContain("R3_EXECUTE");
+    expect(out).toContain("approvalPreset");
+  });
+
+  it("spend + window residuals render dollars and the unlock time", () => {
+    const out = renderAuthorityDelta("delegate_to_agent", {
+      spend_overage_micro: 400_000,
+      not_before: 1_783_425_600_000,
+    }).join("\n");
+    expect(out).toContain("$0.4000");
+    expect(out).toContain(new Date(1_783_425_600_000).toISOString());
+  });
+
+  it("terminal residual short-circuits to re-mint", () => {
+    const out = renderAuthorityDelta("delegate_to_agent", { terminal: "revoked" }).join("\n");
+    expect(out).toContain("revoked — terminal");
+    expect(out).toContain("grant create");
+  });
+});

--- a/apps/cli/src/authority-delta-render.ts
+++ b/apps/cli/src/authority-delta-render.ts
@@ -1,0 +1,55 @@
+/**
+ * Owner-side rendering of `AuthorityDelta` — every refusal a typed
+ * repair instruction (the gate-repair-instructions contract in the
+ * product; sibling of grant-preflight's renderer). This is the OWNER
+ * half of the asymmetry: the model saw only the coarse reason; the
+ * sovereign sees exactly what's missing and how to mint it.
+ */
+
+import type { AuthorityDelta } from "@motebit/sdk";
+import { RiskLevel } from "@motebit/sdk";
+
+export function renderAuthorityDelta(toolName: string, delta: AuthorityDelta): string[] {
+  const lines: string[] = [`  [${toolName} refused — missing authority:]`];
+
+  if (delta.terminal != null) {
+    lines.push(
+      `    ✗ grant ${delta.terminal} — terminal; mint a new grant: motebit grant create …`,
+    );
+    return lines;
+  }
+  if (delta.missing_scope != null && delta.missing_scope.length > 0) {
+    lines.push(
+      `    ✗ scope: grant does not cover ${delta.missing_scope.join(", ")}`,
+      `      → mint a grant with --scope ${delta.missing_scope.join(",")}`,
+    );
+  }
+  if (delta.requires_verified_grant === true) {
+    lines.push(
+      `    ✗ standing authority: ${riskName(delta.required_risk)} needs a verified grant or your live approval`,
+      `      → motebit grant create --scope ${toolName} …, then relaunch with --grant <id>`,
+    );
+  } else if (delta.required_risk != null && delta.posture_ceiling != null) {
+    lines.push(
+      `    ✗ posture: action is ${riskName(delta.required_risk)}, your governance ceiling is ${riskName(delta.posture_ceiling)}`,
+      `      → a deliberate posture change permits it: governance.approvalPreset in ~/.motebit/config.json`,
+    );
+  }
+  if (delta.spend_overage_micro != null) {
+    lines.push(
+      `    ✗ spend: exceeds remaining ceiling by $${(delta.spend_overage_micro / 1_000_000).toFixed(4)}`,
+      `      → a new grant with the difference covers it`,
+    );
+  }
+  if (delta.not_before != null) {
+    lines.push(`    ✗ window: headroom returns ${new Date(delta.not_before).toISOString()}`);
+  }
+  if (delta.quorum_shortfall != null) {
+    lines.push(`    ✗ quorum: ${delta.quorum_shortfall} more approval(s) required`);
+  }
+  return lines;
+}
+
+function riskName(risk: RiskLevel | undefined): string {
+  return risk != null ? RiskLevel[risk] : "this action";
+}

--- a/apps/cli/src/stream.ts
+++ b/apps/cli/src/stream.ts
@@ -5,6 +5,7 @@ import { formatBodyAwareness } from "@motebit/ai-core";
 import { action, meta, warn, dim, prompt as promptColor } from "./colors.js";
 import { writeOutput, askQuestion } from "./terminal.js";
 import { archiveReceipt, renderReceipt } from "./receipt.js";
+import { renderAuthorityDelta } from "./authority-delta-render.js";
 import type { VoiceController } from "./voice.js";
 
 // Animated dots: cycles .  → .. → ... while a tool call is in flight.
@@ -44,6 +45,19 @@ export async function consumeStream(
         break;
 
       case "tool_status":
+        // Owner-facing authority residual — render the exact repair even
+        // for delegation tools (the delta rides only this surface channel;
+        // the model saw the coarse reason). See AuthorityDelta invariants.
+        if (chunk.status === "done" && chunk.missing_authority != null) {
+          if (stopAnimation) {
+            stopAnimation();
+            stopAnimation = null;
+          }
+          for (const line of renderAuthorityDelta(chunk.name, chunk.missing_authority)) {
+            writeOutput(meta(line) + "\n");
+          }
+          break;
+        }
         // Delegation tools are announced by delegation_start/delegation_complete instead
         if (chunk.name === "delegate_to_agent") break;
         if (chunk.status === "calling") {

--- a/packages/ai-core/src/__tests__/loop.test.ts
+++ b/packages/ai-core/src/__tests__/loop.test.ts
@@ -2321,3 +2321,146 @@ describe("late-bound money metering (moneyBinding: 'late')", () => {
     expect(result.toolCallsSucceeded).toBe(0);
   });
 });
+
+describe("AuthorityDelta asymmetry — owner channel precise, model channel coarse", () => {
+  it("a denial's missing_authority rides the tool_status chunk and NEVER reaches the provider", async () => {
+    // The security invariant of @motebit/protocol's AuthorityDelta: a
+    // precise residual is a boundary oracle ("you need exactly X and
+    // $0.40 more") — a perfectly optimized social-engineering script
+    // aimed at the one party who can mint the difference. The surface
+    // chunk (owner-facing) carries the delta; the conversation history
+    // the model sees carries only the coarse reason string.
+    const denyingGate = {
+      filterTools: (t: ToolDefinition[]) => t,
+      createTurnContext: () => ({
+        turnId: "t",
+        toolCallCount: 0,
+        turnStartMs: 0,
+        costAccumulated: 0,
+      }),
+      validate: (tool: ToolDefinition) =>
+        tool.name === "send_money"
+          ? {
+              allowed: false,
+              requiresApproval: false,
+              reason: "outside delegated scope",
+              missing_authority: { missing_scope: ["send_money"], spend_overage_micro: 400_000 },
+            }
+          : { allowed: true, requiresApproval: false },
+      classify: (tool: ToolDefinition) =>
+        tool.name === "send_money"
+          ? { risk: 4, dataClass: "private", sideEffect: "irreversible", requiresApproval: true }
+          : { risk: 0, dataClass: "public", sideEffect: "none", requiresApproval: false },
+      recordToolCall: (ctx: unknown) => ctx,
+      sanitizeAndCheck: (result: ToolResult) => ({
+        result,
+        injectionDetected: false,
+        injectionPatterns: [],
+      }),
+      sanitizeResult: (result: ToolResult) => result,
+      logInjection: () => undefined,
+    };
+
+    const toolRegistry = makeMockToolRegistry(
+      new Map([
+        [
+          "send_money",
+          {
+            def: {
+              name: "send_money",
+              description: "Send money",
+              inputSchema: { type: "object", properties: { to: { type: "string" } } },
+            },
+            result: { ok: true },
+          },
+        ],
+        [
+          "noop",
+          {
+            def: {
+              name: "noop",
+              description: "No-op",
+              inputSchema: { type: "object", properties: {} },
+            },
+            result: { ok: true },
+          },
+        ],
+      ]),
+    );
+
+    // Capture every context pack the model actually receives.
+    const seenPacks: unknown[] = [];
+    const responses: AIResponse[] = [
+      {
+        text: "",
+        confidence: 0.8,
+        memory_candidates: [],
+        state_updates: {},
+        // The denied money call PLUS a benign allowed call — so the turn
+        // is not all-blocked and the loop makes a second provider call
+        // whose history contains the denial the model actually sees.
+        tool_calls: [
+          { id: "c1", name: "send_money", args: { to: "x" } },
+          { id: "c2", name: "noop", args: {} },
+        ],
+      } as never,
+      { text: "ok", confidence: 0.8, memory_candidates: [], state_updates: {} } as never,
+    ];
+    let callIndex = 0;
+    const provider: StreamingProvider = {
+      model: "test-model",
+      setModel: vi.fn(),
+      async generate(pack: ContextPack): Promise<AIResponse> {
+        seenPacks.push(pack);
+        const r = responses[callIndex] ?? responses[responses.length - 1]!;
+        callIndex++;
+        return r;
+      },
+      async *generateStream(pack: ContextPack) {
+        seenPacks.push(pack);
+        const r = responses[callIndex] ?? responses[responses.length - 1]!;
+        callIndex++;
+        if (r.text) yield { type: "text" as const, text: r.text };
+        yield { type: "done" as const, response: r };
+      },
+      estimateConfidence: () => Promise.resolve(0.8),
+      extractMemoryCandidates: (r: AIResponse) => Promise.resolve(r.memory_candidates),
+    };
+
+    const deps = {
+      ...makeDeps(),
+      provider,
+      tools: toolRegistry,
+      policyGate: denyingGate,
+    } as unknown as SensitivityCleared<MotebitLoopDependencies>;
+
+    let chunkDelta: unknown;
+    for await (const chunk of runTurnStreaming(deps, "send money to x")) {
+      if (
+        chunk.type === "tool_status" &&
+        chunk.status === "done" &&
+        (chunk as { missing_authority?: unknown }).missing_authority != null
+      ) {
+        chunkDelta = (chunk as { missing_authority?: unknown }).missing_authority;
+      }
+    }
+
+    // Owner channel: the precise residual arrived on the surface chunk.
+    expect(chunkDelta).toEqual({ missing_scope: ["send_money"], spend_overage_micro: 400_000 });
+
+    // Model channel: NOTHING the provider ever received contains the
+    // residual — string-level check over every serialized pack so a leak
+    // through ANY field fails loud.
+    expect(seenPacks.length).toBeGreaterThanOrEqual(2);
+    // The second call's pack must contain the COARSE reason (the model
+    // is taught) …
+    const later = JSON.stringify(seenPacks.slice(1));
+    expect(later).toContain("outside delegated scope");
+    // … and no pack, ever, contains the residual.
+    for (const pack of seenPacks) {
+      const raw = JSON.stringify(pack);
+      expect(raw).not.toContain("missing_authority");
+      expect(raw).not.toContain("400000");
+    }
+  });
+});

--- a/packages/ai-core/src/loop.ts
+++ b/packages/ai-core/src/loop.ts
@@ -620,6 +620,15 @@ export type AgenticChunk =
       result?: unknown;
       context?: string;
       /**
+       * Owner-facing typed residual of a policy/meter refusal — WHAT
+       * authority is missing, as data, so the surface renders the exact
+       * repair. Rides ONLY this surface channel: the model-visible
+       * history push carries the coarse `reason` string alone (a precise
+       * residual is a boundary oracle — see AuthorityDelta's asymmetry
+       * invariant in @motebit/protocol).
+       */
+      missing_authority?: import("@motebit/sdk").AuthorityDelta;
+      /**
        * Stable identifier for this tool call — assigned by the model and
        * carried on both the "calling" and "done" chunks for the same
        * invocation. Lets downstream consumers (e.g. the runtime streaming
@@ -1191,6 +1200,10 @@ export async function* runTurnStreaming(
             tool_call_id: toolCall.id,
             mode: toolDef.embodimentMode,
             slabProjection: toolDef.slabProjection,
+            // Owner channel only — the history push below stays coarse.
+            ...(decision.missing_authority != null
+              ? { missing_authority: decision.missing_authority }
+              : {}),
           };
           conversationHistory.push({
             role: "tool",

--- a/packages/policy/src/__tests__/authority-delta.test.ts
+++ b/packages/policy/src/__tests__/authority-delta.test.ts
@@ -1,0 +1,168 @@
+/**
+ * AuthorityDelta — every refusal a typed, owner-facing repair
+ * instruction. Pins that each deny/raise site populates its residual
+ * from the single producer module, that allows carry none, and that the
+ * blast-radius evaluator's overage/window math is exact.
+ * The asymmetry invariant (delta never reaches the model) is pinned in
+ * ai-core's loop tests — this suite owns the producer side.
+ */
+import { describe, it, expect } from "vitest";
+import { PolicyGate } from "../policy-gate.js";
+import { RiskLevel } from "../index.js";
+import { evaluateBlastRadius, freshGrantSpendState } from "../grant-blast-radius.js";
+import type { ToolDefinition } from "@motebit/sdk";
+
+const MONEY_TOOL = {
+  name: "delegate_to_agent",
+  description: "delegate",
+  parameters: { type: "object", properties: {} },
+  riskHint: { risk: RiskLevel.R4_MONEY },
+} as unknown as ToolDefinition;
+
+describe("policy-gate deny/raise sites populate typed residuals", () => {
+  it("scope fence → missing_scope", () => {
+    const g = new PolicyGate({ maxRiskLevel: RiskLevel.R4_MONEY } as never);
+    const d = g.validate(MONEY_TOOL, {}, {
+      ...g.createTurnContext(),
+      delegationScope: "pay_invoice",
+      verifiedGrant: { grant_id: "g" },
+    } as never);
+    expect(d.allowed).toBe(false);
+    expect(d.missing_authority).toEqual({ missing_scope: ["delegate_to_agent"] });
+  });
+
+  it("denyAbove hard ceiling → required_risk + posture_ceiling", () => {
+    const g = new PolicyGate({
+      maxRiskLevel: RiskLevel.R3_EXECUTE,
+      requireApprovalAbove: RiskLevel.R1_DRAFT,
+      denyAbove: RiskLevel.R3_EXECUTE,
+    } as never);
+    const d = g.validate(MONEY_TOOL, {}, g.createTurnContext());
+    expect(d.allowed).toBe(false);
+    expect(d.missing_authority).toEqual({
+      required_risk: RiskLevel.R4_MONEY,
+      posture_ceiling: RiskLevel.R3_EXECUTE,
+    });
+  });
+
+  it("legacy max-risk deny → required_risk + posture_ceiling", () => {
+    const g = new PolicyGate({ maxRiskLevel: RiskLevel.R2_WRITE } as never);
+    const d = g.validate(MONEY_TOOL, {}, g.createTurnContext());
+    expect(d.allowed).toBe(false);
+    expect(d.missing_authority).toEqual({
+      required_risk: RiskLevel.R4_MONEY,
+      posture_ceiling: RiskLevel.R2_WRITE,
+    });
+  });
+
+  it("8b raise (R4, no grant) → requires_verified_grant", () => {
+    const g = new PolicyGate({
+      maxRiskLevel: RiskLevel.R4_MONEY,
+      requireApprovalAbove: RiskLevel.R3_EXECUTE,
+      denyAbove: RiskLevel.R4_MONEY,
+    } as never);
+    const d = g.validate(MONEY_TOOL, {}, g.createTurnContext());
+    expect(d.allowed).toBe(true);
+    expect(d.requiresApproval).toBe(true);
+    expect(d.missing_authority).toEqual({
+      required_risk: RiskLevel.R4_MONEY,
+      requires_verified_grant: true,
+    });
+  });
+
+  it("grant-cleared R4 (8c) carries NO residual — nothing is missing", () => {
+    const g = new PolicyGate({
+      maxRiskLevel: RiskLevel.R4_MONEY,
+      requireApprovalAbove: RiskLevel.R3_EXECUTE,
+      denyAbove: RiskLevel.R4_MONEY,
+    } as never);
+    const d = g.validate(MONEY_TOOL, {}, {
+      ...g.createTurnContext(),
+      delegationScope: "delegate_to_agent",
+      verifiedGrant: { grant_id: "g" },
+    } as never);
+    expect(d.allowed).toBe(true);
+    expect(d.requiresApproval).toBe(false);
+    expect(d.missing_authority).toBeUndefined();
+  });
+});
+
+describe("blast-radius residuals — exact overage and window math", () => {
+  const CEILING = {
+    lifetime_limit_micro: 1_000_000,
+    cumulative_limit_micro: 100_000,
+    window_ms: 3_600_000,
+  } as never;
+
+  it("lifetime overage is exact, with no window unlock (lifetime never rolls)", () => {
+    const state = { ...freshGrantSpendState("g", 0), lifetime_spent_micro: 990_000 };
+    const r = evaluateBlastRadius(
+      CEILING,
+      state as never,
+      {
+        amount_micro: 60_000,
+        counterparty: "addr1",
+      } as never,
+      1,
+      10,
+    );
+    expect(r.decision.allowed).toBe(false);
+    expect(r.decision.denial).toBe("lifetime_exceeded");
+    expect(r.decision.missing_authority).toEqual({ spend_overage_micro: 50_000 });
+  });
+
+  it("window overage carries the overage AND when headroom returns", () => {
+    const state = {
+      ...freshGrantSpendState("g", 1_000),
+      window_spent_micro: 90_000,
+      window_started_at: 1_000,
+    };
+    const r = evaluateBlastRadius(
+      CEILING,
+      state as never,
+      {
+        amount_micro: 52_632,
+        counterparty: "addr1",
+      } as never,
+      2,
+      2_000,
+    );
+    expect(r.decision.allowed).toBe(false);
+    expect(r.decision.denial).toBe("cumulative_exceeded");
+    expect(r.decision.missing_authority).toEqual({
+      spend_overage_micro: 42_632,
+      not_before: 1_000 + 3_600_000,
+    });
+  });
+
+  it("structural denials (replay) carry NO residual — no repair exists in-band", () => {
+    const state = { ...freshGrantSpendState("g", 0), high_water_nonce: 99 };
+    const r = evaluateBlastRadius(
+      CEILING,
+      state as never,
+      {
+        amount_micro: 1_000,
+        counterparty: "addr1",
+      } as never,
+      99,
+      10,
+    );
+    expect(r.decision.denial).toBe("replay");
+    expect(r.decision.missing_authority).toBeUndefined();
+  });
+
+  it("allowed actions carry no residual", () => {
+    const r = evaluateBlastRadius(
+      CEILING,
+      freshGrantSpendState("g", 0) as never,
+      {
+        amount_micro: 1_000,
+        counterparty: "addr1",
+      } as never,
+      1,
+      10,
+    );
+    expect(r.decision.allowed).toBe(true);
+    expect(r.decision.missing_authority).toBeUndefined();
+  });
+});

--- a/packages/policy/src/authority-delta.ts
+++ b/packages/policy/src/authority-delta.ts
@@ -1,0 +1,51 @@
+/**
+ * The single producer of `AuthorityDelta` — every deny/raise site calls
+ * a constructor here; none hand-rolls a delta. One module, one shape
+ * per refusal class, or the system regresses to the scattered-residuals
+ * problem this primitive exists to fix (the first-metered-dollar
+ * ceremony, 2026-07-06/07: five correct refusals, five bespoke proses,
+ * six hours of debugging).
+ *
+ * Constructors, not an algebra: each deny site already knows its axis,
+ * so composition helpers (`leq`/`join`/fold) are deliberately absent —
+ * promote them only when a third consumer needs to COMPOSE authorities
+ * (multi-grant join, plan-level folds), per rule-of-three.
+ *
+ * See `AuthorityDelta` in @motebit/protocol for the two load-bearing
+ * invariants (owner-facing asymmetry; predictor-never-authority).
+ */
+
+import type { AuthorityDelta, RiskLevel } from "@motebit/protocol";
+
+/** The delegated scope lacks the tool — repair: a grant covering it. */
+export function scopeDelta(toolName: string): AuthorityDelta {
+  return { missing_scope: [toolName] };
+}
+
+/** Governance posture ceiling below the action's risk — repair: a
+ *  deliberate posture change by the owner (never by grant override). */
+export function postureDelta(requiredRisk: RiskLevel, postureCeiling: RiskLevel): AuthorityDelta {
+  return { required_risk: requiredRisk, posture_ceiling: postureCeiling };
+}
+
+/** R4 raised for lack of standing authority — repair: a verified grant
+ *  covering the tool, or a live human approval (the disjunction of
+ *  memory-never-confers-authority). */
+export function grantRequiredDelta(requiredRisk: RiskLevel): AuthorityDelta {
+  return { required_risk: requiredRisk, requires_verified_grant: true };
+}
+
+/** Spend exceeds remaining ceiling — repair: a grant with the overage. */
+export function spendOverageDelta(overageMicro: number): AuthorityDelta {
+  return { spend_overage_micro: overageMicro };
+}
+
+/** Approval quorum not yet met. */
+export function quorumShortfallDelta(shortfall: number): AuthorityDelta {
+  return { quorum_shortfall: shortfall };
+}
+
+/** Terminal grant states — no residual exists; re-mint is the repair. */
+export function terminalDelta(state: "revoked" | "expired"): AuthorityDelta {
+  return { terminal: state };
+}

--- a/packages/policy/src/grant-blast-radius.ts
+++ b/packages/policy/src/grant-blast-radius.ts
@@ -123,6 +123,12 @@ export interface BlastRadiusDecision {
   readonly allowed: boolean;
   /** Present iff `!allowed`. The first dimension that denied. */
   readonly denial?: BlastRadiusDenial;
+  /** Owner-facing typed residual of the denial (spend overage / window
+   *  unlock time). Model-visible channels carry only the denial code —
+   *  see `AuthorityDelta` in @motebit/protocol for the asymmetry
+   *  invariant. Absent when no residual exists (structural denials
+   *  like invalid_amount, replay without a known schedule). */
+  readonly missing_authority?: import("@motebit/protocol").AuthorityDelta;
   /** Headroom remaining after this action would commit (telemetry/UI). Present iff allowed. */
   readonly remaining?: {
     readonly cumulative_micro?: number;
@@ -218,8 +224,11 @@ export function spendCeilingFromGrant(
   };
 }
 
-const deny = (denial: BlastRadiusDenial): BlastRadiusEvaluation => ({
-  decision: { allowed: false, denial },
+const deny = (
+  denial: BlastRadiusDenial,
+  missing_authority?: import("@motebit/protocol").AuthorityDelta,
+): BlastRadiusEvaluation => ({
+  decision: { allowed: false, denial, ...(missing_authority ? { missing_authority } : {}) },
 });
 
 /**
@@ -280,20 +289,32 @@ export function evaluateBlastRadius(
   }
 
   // 8. Ceilings — lifetime first (strongest bound), then window dimensions.
+  const windowUnlock =
+    hasWindowLimit && windowMs > 0 ? { not_before: windowStartedAt + windowMs } : {};
   if (ceiling.lifetime_limit_micro !== undefined && newLifetime > ceiling.lifetime_limit_micro) {
-    return deny("lifetime_exceeded");
+    // Lifetime never rolls: the only repair is a new grant with the overage.
+    return deny("lifetime_exceeded", {
+      spend_overage_micro: newLifetime - ceiling.lifetime_limit_micro,
+    });
   }
   if (ceiling.cumulative_limit_micro !== undefined && newWindow > ceiling.cumulative_limit_micro) {
-    return deny("cumulative_exceeded");
+    // Window rolls: the overage AND when headroom returns.
+    return deny("cumulative_exceeded", {
+      spend_overage_micro: newWindow - ceiling.cumulative_limit_micro,
+      ...windowUnlock,
+    });
   }
   if (
     ceiling.per_counterparty_limit_micro !== undefined &&
     newCp > ceiling.per_counterparty_limit_micro
   ) {
-    return deny("per_counterparty_exceeded");
+    return deny("per_counterparty_exceeded", {
+      spend_overage_micro: newCp - ceiling.per_counterparty_limit_micro,
+      ...windowUnlock,
+    });
   }
   if (ceiling.max_action_count !== undefined && windowActions + 1 > ceiling.max_action_count) {
-    return deny("action_count_exceeded");
+    return deny("action_count_exceeded", windowUnlock.not_before ? windowUnlock : undefined);
   }
 
   // 9. Allowed — produce the committed state + remaining headroom.

--- a/packages/policy/src/index.ts
+++ b/packages/policy/src/index.ts
@@ -65,6 +65,15 @@ export type { AuditEntry, AuditChainStore } from "./audit-chain.js";
 
 // Re-export SDK types and enums used in the policy API
 export { RiskLevel, DataClass, SideEffect } from "@motebit/protocol";
+export {
+  scopeDelta,
+  postureDelta,
+  grantRequiredDelta,
+  spendOverageDelta,
+  quorumShortfallDelta,
+  terminalDelta,
+} from "./authority-delta.js";
+export type { AuthorityDelta } from "@motebit/protocol";
 export type {
   ToolRiskProfile,
   PolicyDecision,

--- a/packages/policy/src/policy-gate.ts
+++ b/packages/policy/src/policy-gate.ts
@@ -12,6 +12,12 @@ import { classifyTool, isToolAllowed } from "./risk-model.js";
 import { BudgetEnforcer } from "./budget.js";
 import type { BudgetConfig } from "./budget.js";
 import { RedactionEngine } from "./redaction.js";
+import {
+  scopeDelta,
+  postureDelta,
+  grantRequiredDelta,
+  quorumShortfallDelta,
+} from "./authority-delta.js";
 import { ContentSanitizer } from "./sanitizer.js";
 import { AuditLogger } from "./audit.js";
 import type { AuditLogSink } from "./audit.js";
@@ -255,6 +261,7 @@ export class PolicyGate {
           allowed: false,
           requiresApproval: false,
           reason: `Tool "${tool.name}" is outside delegated scope "${ctx.delegationScope}"`,
+          missing_authority: scopeDelta(tool.name),
         };
         this.audit.logDecision(ctx.turnId, callId, tool.name, args, decision, ctx.runId);
         return decision;
@@ -272,6 +279,7 @@ export class PolicyGate {
           allowed: false,
           requiresApproval: false,
           reason: `Tool "${tool.name}" risk ${RiskLevel[profile.risk]} exceeds deny threshold ${RiskLevel[this.config.denyAbove!]}`,
+          missing_authority: postureDelta(profile.risk, this.config.denyAbove!),
         };
         this.audit.logDecision(ctx.turnId, callId, tool.name, args, decision, ctx.runId);
         return decision;
@@ -283,6 +291,7 @@ export class PolicyGate {
           allowed: false,
           requiresApproval: false,
           reason: `Tool "${tool.name}" requires risk level ${RiskLevel[profile.risk]} but max allowed is ${RiskLevel[maxRisk]}. Enable Operator Mode for higher-risk tools.`,
+          missing_authority: postureDelta(profile.risk, maxRisk),
         };
         this.audit.logDecision(ctx.turnId, callId, tool.name, args, decision, ctx.runId);
         return decision;
@@ -473,6 +482,21 @@ export class PolicyGate {
       }
     }
 
+    // Owner-facing residual for a RAISED (not denied) decision: what
+    // authority would let this auto-execute. Single producer module;
+    // grant-required takes precedence over quorum shortfall (the grant
+    // is the deeper missing artifact). Model-visible channels never
+    // carry this — see AuthorityDelta's asymmetry invariant.
+    // R4 pending approval without a verified grant: the missing authority
+    // IS a grant (or the live tap) — true whether the band or 8b raised
+    // it. Otherwise a pending quorum names its shortfall.
+    const raiseDelta =
+      profile.risk >= RiskLevel.R4_MONEY && ctx.verifiedGrant == null
+        ? grantRequiredDelta(profile.risk)
+        : quorumMeta != null
+          ? quorumShortfallDelta(quorumMeta.required - quorumMeta.collected.length)
+          : undefined;
+
     const decision: PolicyDecision = {
       allowed: true,
       requiresApproval: needsApproval,
@@ -482,6 +506,7 @@ export class PolicyGate {
         cost: budgetResult.remaining.cost,
       },
       ...(quorumMeta ? { quorum: quorumMeta } : {}),
+      ...(needsApproval && raiseDelta != null ? { missing_authority: raiseDelta } : {}),
     };
 
     this.audit.logDecision(ctx.turnId, callId, tool.name, args, decision, ctx.runId);

--- a/packages/protocol/etc/protocol.api.md
+++ b/packages/protocol/etc/protocol.api.md
@@ -588,6 +588,18 @@ export interface AuditStatsSince {
 }
 
 // @public
+export interface AuthorityDelta {
+    missing_scope?: string[];
+    not_before?: number;
+    posture_ceiling?: RiskLevel;
+    quorum_shortfall?: number;
+    required_risk?: RiskLevel;
+    requires_verified_grant?: true;
+    spend_overage_micro?: number;
+    terminal?: "revoked" | "expired";
+}
+
+// @public
 export interface BalanceWaiver {
     motebit_id: string;
     signature: string;
@@ -2965,6 +2977,7 @@ export interface PolicyDecision {
         timeMs: number;
         cost: number;
     };
+    missing_authority?: AuthorityDelta;
     quorum?: {
         required: number;
         approvers: string[];

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -847,6 +847,52 @@ export interface ApprovalQuorum {
   risk_floor?: string;
 }
 
+/**
+ * The typed residual of a refused (or approval-raised) authority check —
+ * WHAT is missing, as data, so owner surfaces can render the exact
+ * repair instruction ("mint the difference") instead of prose.
+ *
+ * Two invariants, both load-bearing:
+ *
+ * ASYMMETRY — the delta is OWNER-FACING. Model-visible channels (tool
+ * results pushed into conversation history) carry only the coarse
+ * `reason` string: a precise residual is a boundary oracle, and
+ * "you need exactly publish.external and $0.40 more" is also a
+ * perfectly optimized social-engineering script aimed at the one party
+ * who can mint the difference. Owner surfaces (stream chunks, audit
+ * log, pre-flight) get precision; the model keeps today's actionable
+ * category, never the oracle.
+ *
+ * PREDICTOR, NEVER AUTHORITY — the delta describes a boundary's
+ * refusal; it never participates in allowing anything. The gate and
+ * the money meter remain the sole enforcement authorities.
+ *
+ * Closed field set (extend by registry-append discipline, never by a
+ * generic effect-algebra parameter). Sibling of `Semiring` on the
+ * algebra floor: the semiring answers "which path is best"; the delta
+ * answers "what authority is missing". Money is integer micro-units
+ * (`number`, wire-safe) per the repo money model.
+ */
+export interface AuthorityDelta {
+  /** Scope entries the delegated scope lacks (e.g. the denied tool name). */
+  missing_scope?: string[];
+  /** The action's risk level. */
+  required_risk?: RiskLevel;
+  /** The ceiling the governance posture permits (deny threshold or max risk). */
+  posture_ceiling?: RiskLevel;
+  /** R4 without a verified standing grant: the missing authority IS a grant
+   *  (or a live human approval) — memory-never-confers-authority. */
+  requires_verified_grant?: true;
+  /** Micro-USD by which the attempted spend exceeds remaining ceiling. */
+  spend_overage_micro?: number;
+  /** Epoch ms when the next authority window opens (tick schedule). */
+  not_before?: number;
+  /** Approvals still needed to meet the configured quorum. */
+  quorum_shortfall?: number;
+  /** Terminal states: no residual exists; re-mint is the only repair. */
+  terminal?: "revoked" | "expired";
+}
+
 export interface PolicyDecision {
   allowed: boolean;
   requiresApproval: boolean;
@@ -854,6 +900,9 @@ export interface PolicyDecision {
   budgetRemaining?: { calls: number; timeMs: number; cost: number };
   /** When quorum is required, contains the quorum metadata. */
   quorum?: { required: number; approvers: string[]; collected: string[] };
+  /** Owner-facing typed residual of a refusal/raise. See `AuthorityDelta`
+   *  for the asymmetry + predictor invariants. */
+  missing_authority?: AuthorityDelta;
 }
 
 export interface TurnContext {

--- a/packages/runtime/src/runtime-config.ts
+++ b/packages/runtime/src/runtime-config.ts
@@ -329,6 +329,14 @@ export type StreamChunk =
       result?: unknown;
       context?: string;
       /**
+       * Owner-facing typed residual of a policy/meter refusal (WHAT
+       * authority is missing, as data). Pass-through from ai-core's
+       * tool_status chunk; rides ONLY this surface channel — the
+       * model-visible history carries the coarse reason string alone.
+       * See `AuthorityDelta` in @motebit/protocol.
+       */
+      missing_authority?: import("@motebit/protocol").AuthorityDelta;
+      /**
        * Embodiment mode the slab item should stamp when this tool's
        * activity lands on the slab. Sourced from
        * `ToolDefinition.embodimentMode` at the registration site,


### PR DESCRIPTION
The residual, without the quantale. `AuthorityDelta` in `@motebit/protocol` (closed fields; two invariants documented ON the type: **ASYMMETRY** — owner surfaces get precision, model channels only the coarse reason, because a precise residual is a boundary oracle aimed at the one party who can mint the difference; **PREDICTOR-NEVER-AUTHORITY** — gate + meter stay the sole enforcers). `PolicyDecision.missing_authority` extends additively, beside the `budgetRemaining` residual already there in embryo.

- Single producer module in `@motebit/policy` (deny sites call constructors; none hand-rolls) — scope fence, both posture denies, R4-without-grant raise (whether the band or 8b raised it), quorum shortfall.
- Blast-radius evaluator emits **exact** spend overages (lifetime: overage only — it never rolls; window dims: overage + `not_before` when headroom returns); structural denials (replay) deliberately carry none.
- ai-core `tool_status` chunk (surface channel) carries the delta; the conversation-history push stays coarse — **pinned by a leak test** capturing every context pack the model receives (coarse reason must appear; the residual must not).
- CLI `renderAuthorityDelta` — the owner half; every residual class produces its exact repair line.
- Types route through `@motebit/sdk` in apps/ai-core (layer discipline, enforced by check-deps + check-app-primitives).
- Composition helpers (`leq`/`join`/folds) deliberately absent — rule-of-three; promote when a third consumer needs to COMPOSE authorities.

policy 482 (9 new) / ai-core 558 / cli 260 (5 new) / protocol 446 / runtime 1178; gates 127/127; protocol api baseline regenerated; protocol + motebit minor changesets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)