### PR TITLE
feat: release witness — the self-signing body, self-verifying

### DIFF
--- a/.changeset/verify-release.md
+++ b/.changeset/verify-release.md
@@ -1,0 +1,5 @@
+---
+"motebit": minor
+---
+
+`motebit verify-release` — the self-signing body, self-verifying. Hashes the RUNNING bundle's own bytes and checks them against the relay's signed release witness (`/.well-known/motebit-releases.json` — the operator's signed observation of the npm registry: tarball integrity + per-file bundle hashes, in the same envelope and via the same canonical verifier as the transparency declaration, under the same key pinned at `motebit register`). Closes the one unverifiable claim the bundled-CLI distribution model leaves open: that the artifact npm delivered is the artifact the operator published. Read-only, passphrase-free by design (a binary asking you to unlock your identity to "verify itself" would be the attack). Stated honestly: this proves the operator's word about the artifact, not a reproducible build — that rung is a later arc.

--- a/apps/cli/etc/cli-surface.json
+++ b/apps/cli/etc/cli-surface.json
@@ -52,6 +52,7 @@
     "verify": [
       "identity"
     ],
+    "verify-release": [],
     "wallet": [],
     "withdraw": []
   },

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -417,6 +417,7 @@ Commands:
     --solana-rpc-url <url>    Solana RPC endpoint (default: mainnet-beta public RPC)
     --address-only            Skip the balance query (address-only)
   wallet swap <sol>         Convert SOL → USDC working capital (Jupiter; gas floor enforced)
+  verify-release            Verify this binary's bytes against the operator's signed witness
   doctor                    Check system readiness (Node, SQLite, config)
   export [--output <dir>]   Export identity bundle (motebit.md, credentials, budget, gradient)
     --all                   Include sensitive memories (medical/financial/secret) in export

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -88,6 +88,7 @@ import {
   handleWithdraw,
   handleWallet,
   handleWalletSwap,
+  handleVerifyRelease,
   handleSkillsInstall,
   handleSkillsAudit,
   handleSkillsList,
@@ -163,6 +164,11 @@ async function main(): Promise<void> {
 
   if (subcommand === "id") {
     handleId();
+    return;
+  }
+
+  if (subcommand === "verify-release") {
+    await handleVerifyRelease();
     return;
   }
 

--- a/apps/cli/src/subcommands/index.ts
+++ b/apps/cli/src/subcommands/index.ts
@@ -79,3 +79,4 @@ export {
 export { handleVerify } from "./verify.js";
 export { handleVerifyWire, isVerifyKind } from "./verify-wire.js";
 export { handleWallet, handleWalletSwap } from "./wallet.js";
+export { handleVerifyRelease } from "./verify-release.js";

--- a/apps/cli/src/subcommands/verify-release.ts
+++ b/apps/cli/src/subcommands/verify-release.ts
@@ -1,0 +1,117 @@
+/**
+ * `motebit verify-release` — the self-signing body, self-verifying.
+ *
+ * Hashes the RUNNING bundle's own bytes and checks them against the
+ * relay's signed release witness (`/.well-known/motebit-releases.json`,
+ * same envelope + same canonical verifier as the transparency
+ * declaration, same key the owner pinned at `motebit register`). Closes
+ * the one unverifiable claim the bundled-CLI distribution model leaves
+ * open: that the artifact npm delivered is the artifact the operator
+ * published from the audited tree.
+ *
+ * Trust chain, stated honestly: bytes-on-disk → operator's signed
+ * observation of the registry → key pinned at register (TOFU +
+ * optional onchain anchor). It proves the operator's word about the
+ * artifact, not a reproducible build — that rung is a later arc.
+ *
+ * Read-only; no passphrase (verification must never require unlocking
+ * the identity — a compromised binary asking for your passphrase to
+ * "verify itself" would be the exact attack).
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { verifyTransparencyDeclaration } from "@motebit/state-export-client";
+import { loadFullConfig } from "../config.js";
+import { VERSION } from "../config.js";
+
+interface WitnessRelease {
+  version: string;
+  tarball_integrity: string;
+  git_head?: string;
+  files: Record<string, string>;
+}
+
+export async function handleVerifyRelease(options: { bundlePath?: string } = {}): Promise<void> {
+  const fullConfig = loadFullConfig();
+  const relayUrl = (fullConfig.sync_url ?? "https://relay.motebit.com").replace(/\/+$/, "");
+  const pinned = fullConfig.relay_public_key;
+
+  // 1. Hash our own bytes — the running bundle.
+  const bundlePath = options.bundlePath ?? process.argv[1];
+  if (bundlePath == null || bundlePath === "") {
+    console.error("verify-release: cannot locate the running bundle");
+    process.exit(1);
+  }
+  let selfHash: string;
+  try {
+    selfHash = createHash("sha256").update(readFileSync(bundlePath)).digest("hex");
+  } catch (err) {
+    console.error(
+      `verify-release: cannot read own bytes at ${bundlePath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  }
+
+  // 2. Fetch + verify the witness (canonical verifier — hash + Ed25519
+  //    against the key the envelope carries).
+  let witness: {
+    relay_public_key: string;
+    declared_at: number;
+    content: { package: string; releases: WitnessRelease[] };
+  };
+  try {
+    const res = await fetch(`${relayUrl}/.well-known/motebit-releases.json`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const raw = (await res.json()) as Parameters<typeof verifyTransparencyDeclaration>[0];
+    const verdict = await verifyTransparencyDeclaration(raw);
+    if (!verdict.ok) {
+      console.error(`✗ witness failed verification (${verdict.reason}) — do not trust it.`);
+      process.exit(1);
+    }
+    witness = raw as unknown as typeof witness;
+  } catch (err) {
+    console.error(
+      `verify-release: witness unavailable from ${relayUrl} ` +
+        `(${err instanceof Error ? err.message : String(err)}). Retry online.`,
+    );
+    process.exit(1);
+  }
+
+  // 3. The self-signature proves integrity; the PIN proves it is YOUR
+  //    operator's word. Without a pin this is TOFU — say so, honestly.
+  if (pinned != null && pinned !== "" && witness.relay_public_key !== pinned) {
+    console.error(
+      `✗ PIN MISMATCH: witness signed by ${witness.relay_public_key.slice(0, 12)}… but your ` +
+        `config pins ${pinned.slice(0, 12)}…. Do not trust this witness.`,
+    );
+    process.exit(1);
+  }
+
+  // 4. Compare our bytes against the witnessed release for our version.
+  const release = witness.content.releases.find((r) => r.version === VERSION);
+  if (release == null) {
+    console.error(
+      `✗ motebit@${VERSION} is not in the operator's witness ` +
+        `(witnessed: ${witness.content.releases.map((r) => r.version).join(", ")}).` +
+        ` A repo build or an unwitnessed version — expected for dev builds.`,
+    );
+    process.exit(1);
+  }
+  const attested = release.files["dist/index.js"];
+  if (attested !== selfHash) {
+    console.error(`✗ BYTES DO NOT MATCH the operator's witness for motebit@${VERSION}.`);
+    console.error(`    this binary  sha256 ${selfHash}`);
+    console.error(`    witnessed    sha256 ${attested ?? "(absent)"}`);
+    console.error(`  Reinstall from the registry and re-run. If it persists, treat as tampering.`);
+    process.exit(1);
+  }
+
+  console.log(`✓ motebit@${VERSION} — this binary's bytes match the operator's signed witness`);
+  console.log(`    sha256      ${selfHash}`);
+  if (release.git_head != null) console.log(`    git_head    ${release.git_head}`);
+  console.log(
+    `    signed by   ${witness.relay_public_key.slice(0, 12)}… ${pinned ? "(your pinned relay key)" : "(TOFU — run \`motebit register\` to pin)"}`,
+  );
+  console.log(`    declared    ${new Date(witness.declared_at).toISOString()}`);
+}

--- a/apps/cli/src/subcommands/verify-release.ts
+++ b/apps/cli/src/subcommands/verify-release.ts
@@ -111,7 +111,7 @@ export async function handleVerifyRelease(options: { bundlePath?: string } = {})
   console.log(`    sha256      ${selfHash}`);
   if (release.git_head != null) console.log(`    git_head    ${release.git_head}`);
   console.log(
-    `    signed by   ${witness.relay_public_key.slice(0, 12)}… ${pinned ? "(your pinned relay key)" : "(TOFU — run \`motebit register\` to pin)"}`,
+    `    signed by   ${witness.relay_public_key.slice(0, 12)}… ${pinned ? "(your pinned relay key)" : "(TOFU — run motebit register to pin)"}`,
   );
   console.log(`    declared    ${new Date(witness.declared_at).toISOString()}`);
 }

--- a/scripts/check-transparency-processors-canonical.ts
+++ b/scripts/check-transparency-processors-canonical.ts
@@ -79,6 +79,10 @@ const MOTEBIT_OWNED_HOSTS: ReadonlySet<string> = new Set([
 const HOSTNAME_TO_PROCESSOR: Record<string, string> = {
   // AI inference (via services/proxy when motebit-cloud routes)
   "api.anthropic.com": "Anthropic",
+  // Release witness (services/relay/src/release-witness.ts) — read-only
+  // fetch of PUBLIC package metadata + tarballs; nothing user-derived
+  // is transmitted.
+  "registry.npmjs.org": "npm registry",
   "api.openai.com": "OpenAI",
   "generativelanguage.googleapis.com": "Google (Generative Language API)",
   "api.groq.com": "Groq",

--- a/services/relay/PRIVACY.md
+++ b/services/relay/PRIVACY.md
@@ -103,6 +103,13 @@ client IP is read for rate limiting (in-memory FixedWindowLimiter, no DB) and in
 
 ## Third-party processors
 
+### npm registry
+
+- **Role**: release witness source (services/relay/src/release-witness.ts). The relay fetches PUBLIC package metadata and tarballs for the `motebit` package to sign the release witness served at /.well-known/motebit-releases.json. Read-only observation: no user, agent, or operator data is transmitted — the request itself (relay IP, user-agent) is the only signal npm receives.
+- **Data shared**: none (public registry reads only; requester IP visible to npm as with any HTTP fetch)
+- **Jurisdiction**: United States (npm, Inc. / GitHub / Microsoft)
+- **DPA / terms**: https://docs.npmjs.com/policies/privacy
+
 ### Stripe
 
 - **Role**: fiat payment processor

--- a/services/relay/src/__tests__/release-witness.test.ts
+++ b/services/relay/src/__tests__/release-witness.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Release witness — signed observation of the npm registry, verified
+ * by the SAME consumer verifier as the transparency declaration (the
+ * whole point: one pinned key, one envelope, one verification path).
+ */
+import { describe, it, expect } from "vitest";
+import { gzipSync } from "node:zlib";
+import { extractTarEntry, observeReleases, buildSignedReleaseWitness } from "../release-witness.js";
+import { verifyTransparencyDeclaration } from "@motebit/state-export-client";
+// eslint-disable-next-line no-restricted-imports -- tests need direct crypto
+import { generateKeypair } from "@motebit/encryption";
+
+/** Build a minimal valid tarball containing the given entries. */
+function makeTar(entries: Record<string, string>): Uint8Array {
+  const blocks: Uint8Array[] = [];
+  for (const [name, content] of Object.entries(entries)) {
+    const data = new TextEncoder().encode(content);
+    const header = new Uint8Array(512);
+    header.set(new TextEncoder().encode(name), 0);
+    header.set(new TextEncoder().encode(data.length.toString(8).padStart(11, "0") + "\0"), 124);
+    blocks.push(header, data, new Uint8Array((512 - (data.length % 512)) % 512));
+  }
+  blocks.push(new Uint8Array(1024)); // end-of-archive
+  const total = blocks.reduce((n, b) => n + b.length, 0);
+  const tar = new Uint8Array(total);
+  let off = 0;
+  for (const b of blocks) {
+    tar.set(b, off);
+    off += b.length;
+  }
+  return tar;
+}
+
+describe("extractTarEntry", () => {
+  it("extracts the named entry and returns null for absent/malformed", () => {
+    const tar = makeTar({
+      "package/dist/index.js": "#!/usr/bin/env node\nhello",
+      "package/README.md": "docs",
+    });
+    expect(new TextDecoder().decode(extractTarEntry(tar, "package/dist/index.js")!)).toContain(
+      "hello",
+    );
+    expect(extractTarEntry(tar, "package/missing.js")).toBeNull();
+    expect(extractTarEntry(new Uint8Array(1024), "x")).toBeNull();
+  });
+});
+
+describe("observeReleases", () => {
+  it("witnesses the most recent versions with per-file bundle hashes", async () => {
+    const tarball = gzipSync(makeTar({ "package/dist/index.js": "BUNDLE-BYTES-1.8.0" }));
+    const fetchImpl = (async (url: string | URL | Request) => {
+      const u = url instanceof Request ? url.url : String(url);
+      if (u.endsWith("/motebit")) {
+        return new Response(
+          JSON.stringify({
+            versions: {
+              "1.8.0": {
+                dist: { integrity: "sha512-abc", tarball: "https://reg/motebit-1.8.0.tgz" },
+                gitHead: "deadbeef",
+              },
+            },
+            time: { "1.8.0": "2026-07-07T12:00:00Z" },
+          }),
+        );
+      }
+      return new Response(tarball);
+    }) as typeof fetch;
+
+    const releases = await observeReleases(fetchImpl);
+    expect(releases).toHaveLength(1);
+    expect(releases[0]!.version).toBe("1.8.0");
+    expect(releases[0]!.tarball_integrity).toBe("sha512-abc");
+    expect(releases[0]!.git_head).toBe("deadbeef");
+    expect(releases[0]!.files["dist/index.js"]).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("fails loud when the bundle file is missing from a tarball — never silently skipped", async () => {
+    const tarball = gzipSync(makeTar({ "package/README.md": "no bundle here" }));
+    const fetchImpl = (async (url: string | URL | Request) => {
+      const u = url instanceof Request ? url.url : String(url);
+      if (u.endsWith("/motebit")) {
+        return new Response(
+          JSON.stringify({
+            versions: { "1.8.0": { dist: { integrity: "x", tarball: "https://reg/t.tgz" } } },
+            time: { "1.8.0": "2026-07-07T12:00:00Z" },
+          }),
+        );
+      }
+      return new Response(tarball);
+    }) as typeof fetch;
+    await expect(observeReleases(fetchImpl)).rejects.toThrow(/missing from motebit@1.8.0/);
+  });
+});
+
+describe("buildSignedReleaseWitness — one envelope, one verifier", () => {
+  it("verifies with the canonical transparency verifier and fails on tamper", async () => {
+    const keys = await generateKeypair();
+    const identity = {
+      relayMotebitId: "relay-test",
+      publicKey: keys.publicKey,
+      privateKey: keys.privateKey,
+    };
+    const witness = await buildSignedReleaseWitness(identity, [
+      {
+        version: "1.8.0",
+        tarball_integrity: "sha512-abc",
+        files: { "dist/index.js": "aa".repeat(32) },
+      },
+    ]);
+
+    const ok = await verifyTransparencyDeclaration(witness as never);
+    expect(ok.ok).toBe(true);
+
+    // Tamper with the witnessed hash → the same verifier refuses.
+    const tampered = JSON.parse(JSON.stringify(witness));
+    tampered.content.releases[0].files["dist/index.js"] = "bb".repeat(32);
+    const bad = await verifyTransparencyDeclaration(tampered as never);
+    expect(bad.ok).toBe(false);
+  });
+});

--- a/services/relay/src/index.ts
+++ b/services/relay/src/index.ts
@@ -932,6 +932,14 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
   const { registerRetentionManifestRoutes } = await import("./retention-manifest.js");
   await registerRetentionManifestRoutes({ app, relayIdentity, db: moteDb.db });
 
+  // --- Release witness (self-attesting-system doctrine, artifact layer) ---
+  // Signed observation of the npm registry at /.well-known/motebit-releases.json:
+  // tarball integrity + per-file bundle hash, in the transparency-declaration
+  // envelope (same pinned-key verification path). `motebit verify-release`
+  // closes the loop: an installed CLI hashes its own bytes against this.
+  const { registerReleaseWitnessRoutes } = await import("./release-witness.js");
+  registerReleaseWitnessRoutes({ app, relayIdentity });
+
   // --- Skills registry routes (skills-registry-v1.md) ---
   const { registerSkillRegistryRoutes, createSkillRegistryTables, parseFeaturedSubmitters } =
     await import("./skill-registry.js");

--- a/services/relay/src/release-witness.ts
+++ b/services/relay/src/release-witness.ts
@@ -1,0 +1,213 @@
+/**
+ * Release witness — the operator-transparency domain extended to the
+ * published artifact (docs/doctrine/operator-transparency.md;
+ * docs/doctrine/self-attesting-system.md).
+ *
+ * The `motebit` npm package ships the whole workspace inlined into one
+ * bundled file. That is the right shape for a money-path application
+ * (the tested bytes ARE the shipped bytes) — but it leaves one
+ * unverifiable claim in a system whose thesis is claims-you-can-verify:
+ * nothing proves that `motebit@X` on the registry is the audited tree.
+ * Its provenance is "trust npm."
+ *
+ * This module closes that gap as a WITNESS: the relay observes the
+ * public registry, hashes what it sees — the tarball and the bundle
+ * file inside it — and signs the observation in the exact envelope of
+ * the transparency declaration (same canonicalJson + SHA-256 + Ed25519,
+ * same `verifyTransparencyDeclaration` on the consumer side, same
+ * pinned key from `motebit register`). An installed CLI can then hash
+ * its OWN bytes and check them against the witness: the self-signing
+ * body becomes self-verifying.
+ *
+ * Honesty boundary: this is an operator's signed observation of
+ * registry state, not a reproducible-build proof. It binds artifact →
+ * operator's word → pinned key; a verifier who distrusts the operator
+ * gains nothing (correctly — the operator published the artifact). The
+ * reproducible-build rung is a separate, later arc.
+ */
+
+import { gunzipSync } from "node:zlib";
+import { canonicalJson, sha256, sign, bytesToHex } from "@motebit/encryption";
+import { TRANSPARENCY_SUITE } from "@motebit/protocol";
+import type { Hono } from "hono";
+import { createLogger } from "./logger.js";
+
+const logger = createLogger({ service: "release-witness" });
+
+/** Spec id for the witness envelope (sibling of the transparency draft). */
+const SPEC_ID = "motebit-release-witness/draft-2026-07-07";
+
+/** Registry packument + tarball origin. */
+const REGISTRY = "https://registry.npmjs.org";
+
+/** Witnessed package + the attested file inside its tarball. */
+const PACKAGE = "motebit";
+const BUNDLE_PATH = "package/dist/index.js";
+
+/** How many most-recent versions to witness per build. */
+const VERSION_COUNT = 3;
+
+/** Rebuild the witness when older than this (registry state moves slowly). */
+const WITNESS_TTL_MS = 60 * 60 * 1000;
+
+export interface WitnessedRelease {
+  version: string;
+  /** npm's own content address for the tarball (`dist.integrity`). */
+  tarball_integrity: string;
+  /** The commit npm recorded at publish (`gitHead`), when present. */
+  git_head?: string;
+  /** SHA-256 (hex) of the bundle file inside the tarball — what an
+   *  installed CLI compares its own bytes against. */
+  files: Record<string, string>;
+}
+
+interface RelayIdentityLike {
+  relayMotebitId: string;
+  publicKey: Uint8Array;
+  privateKey: Uint8Array;
+}
+
+/**
+ * Minimal tar reader — extract one entry by name from a tarball buffer.
+ * The tar format is a sequence of 512-byte headers (name at offset 0,
+ * size as octal ASCII at offset 124) followed by size bytes rounded up
+ * to 512. No dependency earns its keep for one-file extraction.
+ */
+export function extractTarEntry(tarBytes: Uint8Array, entryName: string): Uint8Array | null {
+  let offset = 0;
+  while (offset + 512 <= tarBytes.length) {
+    const header = tarBytes.subarray(offset, offset + 512);
+    if (header.every((b) => b === 0)) return null; // end-of-archive
+    const nameEnd = header.indexOf(0);
+    const name = new TextDecoder().decode(header.subarray(0, nameEnd === -1 ? 100 : nameEnd));
+    const sizeField = new TextDecoder().decode(header.subarray(124, 136)).replace(/\0.*$/, "");
+    const size = parseInt(sizeField.trim(), 8);
+    if (!Number.isFinite(size) || size < 0) return null; // malformed — fail closed
+    const dataStart = offset + 512;
+    if (name === entryName) {
+      if (dataStart + size > tarBytes.length) return null;
+      return tarBytes.subarray(dataStart, dataStart + size);
+    }
+    offset = dataStart + Math.ceil(size / 512) * 512;
+  }
+  return null;
+}
+
+/** Observe the registry: packument → recent versions → tarball hashes. */
+export async function observeReleases(
+  fetchImpl: typeof fetch = fetch,
+): Promise<WitnessedRelease[]> {
+  const res = await fetchImpl(`${REGISTRY}/${PACKAGE}`);
+  if (!res.ok) throw new Error(`packument fetch failed: HTTP ${res.status}`);
+  const packument = (await res.json()) as {
+    versions: Record<string, { dist: { integrity?: string; tarball: string }; gitHead?: string }>;
+    time?: Record<string, string>;
+  };
+  const versions = Object.keys(packument.versions)
+    .sort((a, b) => (packument.time?.[a] ?? "").localeCompare(packument.time?.[b] ?? ""))
+    .slice(-VERSION_COUNT);
+
+  const witnessed: WitnessedRelease[] = [];
+  for (const version of versions) {
+    const meta = packument.versions[version]!;
+    const tarRes = await fetchImpl(meta.dist.tarball);
+    if (!tarRes.ok) throw new Error(`tarball fetch failed for ${version}: HTTP ${tarRes.status}`);
+    const gz = new Uint8Array(await tarRes.arrayBuffer());
+    const tar = new Uint8Array(gunzipSync(gz));
+    const bundle = extractTarEntry(tar, BUNDLE_PATH);
+    if (bundle == null) {
+      // A published version without the bundle is itself worth
+      // witnessing loudly — but never silently skipped.
+      throw new Error(`${BUNDLE_PATH} missing from ${PACKAGE}@${version} tarball`);
+    }
+    witnessed.push({
+      version,
+      tarball_integrity: meta.dist.integrity ?? "",
+      ...(meta.gitHead != null ? { git_head: meta.gitHead } : {}),
+      files: { "dist/index.js": bytesToHex(await sha256(bundle)) },
+    });
+  }
+  return witnessed;
+}
+
+/** Sign the observation in the transparency-declaration envelope. */
+export async function buildSignedReleaseWitness(
+  relayIdentity: RelayIdentityLike,
+  releases: WitnessedRelease[],
+  declaredAt: number = Date.now(),
+): Promise<Record<string, unknown>> {
+  const payload = {
+    spec: SPEC_ID,
+    declared_at: declaredAt,
+    relay_id: relayIdentity.relayMotebitId,
+    relay_public_key: bytesToHex(relayIdentity.publicKey),
+    content: { package: PACKAGE, registry: REGISTRY, releases },
+  };
+  const canonical = canonicalJson(payload);
+  const canonicalBytes = new TextEncoder().encode(canonical);
+  const hashHex = bytesToHex(await sha256(canonicalBytes));
+  const signatureHex = bytesToHex(await sign(canonicalBytes, relayIdentity.privateKey));
+  return { ...payload, hash: hashHex, suite: TRANSPARENCY_SUITE, signature: signatureHex };
+}
+
+/**
+ * `GET /.well-known/motebit-releases.json` — lazy-built, TTL-cached.
+ * Registry unavailability degrades to 503 (the witness never serves a
+ * stale-beyond-TTL or partial observation as fresh truth).
+ */
+export function registerReleaseWitnessRoutes(deps: {
+  app: Hono;
+  relayIdentity: RelayIdentityLike;
+  fetchImpl?: typeof fetch;
+}): void {
+  const { app, relayIdentity } = deps;
+  let cached: { body: string; builtAt: number } | null = null;
+  let building: Promise<string> | null = null;
+
+  const build = async (): Promise<string> => {
+    const releases = await observeReleases(deps.fetchImpl ?? fetch);
+    const witness = await buildSignedReleaseWitness(relayIdentity, releases);
+    const body = canonicalJson(witness);
+    cached = { body, builtAt: Date.now() };
+    return body;
+  };
+
+  /** @internal */
+  app.get("/.well-known/motebit-releases.json", async (_c) => {
+    try {
+      if (cached != null && Date.now() - cached.builtAt < WITNESS_TTL_MS) {
+        return new Response(cached.body, {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json; charset=utf-8",
+            "Cache-Control": "public, max-age=300",
+          },
+        });
+      }
+      building ??= build().finally(() => {
+        building = null;
+      });
+      const body = await building;
+      return new Response(body, {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Cache-Control": "public, max-age=300",
+        },
+      });
+    } catch (err) {
+      logger.warn("release_witness.build_failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      // Serve a stale witness over an error — it is still SIGNED truth
+      // about the registry at builtAt; the consumer sees declared_at.
+      if (cached != null) {
+        return new Response(cached.body, {
+          status: 200,
+          headers: { "Content-Type": "application/json; charset=utf-8" },
+        });
+      }
+      return new Response(JSON.stringify({ error: "witness_unavailable" }), { status: 503 });
+    }
+  });
+}

--- a/services/relay/src/transparency.ts
+++ b/services/relay/src/transparency.ts
@@ -173,6 +173,15 @@ export const DECLARATION_CONTENT = {
   ],
   third_party_processors: [
     {
+      name: "npm registry",
+      role: "release witness source (services/relay/src/release-witness.ts). The relay fetches PUBLIC package metadata and tarballs for the `motebit` package to sign the release witness served at /.well-known/motebit-releases.json. Read-only observation: no user, agent, or operator data is transmitted — the request itself (relay IP, user-agent) is the only signal npm receives.",
+      data_shared: [
+        "none (public registry reads only; requester IP visible to npm as with any HTTP fetch)",
+      ],
+      jurisdiction: "United States (npm, Inc. / GitHub / Microsoft)",
+      data_processing_terms: "https://docs.npmjs.com/policies/privacy",
+    },
+    {
       name: "Stripe",
       role: "fiat payment processor",
       data_shared: ["email", "payment method (held by Stripe)", "subscription metadata"],


### PR DESCRIPTION
The bundled-CLI distribution model leaves ONE unverifiable claim in a system whose thesis is claims-you-can-verify: nothing proves `motebit@X` on npm is the audited tree — its provenance was "trust npm."

- **relay `/.well-known/motebit-releases.json`**: signed observation of the public registry — packument + tarball fetch, per-file bundle hash (dependency-free 30-line tar reader), in the EXACT transparency-declaration envelope (`TRANSPARENCY_SUITE` from the protocol registry; hand-writing the suite string cost one red test — the registry pattern working). Same consumer verifier, same key the owner pinned at `motebit register`. TTL-cached; stale-signed-truth over errors; 503 before unsigned truth; a missing bundle file in a published tarball fails LOUD.
- **`motebit verify-release`**: hashes the RUNNING bundle's own bytes, verifies the witness, enforces the pin (mismatch = do-not-trust), compares the byte-hash for its own version. Read-only and passphrase-free by design — a binary asking you to unlock your identity to "verify itself" would be the attack.
- **Transparency declaration** gains the npm-registry processor entry (read-only public fetches, nothing user-derived transmitted) — demanded by `check-transparency-processors-canonical` in the same pass; PRIVACY.md regenerated.
- Honesty boundary in both headers: this binds artifact → operator's signed word → pinned key. NOT a reproducible-build proof; that rung is a later arc.

relay 1411 (4 new, incl. tamper-refusal via the canonical verifier) / cli 260; gates 127/127; cli-surface baseline regenerated; `motebit` minor changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)