### PR TITLE
docs: first-metered-dollar runbook — the post-execution 1.8.0 path

### DIFF
--- a/docs/ops/first-metered-dollar.md
+++ b/docs/ops/first-metered-dollar.md
@@ -2,8 +2,11 @@
 
 The first autonomous payment executed under a standing grant's signed ceiling:
 grant → due tick → `delegate_to_agent` → quote metered at the rail → atomic
-Solana USDC settlement → relay-recorded p2p row. Written 2026-07-05, every
-precondition below verified live that day.
+Solana USDC settlement → relay-recorded p2p row. Written 2026-07-05; **executed
+live 2026-07-07** — tx `2RJg2Yzj4Xwqb5vtuDeBhTykxMUDETY9nyinp8rP1uhwS8dZpgsij8sng4fARAWcQdMF9HfLJXswwBHmpRfHbaNS`
+(worker +$0.050000, treasury fee +$0.002632, atomic), refusal half proven the
+same tick. Everything below is the post-execution path as `motebit@1.8.0`
+ships it.
 
 ## Preconditions (verified)
 
@@ -20,16 +23,25 @@ relay,p2p`, Solana settlement address published. The quote the meter will see:
 
 ## Operator steps (founder's terminal — passphrase prompts throughout)
 
-1. **CLI with the metering chain.** Until `motebit@1.8+` is on npm, run the
-   repo build: `pnpm --filter motebit build` then alias
-   `alias mb='node <repo>/apps/cli/dist/index.js'`.
-2. **Point at the relay.** Add `"sync_url": "https://relay.motebit.com"` to
-   `~/.motebit/config.json` (or `export MOTEBIT_SYNC_URL=...`).
-3. **Register** the identity + device with the relay: `mb register`.
-   (Signed task submission verifies against the relay's device store.)
-4. **Fund the sovereign wallet.** `mb wallet` prints the identity-derived
-   Solana address and USDC balance. Send **≥ $1 USDC + ~0.005 SOL** (tx fees)
-   to it from the treasury Ledger. $1 covers ~19 tasks at the worker's price.
+1. **Install the CLI**: `npm i -g motebit` (≥ 1.8.0 — the metering chain,
+   grant pre-flight, and wallet homeostasis all ship in the published bundle).
+   Optionally prove the binary itself: `motebit verify-release` checks the
+   installed bundle's bytes against the relay's signed release witness.
+2. **Governance posture.** The `balanced` preset hard-denies R4 money — the
+   grant never overrides a hard ceiling (by design; proven live when the
+   first ceremony stalled on exactly this). Permit governed money
+   deliberately: set `"governance": {"approvalPreset": "autonomous"}` in
+   `~/.motebit/config.json`.
+3. **Register**: `motebit register` (defaults to the production relay and
+   saves `sync_url`). This also **pins the relay operator's key** from its
+   signed transparency declaration — the trust root the P2P treasury address
+   derives from. Watch for the `Pinned relay key …` line.
+4. **Fund the sovereign wallet.** `motebit wallet` prints the identity-derived
+   Solana address, balance, and its own funding posture. Send **≥ $1 USDC on
+   the SOLANA network + ~0.005 SOL** (tx fees) — or send SOL from anywhere
+   and normalize it yourself: `motebit wallet swap 0.02` converts SOL → USDC
+   working capital (gas floor enforced). $1 covers ~19 tasks at the worker's
+   price.
 5. **Mint the delegation grant** (the ceremony's successor to grant
    `019f3415…`, whose `pay_invoice` scope deliberately does not cover
    delegation — scope is a signed ceiling, so a new authority is a new grant):
@@ -51,13 +63,18 @@ relay,p2p`, Solana settlement address published. The quote the meter will see:
 
    `--pay-new-agents` is the cold-start acknowledgment — there is no trust
    history with the worker yet, and P2P eligibility fail-closes without it.
-   Then ask, in the REPL: _"Delegate a web search about <topic> to another
-   agent."_
+   **The pre-flight prints at launch**: one `[grant armed — …]` line means the
+   whole chain (grant → tick → governance → rail → pin → capital) is ready;
+   any blocker prints with its exact remedy. Then ask, in the REPL:
+   _"Delegate a web search about <topic> to another agent."_ No approval
+   prompt appears: the verified in-scope grant IS the R4 authorizer
+   (policy-gate 8c), bounded by everything the ceiling signed.
 
 ## What executes (the chain you are watching)
 
-gate 8b auto-clears R4 under the verified grant → loop admits the late-bound
-tool (grant + meter present) → discovery finds the worker → quote resolves
+the verified in-scope grant extends the tool offering to R4 and satisfies the
+approval band (gate 8c; 8b still re-raises any grantless R4) → loop admits the
+late-bound tool (grant + meter present) → discovery finds the worker → quote resolves
 ($0.05 + fee) → **`wrapP2pPaymentWithMeter` meters the gross against the $1
 lifetime with the tick's signed nonce** → atomic multi-output Solana USDC tx
 (worker leg + treasury fee leg) → submission carries `grant_id` (relay fence
@@ -73,8 +90,11 @@ signed receipt → trust bumps → relay records the `settlement_mode='p2p'` row
 - The accumulator: `sqlite3 ~/.motebit/motebit.db "select * from grant_spend_state;"`
   — lifetime_spent_micro should read the gross, high_water_nonce the tick's
   issued_at.
-- **The refusals are the proof.** Ask for a second delegation in the same
-  hour: the meter replays the nonce and refuses before broadcast. Run
+- **The refusals are the proof** (proven live 2026-07-07: meter row and
+  on-chain balance byte-identical after the refusal). Ask for a second
+  delegation in the same hour: the meter replays the nonce and refuses
+  before broadcast — the model surfaces it as a payment-authorization wall,
+  and the owner surface renders the typed `AuthorityDelta` repair. Run
   `mb grant revoke <id>`: the next tick is refused locally AND the relay
   fence 403s the submission — watch both.
 


### PR DESCRIPTION
Runbook refreshed from pre-execution draft to the path motebit@1.8.0 actually ships: npm install (verify-release optional), the governance-posture step the live ceremony stalled on, register's key pinning, wallet swap, the pre-flight verdict, 8c semantics, and the proven-live annotations (payment tx + refusal). Docs are siblings of code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)