### PR TITLE
fix(relay,surfaces,cli): make credentials + presentation owner-private (caller===:motebitId)

### DIFF
--- a/.changeset/owner-private-credentials.md
+++ b/.changeset/owner-private-credentials.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+CLI credential reads (`motebit credentials`, `motebit export`) now send the least-privilege `credentials` / `credentials:present` audience tokens the relay requires for the newly owner-private credential + presentation routes.

--- a/apps/cli/src/subcommands/credentials.ts
+++ b/apps/cli/src/subcommands/credentials.ts
@@ -19,7 +19,13 @@ export async function handleCredentials(config: CliConfig): Promise<void> {
   const motebitId = requireMotebitId(loadFullConfig());
 
   const syncUrl = config.syncUrl ?? process.env["MOTEBIT_SYNC_URL"];
-  const headers = await getRelayAuthHeaders(config);
+  // Credentials are owner-private (caller===:motebitId). Mint the
+  // least-privilege audience the relay enforces per route: the --presentation
+  // branch below hits POST /presentation (credentials:present), otherwise the
+  // GET /credentials read (credentials).
+  const headers = await getRelayAuthHeaders(config, {
+    aud: config.presentation ? "credentials:present" : "credentials",
+  });
 
   // Read locally-persisted peer-issued credentials from SQLite
   type CredRow = {

--- a/apps/cli/src/subcommands/export.ts
+++ b/apps/cli/src/subcommands/export.ts
@@ -162,6 +162,12 @@ export async function handleExport(config: CliConfig): Promise<void> {
 
   // Relay-dependent exports
   const syncUrl = config.syncUrl ?? process.env["MOTEBIT_SYNC_URL"];
+  // Credentials are owner-private per route: GET /credentials needs the
+  // `credentials` audience, POST /presentation the `credentials:present`
+  // audience. Mint both (per-call signed tokens are cheap).
+  const credHeaders = await getRelayAuthHeaders(config, { aud: "credentials" });
+  const vpHeaders = await getRelayAuthHeaders(config, { aud: "credentials:present" });
+  // Other relay reads below (e.g. /budget) keep the default admin:query.
   const headers = await getRelayAuthHeaders(config);
   const baseUrl = syncUrl ? syncUrl.replace(/\/$/, "") : null;
 
@@ -173,7 +179,7 @@ export async function handleExport(config: CliConfig): Promise<void> {
     // 3. Credentials
     const credResult = await fetchRelayJson(
       `${baseUrl}/api/v1/agents/${motebitId}/credentials`,
-      headers,
+      credHeaders,
     );
     if (credResult.ok) {
       const credBody = credResult.data as {
@@ -190,7 +196,7 @@ export async function handleExport(config: CliConfig): Promise<void> {
     // 4. Presentation (signed VP bundle)
     const vpResult = await fetchRelayJson(
       `${baseUrl}/api/v1/agents/${motebitId}/presentation`,
-      headers,
+      vpHeaders,
       "POST",
     );
     if (vpResult.ok) {

--- a/apps/mobile/src/components/SovereignPanel.tsx
+++ b/apps/mobile/src/components/SovereignPanel.tsx
@@ -14,6 +14,7 @@ import {
   Linking,
 } from "react-native";
 import type { MobileApp } from "../mobile-app";
+import type { TokenAudience } from "@motebit/sdk";
 import { useTheme, type ThemeColors } from "../theme";
 import {
   createSovereignController,
@@ -94,6 +95,15 @@ async function bootstrapAnchor(syncUrl: string): Promise<TransparencyAnchor | un
   }
 }
 
+// Owner-private credential routes (2026-07-07) need their least-privilege
+// audience so a sync token can't read/present another agent's credentials.
+// Mirror of web's audienceForPath.
+function audienceForPath(path: string): TokenAudience {
+  if (path.includes("/presentation")) return "credentials:present";
+  if (path.includes("/credentials")) return "credentials";
+  return "sync";
+}
+
 // Mobile's sync URL comes from AsyncStorage (async). The adapter's `syncUrl`
 // getter is synchronous, so we cache the URL in a ref and prime it in the
 // effect before calling refresh().
@@ -111,7 +121,7 @@ function createMobileAdapter(
     async fetch(path: string, init?: SovereignFetchInit) {
       const syncUrl = syncUrlRef.current;
       if (!syncUrl) throw new Error("No relay URL configured");
-      const token = await app.createSyncToken();
+      const token = await app.createSyncToken(audienceForPath(path));
       const headers: Record<string, string> = {
         "Content-Type": "application/json",
         ...(init?.headers ?? {}),

--- a/apps/spatial/src/app.ts
+++ b/apps/spatial/src/app.ts
@@ -1071,7 +1071,13 @@ async function loadCredentials(): Promise<void> {
   if (!settings.relayUrl || !settings.showNetwork) return;
 
   try {
-    const resp = await fetch(`${settings.relayUrl}/api/v1/agents/${app.motebitId}/credentials`);
+    // Credentials are owner-private (caller===:motebitId, 2026-07-07): send a
+    // credentials-audience device token. Null before identity unlock → skip.
+    const token = await app.createSyncToken("credentials");
+    if (token == null) return;
+    const resp = await fetch(`${settings.relayUrl}/api/v1/agents/${app.motebitId}/credentials`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
     if (!resp.ok) return;
     const data = (await resp.json()) as {
       credentials?: Array<{

--- a/apps/spatial/src/spatial-app.ts
+++ b/apps/spatial/src/spatial-app.ts
@@ -47,6 +47,7 @@ import {
   type BootstrapKeyStore,
 } from "@motebit/core-identity";
 import { createSignedToken, secureErase } from "@motebit/encryption";
+import type { TokenAudience } from "@motebit/sdk";
 import { generate as generateIdentityFile } from "@motebit/identity-file";
 import type {
   MotebitState,
@@ -263,6 +264,29 @@ export class SpatialApp {
   // and exportIdentity also reads privKeyBytes for motebit.md generation.
   private tokenFactory: (() => Promise<string>) | null = null;
   private _privKeyBytes: Uint8Array | null = null;
+
+  /**
+   * Mint a signed device-auth token bound to this motebit, for a given
+   * audience. Public so surface code (app.ts loadCredentials) can
+   * authenticate owner-private relay reads (credentials became
+   * caller===:motebitId-authed 2026-07-07). Returns null before the
+   * identity is unlocked. Sibling of the sync-controller's tokenFactory
+   * (which is hardcoded to `sync`).
+   */
+  async createSyncToken(aud: TokenAudience = "sync"): Promise<string | null> {
+    if (this._privKeyBytes == null || this.motebitId === "spatial-local") return null;
+    return createSignedToken(
+      {
+        mid: this.motebitId,
+        did: this.deviceId,
+        iat: Date.now(),
+        exp: Date.now() + 5 * 60 * 1000,
+        jti: crypto.randomUUID(),
+        aud,
+      },
+      this._privKeyBytes,
+    );
+  }
   private _planStore: IdbPlanStore | null = null;
   private _pendingApprovalResolve: ((approved: boolean) => void) | null = null;
 

--- a/apps/web/src/ui/sovereign-panels.ts
+++ b/apps/web/src/ui/sovereign-panels.ts
@@ -105,6 +105,12 @@ async function bootstrapAnchor(syncUrl: string): Promise<TransparencyAnchor | un
 // `check-audience-canonical` stays green.
 function audienceForPath(path: string): TokenAudience {
   if (path.includes("/balance")) return ACCOUNT_BALANCE_AUDIENCE;
+  // Owner-private credential routes (2026-07-07): mint the least-privilege
+  // audience the relay enforces so a sync token can't read/present another
+  // agent's credentials. Presentation before credentials — /presentation
+  // also contains no "/credentials" substring, but order-guard anyway.
+  if (path.includes("/presentation")) return "credentials:present";
+  if (path.includes("/credentials")) return "credentials";
   return "sync";
 }
 

--- a/services/relay/src/__tests__/dogfood-e2e.test.ts
+++ b/services/relay/src/__tests__/dogfood-e2e.test.ts
@@ -693,7 +693,8 @@ describe("Dogfood E2E — Two-Motebit Delegation", () => {
 
   it("18. Relay issues AgentReputationCredential to B after successful receipt", async () => {
     const tokenASubmit = await makeSignedToken(motebitIdA, relayDeviceIdA, keypairA, "task:submit");
-    const tokenACreds = await makeSignedToken(motebitIdA, relayDeviceIdA, keypairA, "credentials");
+    // Owner-private (2026-07-07): B's credential is read by B, not A.
+    const tokenBCreds = await makeSignedToken(motebitIdB, relayDeviceIdB, keypairB, "credentials");
 
     // B is already in the agent registry (from test 7). Connect B's device.
     const bWs = { send: vi.fn(), close: vi.fn(), readyState: 1 };
@@ -746,7 +747,7 @@ describe("Dogfood E2E — Two-Motebit Delegation", () => {
     // Retrieve credentials from the relay's credential store
     const credsRes = await relay.app.request(`/api/v1/agents/${motebitIdB}/credentials`, {
       method: "GET",
-      headers: { Authorization: `Bearer ${tokenACreds}` },
+      headers: { Authorization: `Bearer ${tokenBCreds}` },
     });
     expect(credsRes.status).toBe(200);
     const credsBody = (await credsRes.json()) as {
@@ -775,12 +776,14 @@ describe("Dogfood E2E — Two-Motebit Delegation", () => {
   });
 
   it("19. Public credential verification endpoint validates B's reputation credential", async () => {
-    const tokenA = await makeSignedToken(motebitIdA, relayDeviceIdA, keypairA, "credentials");
+    // B reads its OWN reputation credential (owner-private); the /credentials/verify
+    // endpoint below is public and verifies the resulting VC regardless of caller.
+    const tokenBCred = await makeSignedToken(motebitIdB, relayDeviceIdB, keypairB, "credentials");
 
     // Fetch the credential
     const credsRes = await relay.app.request(`/api/v1/agents/${motebitIdB}/credentials`, {
       method: "GET",
-      headers: { Authorization: `Bearer ${tokenA}` },
+      headers: { Authorization: `Bearer ${tokenBCred}` },
     });
     const credsBody = (await credsRes.json()) as {
       credentials: Array<{ credential: Record<string, unknown> }>;

--- a/services/relay/src/__tests__/listing-auth.test.ts
+++ b/services/relay/src/__tests__/listing-auth.test.ts
@@ -168,11 +168,60 @@ describe("sibling-sweep: previously-bypassing agent routes now fail closed", () 
     expect(res.status).not.toBe(401);
   });
 
-  it("GET credentials stays public-read (deliberate carve-out pending the privacy decision)", async () => {
-    const a = await seedAgent(relay);
-    const res = await relay.app.request(`/api/v1/agents/${a.motebitId}/credentials`, {
+  it("GET credentials is now OWNER-PRIVATE — no token 401, another agent 403, own 200", async () => {
+    // Flipped 2026-07-07 (Daniel's decision): credentials became
+    // owner-private (caller===:motebitId) under the `credentials` audience.
+    const victim = await seedAgent(relay);
+    const noAuth = await relay.app.request(`/api/v1/agents/${victim.motebitId}/credentials`, {
       method: "GET",
     });
-    expect(res.status).not.toBe(401);
+    expect(noAuth.status).toBe(401);
+
+    const attacker = await seedAgent(relay);
+    const attackerToken = await mintToken(
+      attacker.motebitId,
+      attacker.deviceId,
+      attacker.privateKey,
+      "credentials",
+    );
+    const crossed = await relay.app.request(`/api/v1/agents/${victim.motebitId}/credentials`, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${attackerToken}` },
+    });
+    expect(crossed.status).toBe(403);
+
+    const ownToken = await mintToken(
+      victim.motebitId,
+      victim.deviceId,
+      victim.privateKey,
+      "credentials",
+    );
+    const own = await relay.app.request(`/api/v1/agents/${victim.motebitId}/credentials`, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${ownToken}` },
+    });
+    expect(own.status).toBe(200);
+  });
+
+  it("POST presentation is owner-private — no token 401, another agent 403", async () => {
+    const victim = await seedAgent(relay);
+    const noAuth = await relay.app.request(`/api/v1/agents/${victim.motebitId}/presentation`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(noAuth.status).toBe(401);
+
+    const attacker = await seedAgent(relay);
+    const attackerToken = await mintToken(
+      attacker.motebitId,
+      attacker.deviceId,
+      attacker.privateKey,
+      "credentials:present",
+    );
+    const crossed = await relay.app.request(`/api/v1/agents/${victim.motebitId}/presentation`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${attackerToken}` },
+    });
+    expect(crossed.status).toBe(403);
   });
 });

--- a/services/relay/src/agents.ts
+++ b/services/relay/src/agents.ts
@@ -334,27 +334,12 @@ export const PUBLIC_AGENT_ROUTES: ReadonlyArray<{
   {
     match: (p, m) => p.endsWith("/settlements") && m === "GET",
     reason:
-      "settlements (GET): financial settlement history. CURRENTLY OPEN " +
-      "(was registered before the pre-fix middleware). PENDING DECISION: " +
-      "owner-private (like receipts, caller===:motebitId) vs public-audit — " +
-      "needs client-auth reconciliation before enforcing. Tracked in the " +
-      "security backlog; carved explicit (not silently open) meanwhile.",
-  },
-  {
-    match: (p, m) => p.endsWith("/credentials") && m === "GET",
-    reason:
-      "credentials (GET): public-read of verifiable attestations — VCs are " +
-      "designed to be presentable/verifiable. PENDING DECISION: if these " +
-      "become owner-private, reconcile the divergent client audiences " +
-      "(web/mobile=sync, cli=admin:query, desktop/inspector=master) and " +
-      "wire apps/spatial loadCredentials to send a token before enforcing.",
-  },
-  {
-    match: (p, m) => p.endsWith("/presentation") && m === "POST",
-    reason:
-      "presentation (POST): generates a shareable Verifiable Presentation " +
-      "from an agent's attestations. Same public-attestation rationale + " +
-      "pending owner-private decision as credentials (GET).",
+      "settlements (GET): owner-private financial history, but enforced by " +
+      "its OWN dedicated dualAuth(account:balance) in middleware.ts (same " +
+      "class as /balance) + the handler's first-person own-id check. This " +
+      "agent-middleware carve-out DEFERS to that dualAuth — removing it would " +
+      "double-wrap the route (admin:query here vs account:balance there) and " +
+      "conflict. Not public: account:balance-authed, caller===:motebitId.",
   },
 ];
 

--- a/services/relay/src/credentials.ts
+++ b/services/relay/src/credentials.ts
@@ -295,6 +295,14 @@ export function registerCredentialRoutes(deps: CredentialDeps): void {
   /** @spec motebit/credential@1.0 */
   app.get("/api/v1/agents/:motebitId/credentials", (c) => {
     const mid = asMotebitId(c.req.param("motebitId"));
+    // Owner-private (2026-07-07): an agent's credentials are its own. The
+    // `/api/v1/agents/*` middleware verified a `credentials`-audience device
+    // token and set callerMotebitId; enforce caller===:motebitId here (the
+    // operator master token leaves callerMotebitId undefined = allowed).
+    const callerMotebitId = c.get("callerMotebitId" as never) as string | undefined;
+    if (callerMotebitId !== undefined && callerMotebitId !== mid) {
+      throw new HTTPException(403, { message: "Cannot read another agent's credentials" });
+    }
     const typeFilter = c.req.query("type");
     const limit = Math.min(parseInt(c.req.query("limit") ?? "50", 10) || 50, 200);
 
@@ -332,6 +340,14 @@ export function registerCredentialRoutes(deps: CredentialDeps): void {
   /** @spec motebit/credential@1.0 */
   app.post("/api/v1/agents/:motebitId/presentation", async (c) => {
     const mid = asMotebitId(c.req.param("motebitId"));
+    // Owner-private (2026-07-07): a Verifiable Presentation exposes the
+    // agent's own credentials — leaving it public would defeat the
+    // credentials-GET privacy above. `credentials:present`-audience device
+    // token; caller===:motebitId (master token = operator-allowed).
+    const callerMotebitId = c.get("callerMotebitId" as never) as string | undefined;
+    if (callerMotebitId !== undefined && callerMotebitId !== mid) {
+      throw new HTTPException(403, { message: "Cannot present another agent's credentials" });
+    }
     const typeFilter = c.req.query("type");
     const limit = Math.min(parseInt(c.req.query("limit") ?? "100", 10) || 100, 500);
 


### PR DESCRIPTION
Your decision (2026-07-07): settlements + credentials owner-private. The last `PUBLIC_AGENT_ROUTES` pending-decision entries, closed — the sweep is fully done.

- **settlements**: already owner-private via its own `dualAuth(account:balance)` + the handler's first-person check. The agent-middleware carve-out just defers to that dualAuth (removing it would double-wrap and conflict). Fixed its reason; no behavior change.
- **credentials (GET) + presentation (POST)**: removed from `PUBLIC_AGENT_ROUTES`; the hoisted middleware now authenticates them under the least-privilege `credentials` / `credentials:present` audiences (already in the registry — no protocol change); handlers gained `caller===:motebitId` (master token = operator-allowed). **Presentation is included with credentials** — a VP exposes the same data, so leaving it public would defeat credential privacy.
- **clients wired**: web + mobile panels (`audienceForPath` extended), cli `credentials.ts` + `export.ts` (per-route audience), spatial (new public `SpatialApp.createSyncToken`; `loadCredentials` was a bare unauth fetch — the one hard break, now fixed). desktop + inspector use the operator master token (bypass), unchanged.
- **dogfood-e2e**: cross-agent credential reads corrected to owner-reads-own. The secure VC pattern is holder-presents + public `/credentials/verify`, not a direct cross-agent GET — worth knowing: agent-to-agent credential inspection now goes through present→verify, never a raw read. `listing-auth` regression flipped: credentials/presentation now no-token→401, another-agent→403, own→200.

relay 1421; gates 128/128; typecheck + lint clean across relay + 4 surfaces + cli. `motebit` patch changeset (cli audience change).

**Deploy note:** changes live routes; holding for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)