### PR TITLE
build(deps): bump docker/* actions in publish-images.yml (consolidates #276-279)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -78,13 +78,13 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU (cross-arch emulation for arm64 builds)
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -92,7 +92,7 @@ jobs:
 
       - name: Build and push (amd64 + arm64)
         id: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: services/relay/Dockerfile


### PR DESCRIPTION
Folds four same-file dependabot bumps into one commit to avoid the merge-conflict cascade — all four edit `.github/workflows/publish-images.yml`:

- `docker/setup-qemu-action` 4.1.0 → 4.2.0 (#279)
- `docker/setup-buildx-action` 4.1.0 → 4.2.0 (#278)
- `docker/login-action` 4.2.0 → 4.4.0 (#277)
- `docker/build-push-action` 7.2.0 → 7.3.0 (#276)

SHA-pinned to the exact versions dependabot resolved. Supersedes and closes #276–279. CI-infra only (workflow file); no product/runtime change, no relay deploy triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)