### PR TITLE
fix(create-motebit): forward-compat crypto args for the Uint8Array generic change

### DIFF
--- a/.changeset/create-motebit-uint8array.md
+++ b/.changeset/create-motebit-uint8array.md
@@ -1,0 +1,5 @@
+---
+"create-motebit": patch
+---
+
+Forward-compat crypto argument handling: WebCrypto calls (digest/importKey/encrypt/deriveBits) wrap their `Uint8Array` args in `new Uint8Array(...)` so they present an ArrayBuffer-backed `BufferSource`. Behavior-preserving (identical bytes); makes the scaffolding CLI compile cleanly under newer `@types/node` (the generic `Uint8Array<ArrayBufferLike>` change) while remaining valid on the current Node 22 runtime.

--- a/packages/create-motebit/src/generate.ts
+++ b/packages/create-motebit/src/generate.ts
@@ -98,7 +98,7 @@ function generateUUIDv7(): string {
  * offline for ids minted this way.
  */
 async function deriveSovereignMotebitId(publicKey: Uint8Array): Promise<string> {
-  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", publicKey));
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", new Uint8Array(publicKey)));
   const b = digest.slice(0, 16);
   b[6] = 0x80 | (b[6]! & 0x0f); // version 8 (RFC 9562, vendor-specific)
   b[8] = 0x80 | (b[8]! & 0x3f); // variant 10b
@@ -151,7 +151,7 @@ async function deriveKey(
     ["deriveBits"],
   );
   const bits = await crypto.subtle.deriveBits(
-    { name: "PBKDF2", salt, iterations, hash: "SHA-256" },
+    { name: "PBKDF2", salt: new Uint8Array(salt), iterations, hash: "SHA-256" },
     keyMaterial,
     256,
   );
@@ -163,8 +163,14 @@ async function encrypt(
   key: Uint8Array,
 ): Promise<{ ciphertext: Uint8Array; nonce: Uint8Array; tag: Uint8Array }> {
   const nonce = generateNonce();
-  const cryptoKey = await crypto.subtle.importKey("raw", key, "AES-GCM", false, ["encrypt"]);
-  const result = await crypto.subtle.encrypt({ name: "AES-GCM", iv: nonce }, cryptoKey, plaintext);
+  const cryptoKey = await crypto.subtle.importKey("raw", new Uint8Array(key), "AES-GCM", false, [
+    "encrypt",
+  ]);
+  const result = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: new Uint8Array(nonce) },
+    cryptoKey,
+    new Uint8Array(plaintext),
+  );
   const resultArray = new Uint8Array(result);
   // AES-GCM appends a 16-byte tag
   const ciphertext = resultArray.slice(0, resultArray.length - 16);
@@ -179,12 +185,14 @@ export async function decrypt(
   payload: { ciphertext: Uint8Array; nonce: Uint8Array; tag: Uint8Array },
   key: Uint8Array,
 ): Promise<Uint8Array> {
-  const cryptoKey = await crypto.subtle.importKey("raw", key, "AES-GCM", false, ["decrypt"]);
+  const cryptoKey = await crypto.subtle.importKey("raw", new Uint8Array(key), "AES-GCM", false, [
+    "decrypt",
+  ]);
   const combined = new Uint8Array(payload.ciphertext.length + payload.tag.length);
   combined.set(payload.ciphertext);
   combined.set(payload.tag, payload.ciphertext.length);
   const result = await crypto.subtle.decrypt(
-    { name: "AES-GCM", iv: payload.nonce },
+    { name: "AES-GCM", iv: new Uint8Array(payload.nonce) },
     cryptoKey,
     combined,
   );

--- a/packages/create-motebit/src/rotate.ts
+++ b/packages/create-motebit/src/rotate.ts
@@ -140,7 +140,7 @@ async function deriveKey(
     ["deriveBits"],
   );
   const bits = await crypto.subtle.deriveBits(
-    { name: "PBKDF2", salt, iterations, hash: "SHA-256" },
+    { name: "PBKDF2", salt: new Uint8Array(salt), iterations, hash: "SHA-256" },
     keyMaterial,
     256,
   );
@@ -152,8 +152,14 @@ async function encrypt(
   key: Uint8Array,
 ): Promise<{ ciphertext: Uint8Array; nonce: Uint8Array; tag: Uint8Array }> {
   const nonce = generateNonce();
-  const cryptoKey = await crypto.subtle.importKey("raw", key, "AES-GCM", false, ["encrypt"]);
-  const result = await crypto.subtle.encrypt({ name: "AES-GCM", iv: nonce }, cryptoKey, plaintext);
+  const cryptoKey = await crypto.subtle.importKey("raw", new Uint8Array(key), "AES-GCM", false, [
+    "encrypt",
+  ]);
+  const result = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: new Uint8Array(nonce) },
+    cryptoKey,
+    new Uint8Array(plaintext),
+  );
   const resultArray = new Uint8Array(result);
   const ciphertext = resultArray.slice(0, resultArray.length - 16);
   const tag = resultArray.slice(resultArray.length - 16);


### PR DESCRIPTION
The `@types/node` 26 bump (#235) that dependabot held as a red "major arc" turned out to be **9 typecheck errors, all in one scaffolding package** — `create-motebit`. This lands the fix decoupled from the version bump.

Every failure was the same class: `Uint8Array<ArrayBufferLike>` not assignable to `BufferSource` at WebCrypto call sites (digest / importKey / encrypt / deriveBits). Under @types/node 26 (and the TS 5.7+ generic `Uint8Array`), `ArrayBufferLike` admits `SharedArrayBuffer`, so a plain `Uint8Array` no longer satisfies `BufferSource`. Fix: wrap each crypto arg in `new Uint8Array(...)` (an ArrayBuffer-backed copy) — behavior-preserving (identical bytes), compiles on both @types/node 22 (current Node 22 runtime) and 26.

**Proof it's the whole fix:** full monorepo typecheck is green under @types/node 26 with only this change. create-motebit typecheck + build + 49 tests green on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)