### PR TITLE
fix(summarize): lazy per-task web-search connect (stop the boot flap)

### DIFF
--- a/services/summarize/src/__tests__/lazy-connect.test.ts
+++ b/services/summarize/src/__tests__/lazy-connect.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Lazy-connect contract for the summarize handler.
+ *
+ * The delegating service must register at boot and connect to web-search
+ * on the FIRST task, not eagerly at boot — an unreachable dependency
+ * fails the task, never crashes the service (the staging flap this fixes).
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { McpClientAdapter } from "@motebit/mcp-client";
+import { createSummarizeSearchHandler } from "../tool.js";
+
+function fakeAdapter(executeResult: { ok: boolean; data?: unknown; error?: string }) {
+  return {
+    serverName: "web-search",
+    executeTool: vi.fn(async () => executeResult),
+  } as unknown as McpClientAdapter;
+}
+
+describe("summarize handler — lazy connect", () => {
+  it("calls ensureConnected before delegating, exactly once per invocation", async () => {
+    const ensure = vi.fn(async () => {});
+    const adapter = fakeAdapter({ ok: true, data: "[]" });
+    const handler = createSummarizeSearchHandler(adapter, ensure);
+
+    const res = await handler({ query: "hello" });
+    expect(res.ok).toBe(true);
+    expect(ensure).toHaveBeenCalledTimes(1);
+    // ensure runs before the delegation
+    expect(ensure.mock.invocationCallOrder[0]!).toBeLessThan(
+      (adapter.executeTool as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("a failed connect fails the TASK (ok:false), never throws — the service survives", async () => {
+    const ensure = vi.fn(async () => {
+      throw new Error("web-search cold");
+    });
+    const adapter = fakeAdapter({ ok: true, data: "[]" });
+    const handler = createSummarizeSearchHandler(adapter, ensure);
+
+    const res = await handler({ query: "hello" });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("web-search unreachable");
+    // The dependency was never reached — the connect gate short-circuited.
+    expect(adapter.executeTool).not.toHaveBeenCalled();
+  });
+
+  it("without an ensureConnected fn, the handler still works (backward compatible)", async () => {
+    const adapter = fakeAdapter({ ok: true, data: "[]" });
+    const handler = createSummarizeSearchHandler(adapter);
+    const res = await handler({ query: "hello" });
+    expect(res.ok).toBe(true);
+  });
+});

--- a/services/summarize/src/index.ts
+++ b/services/summarize/src/index.ts
@@ -67,18 +67,37 @@ export { summarizeSearchDefinition, createSummarizeSearchHandler } from "./tool.
 async function main(): Promise<void> {
   const config = loadConfig();
 
-  // Upstream MCP client connects BEFORE the runner boots so handler
-  // registration can close over the adapter. Connection is cheap and
-  // failure should be loud (the service cannot function without
-  // web-search reachable).
+  // Upstream MCP client is created here but connected LAZILY — on the
+  // first task, not at boot. Eager `await connect()` before runMolecule
+  // meant a slow or unreachable web-search crashed the process before its
+  // HTTP server ever started, so the service never registered and the Fly
+  // machine flapped (health-check critical). A delegating service that
+  // can't reach its dependency should fail the TASK loudly, not the
+  // BOOT — the same lazy-per-task pattern `services/research` uses.
+  // McpClientAdapter.connect() is idempotent; a small in-flight guard
+  // coalesces concurrent tasks and lets a transient failure retry on the
+  // next task instead of poisoning the service.
   const webSearchAdapter = new McpClientAdapter({
     name: "web-search",
     transport: "http",
     url: `${config.webSearchUrl}/mcp`,
     ...(config.webSearchAuthToken ? { authToken: config.webSearchAuthToken } : {}),
   });
-  await webSearchAdapter.connect();
-  log(`Connected to web-search at ${config.webSearchUrl}`);
+  let connecting: Promise<void> | null = null;
+  const ensureWebSearchConnected = async (): Promise<void> => {
+    // Reuse an in-flight connect; on failure clear the guard so the next
+    // task retries rather than awaiting a permanently-rejected promise.
+    if (connecting == null) {
+      connecting = webSearchAdapter.connect().then(
+        () => log(`Connected to web-search at ${config.webSearchUrl}`),
+        (err: unknown) => {
+          connecting = null;
+          throw err;
+        },
+      );
+    }
+    return connecting;
+  };
 
   await runMolecule(
     {
@@ -98,7 +117,10 @@ async function main(): Promise<void> {
       const { motebitId, publicKey, privateKey } = identity;
 
       const registry = new InMemoryToolRegistry();
-      registry.register(summarizeSearchDefinition, createSummarizeSearchHandler(webSearchAdapter));
+      registry.register(
+        summarizeSearchDefinition,
+        createSummarizeSearchHandler(webSearchAdapter, ensureWebSearchConnected),
+      );
 
       const handleAgentTask = async function* (
         prompt: string,
@@ -109,6 +131,9 @@ async function main(): Promise<void> {
 
         let result: ToolResult;
         try {
+          // Lazy connect is owned by the handler (createSummarizeSearchHandler)
+          // so BOTH this relay-task path and any direct tool call establish
+          // the web-search link on demand.
           result = await registry.execute("summarize_search", { query: prompt });
         } catch (err: unknown) {
           const msg = err instanceof Error ? err.message : String(err);

--- a/services/summarize/src/tool.ts
+++ b/services/summarize/src/tool.ts
@@ -20,14 +20,30 @@ export const summarizeSearchDefinition: ToolDefinition = {
 
 /**
  * Create the summarize_search handler that delegates to web-search via MCP.
+ *
+ * `ensureConnected` (optional) establishes the web-search link lazily on
+ * the first invocation — the delegating service registers at boot and
+ * connects to its dependency on the task path, so an unreachable
+ * web-search fails THIS call rather than crashing the service. Covers
+ * both the relay `handleAgentTask` path and any direct tool invocation.
  */
 export function createSummarizeSearchHandler(
   webSearchAdapter: McpClientAdapter,
+  ensureConnected?: () => Promise<void>,
 ): (args: Record<string, unknown>) => Promise<ToolResult> {
   return async (args: Record<string, unknown>): Promise<ToolResult> => {
     const rawQuery = args["query"];
     const query = typeof rawQuery === "string" ? rawQuery : "";
     if (!query) return { ok: false, error: "Missing query parameter" };
+
+    if (ensureConnected != null) {
+      try {
+        await ensureConnected();
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { ok: false, error: `web-search unreachable: ${msg}` };
+      }
+    }
 
     // Delegate to web-search's motebit_task (qualified name: serverName__toolName)
     const qualifiedName = `${webSearchAdapter.serverName}__motebit_task`;


### PR DESCRIPTION
Closes #297.

summarize hard-connected to web-search at boot (`await connect()` before `runMolecule` started the HTTP server), so a slow/unreachable web-search crashed the process before it could register — the Fly machine flapped health-check-critical and the atom was never discoverable. `services/research` connects lazily per-task and stays up; summarize now matches.

The adapter is created at boot but connected on the FIRST task via an in-flight-coalescing guard (`connect()` is idempotent; a transient failure clears the guard so the next task retries instead of awaiting a poisoned promise). The connect lives in the handler so BOTH the relay `handleAgentTask` path and any direct `summarize_search` call establish the link on demand — an unreachable dependency fails the TASK (`ok:false "web-search unreachable"`), never the service.

**Verified on staging:** `/health` → 200, summarize registers, slate is 5/5 discoverable with claim names. 3 new lazy-connect tests; 8 summarize tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)