### PR TITLE
fix(web): two prod UI bugs — fused assistant bubbles (#292) + orphaned consent modal (#293)

### DIFF
--- a/apps/web/src/__tests__/capabilities-panel.test.ts
+++ b/apps/web/src/__tests__/capabilities-panel.test.ts
@@ -609,6 +609,98 @@ describe("Skills panel — full lifecycle on web (IDB-backed)", () => {
     expect(installed.length).toBe(0);
   });
 
+  it("closing the panel mid-consent tears down the modal and declines fail-closed (#293)", async () => {
+    const { envelope, body } = await buildBundle("consent-orphan-skill", "medical");
+    const dbName = `panel-orphan-${crypto.randomUUID()}`;
+    const db = await openMotebitDB(dbName);
+    const registry = new SkillRegistry(new IdbSkillStorageAdapter(db));
+
+    const submitter = "did:key:zTestSubmitter";
+    const submittedAt = Date.now();
+    const listing: SkillRegistryListing = {
+      entries: [
+        {
+          submitter_motebit_id: submitter,
+          name: envelope.skill.name,
+          version: envelope.skill.version,
+          content_hash: envelope.skill.content_hash,
+          description: envelope.manifest.description,
+          sensitivity: "medical",
+          platforms: envelope.manifest.platforms ?? ["macos"],
+          signature_public_key: envelope.signature.public_key,
+          submitted_at: submittedAt,
+          featured: true,
+        },
+      ],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    };
+    const bundle: SkillRegistryBundle = {
+      submitter_motebit_id: submitter,
+      envelope,
+      body: bytesToBase64(body),
+      files: {},
+      submitted_at: submittedAt,
+      featured: true,
+    };
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.includes("/api/v1/skills/discover")) {
+        return new Response(JSON.stringify(listing), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.includes(`/api/v1/skills/${encodeURIComponent(submitter)}/`)) {
+        return new Response(JSON.stringify(bundle), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const ctx: WebContext = {
+      app: { getSkillRegistry: () => registry, getSkillAuditSink: () => null } as unknown as WebApp,
+      getConfig: () => null,
+      setConfig: () => undefined,
+      addMessage: () => undefined,
+      showToast: () => undefined,
+      bootstrapProxy: () => Promise.resolve(false),
+    };
+    const api = initCapabilitiesPanel(ctx);
+    api.open();
+    const list = document.getElementById("skills-list") as HTMLDivElement;
+    await waitFor(() => {
+      expect(list.querySelectorAll(".skill-row-browse").length).toBe(1);
+    });
+    list
+      .querySelector<HTMLButtonElement>('.skill-row-browse button[data-action="install"]')!
+      .click();
+
+    const modal = document.getElementById("skills-consent-modal");
+    const modalBackdrop = document.getElementById("skills-consent-backdrop");
+    await waitFor(() => {
+      expect(modal?.classList.contains("open")).toBe(true);
+    });
+
+    // Close the PANEL while the consent modal is still open — the exact
+    // orphaning path from prod #293 (previously the modal + its full-screen
+    // backdrop survived over plain chat with a dangling pending promise).
+    api.close();
+
+    await waitFor(async () => {
+      // The modal and its backdrop are torn down with the panel...
+      expect(modal?.classList.contains("open")).toBe(false);
+      expect(modalBackdrop?.classList.contains("open")).toBe(false);
+      // ...and the install is DECLINED fail-closed — no skill installed.
+      const installed = await registry.list();
+      expect(installed.length).toBe(0);
+    });
+  });
+
   it("personal-tier install skips consent prompt entirely", async () => {
     // Sensitivity below the consent threshold flows straight into install
     // — important counter-test so the gate doesn't false-trigger on

--- a/apps/web/src/__tests__/chat-approval-gate.test.ts
+++ b/apps/web/src/__tests__/chat-approval-gate.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression for #292 — assistant responses must NOT fuse across an
+ * approval gate. The pre-gate narration and the post-gate response are
+ * distinct assistant turns (separated by the tool_use/tool_result the
+ * gate wraps); each must render in its OWN `.chat-bubble.assistant`. The
+ * bug appended the post-gate text into the still-live pre-gate bubble.
+ */
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import type { WebContext } from "../types";
+
+// chat.ts imports the voice queue at module load — stub it.
+vi.mock("@motebit/voice", () => ({
+  StreamingTTSQueue: class {
+    push(): void {}
+    flush(): void {}
+    clear(): void {}
+    cancel(): void {}
+  },
+  WebSpeechTTSProvider: class {
+    cancel(): void {}
+    speak(): Promise<void> {
+      return Promise.resolve();
+    }
+  },
+}));
+
+// The 5 ids chat.ts grabs at module import — must exist BEFORE the import.
+function mountChatDom(): void {
+  document.body.innerHTML = `
+    <div id="chat-log"></div>
+    <input id="chat-input" />
+    <div id="chat-input-row"></div>
+    <button id="send-btn"></button>
+    <div id="toast-container"></div>
+  `;
+}
+
+let initChat: typeof import("../ui/chat").initChat;
+
+beforeAll(async () => {
+  mountChatDom();
+  initChat = (await import("../ui/chat")).initChat;
+});
+
+/** A ctx.app that streams: text → approval_request → (resume) text. */
+function gateStreamingApp() {
+  return {
+    isProcessing: false,
+    isProviderConnected: true,
+    motebitId: "test-motebit",
+    setTaskStepNarration: vi.fn(),
+    addArtifact: vi.fn(),
+    removeArtifact: vi.fn(),
+    // eslint-disable-next-line require-yield -- generator shape is the contract
+    async *sendMessageStreaming() {
+      yield { type: "text", text: "the pre-gate narration" };
+      yield {
+        type: "approval_request",
+        name: "delegate_to_agent",
+        args: { prompt: "x" },
+        risk_level: 4,
+      };
+    },
+    async *resolveApprovalVote() {
+      yield { type: "text", text: "THE-POST-GATE-RESPONSE" };
+      yield { type: "result" };
+    },
+  } as unknown as WebContext["app"];
+}
+
+describe("approval gate — no bubble fusion (#292)", () => {
+  it("renders the pre-gate and post-gate responses in TWO distinct assistant bubbles", async () => {
+    const chatLog = document.getElementById("chat-log")!;
+    chatLog.innerHTML = "";
+
+    const ctx = {
+      app: gateStreamingApp(),
+      showToast: vi.fn(),
+      getConfig: () => null,
+    } as unknown as WebContext;
+
+    const api = initChat(ctx, { openSettings: vi.fn() } as unknown as Parameters<
+      typeof initChat
+    >[1]);
+
+    // Start the send; while it awaits the approval card, click Allow.
+    const done = api.handleSend("do the thing");
+    await vi.waitFor(() => {
+      const allow = chatLog.querySelector<HTMLButtonElement>(".approval-btn.approve");
+      expect(allow).not.toBeNull();
+      allow!.click();
+    });
+    await done;
+
+    const bubbles = chatLog.querySelectorAll(".chat-bubble.assistant");
+    // Two turns, two bubbles — the core regression assertion.
+    expect(bubbles.length).toBe(2);
+
+    await vi.waitFor(() => {
+      const texts = Array.from(bubbles).map((b) => b.textContent ?? "");
+      // Pre-gate text lives only in bubble #1, post-gate only in bubble #2 —
+      // neither bubble contains BOTH (that fusion is the bug).
+      expect(texts.some((t) => t.includes("pre-gate") && t.includes("POST-GATE"))).toBe(false);
+      expect(texts.some((t) => t.includes("pre-gate"))).toBe(true);
+      expect(texts.some((t) => t.includes("POST-GATE"))).toBe(true);
+    });
+  });
+});

--- a/apps/web/src/ui/capabilities-panel.ts
+++ b/apps/web/src/ui/capabilities-panel.ts
@@ -200,7 +200,19 @@ export function initCapabilitiesPanel(ctx: WebContext): CapabilitiesPanelAPI {
     void refresh();
   }
 
+  // Teardown for an in-flight sensitive-skill consent modal. Set while the
+  // modal is open (showConsentModal below), cleared when it resolves. The
+  // consent modal is a child of THIS panel's install flow — it must never
+  // outlive the panel. Without this, closing the panel (close button,
+  // backdrop, or browser Back) left the "Install Sensitive Skill?" modal +
+  // its full-screen backdrop floating over plain chat with a dangling
+  // pending promise (prod #293). Calling it fail-closed DECLINES the
+  // pending install (consistent with the fail-closed default for sensitive
+  // skills at showConsentModal's markup-missing branch).
+  let dismissActiveConsent: (() => void) | null = null;
+
   function close(): void {
+    dismissActiveConsent?.();
     panel.classList.remove("open");
     backdrop.classList.remove("open");
     detail.style.display = "none";
@@ -823,6 +835,7 @@ export function initCapabilitiesPanel(ctx: WebContext): CapabilitiesPanelAPI {
         consentCancel.removeEventListener("click", onCancel);
         consentBackdrop.removeEventListener("click", onCancel);
         document.removeEventListener("keydown", onKeydown);
+        dismissActiveConsent = null;
       };
       const onApprove = (): void => {
         cleanup();
@@ -832,6 +845,11 @@ export function initCapabilitiesPanel(ctx: WebContext): CapabilitiesPanelAPI {
         cleanup();
         resolve(false);
       };
+      // Panel-teardown escape hatch: if the panel closes (button, backdrop,
+      // browser Back) while this modal is open, close() / popstate call this
+      // to tear the modal down and DECLINE the install fail-closed — the
+      // modal can never outlive the flow that owns it.
+      dismissActiveConsent = onCancel;
       const onKeydown = (e: KeyboardEvent): void => {
         if (e.key === "Escape") {
           e.stopPropagation();
@@ -872,6 +890,9 @@ export function initCapabilitiesPanel(ctx: WebContext): CapabilitiesPanelAPI {
 
   window.addEventListener("popstate", () => {
     if (!window.location.pathname.startsWith(CAPABILITIES_ROUTE_PREFIX)) {
+      // Browser Back off the panel route — same teardown as close():
+      // the in-flight consent modal must not survive the panel.
+      dismissActiveConsent?.();
       panel.classList.remove("open");
       backdrop.classList.remove("open");
       detail.style.display = "none";

--- a/apps/web/src/ui/chat.ts
+++ b/apps/web/src/ui/chat.ts
@@ -886,6 +886,22 @@ export function initChat(ctx: WebContext, callbacks: ChatCallbacks): ChatAPI {
               chunk.risk_level,
               chunk.quorum,
             );
+            // Seal the pre-gate bubble before resuming. The approval gate is
+            // a turn boundary: the pre-gate narration and the post-gate
+            // response are DISTINCT assistant messages (separated by the
+            // tool_use/tool_result the gate wraps). Without this reset the
+            // resume loop's `if (!bubble)` guard sees the still-live pre-gate
+            // bubble and appends the post-gate text into it — the two fuse
+            // into one bubble ("…report to you right now?The delegation call
+            // hit an approval gate…", witnessed in prod #292). Flush paints
+            // the pre-gate bubble's final coalesced content into its OWN
+            // textEl, then nulling forces a fresh bubble for the resume;
+            // clearing `accumulated` stops post-gate text concatenating onto
+            // the pre-gate string.
+            renderer.flush();
+            bubble = null;
+            textEl = null;
+            accumulated = "";
             // Resume the stream after approval decision
             for await (const resumeChunk of ctx.app.resolveApprovalVote(
               approved,

--- a/docs/doctrine/agents-as-first-person-trust-graph.md
+++ b/docs/doctrine/agents-as-first-person-trust-graph.md
@@ -51,6 +51,25 @@ sybil-resistance are tightly coupled here — both lean on refusing the global s
 — but sybil-resistance is that conjunction, not the single move. See
 [`security-boundaries.md`](security-boundaries.md).
 
+**Witnessed in the wild (2026-07-09).** Setting up the archetype-slate conformance
+probe, we needed devnet test tokens; the Solana faucet denied the request with
+_"GitHub account has too few public repos."_ That gate is the exact anti-pattern
+this doc refuses, in miniature: a **global, transitive, context-free reputation
+score** — computed by a third party (GitHub), in an unrelated context (open-source
+contribution), transferred wholesale as authority in a different context (test
+tokens). It fails in both directions, which is the signature of the wrong shape: it
+false-negatives the population it should serve (a builder working on _private_
+product has few public repos — the metric is anti-correlated with serious building)
+while a motivated sybil clears it by forking ten repos in five minutes. A gate that
+inconveniences legit users without stopping determined ones is score-inflation's
+worst case. The first-person shape is the fix by construction: a faucet built on
+this model would meter by the wallet's own on-faucet history (a local, pairwise,
+non-transitive edge — "has _this_ wallet abused _this_ faucet"), so a fresh wallet
+earns its rate limit the way a fresh agent earns trust, costly and non-forgeable,
+instead of importing a squatter-friendly global proxy. The importable global score
+is convenient precisely because it is portable — and portable is exactly what makes
+it farmable.
+
 The graph the semiring ranks
 ([`packages/semiring/src/agent-network.ts`](../../packages/semiring/src/agent-network.ts))
 is an **ego graph**: a star of edges from `self → each known peer`, plus


### PR DESCRIPTION
Both bugs witnessed live on motebit.com; both diagnosed to the exact mechanism and regression-tested (each test provably fails without its fix).

## #292 — assistant responses fuse across an approval gate

`handleSend` (`apps/web/src/ui/chat.ts`) held its streaming-bubble refs (`bubble`/`textEl`/`accumulated`) across the approval gate. When `delegate_to_agent` hit a gate, the resume loop's `if (!bubble)` guard saw the still-live pre-gate bubble and appended the post-gate response into it — and `accumulated +=` concatenated the two strings ("…report to you right now?The delegation call hit an approval gate…").

**Fix:** the gate is a turn boundary. Flush the pre-gate bubble's final paint into its own `textEl`, then null the refs + clear `accumulated` so the resume opens a fresh bubble — the exact reset the `/plan` path already does at its step boundary.

## #293 — "Install Sensitive Skill?" consent modal outlives its flow

`showConsentModal` (`capabilities-panel.ts`) wired teardown only to its own approve/cancel/ESC handlers; nothing on **panel** teardown (close button, backdrop, browser Back/`popstate`) tore it down. Closing the panel mid-consent left the modal + full-screen backdrop floating over plain chat with a dangling pending promise.

**Fix:** a panel-scoped `dismissActiveConsent` ref (set while open, cleared on resolve), called from `close()` and the `popstate` handler — **fail-closed DECLINE**, consistent with the sensitive-skill fail-closed default. The modal can never outlive its flow. (Per `no-modals-on-panels` doctrine this should eventually be an inline consent affordance, not a modal — noted on the issue, not done here.)

## Verified
- `chat-approval-gate.test.ts` (jsdom): drives `handleSend` through text → gate → resume, asserts TWO distinct assistant bubbles (fails 1≠2 without the fix).
- `capabilities-panel.test.ts` #293 case: close panel mid-consent → modal torn down + install declined, no skill persisted.
- Web suite 572 green; typecheck clean; `check-dom-id-references` passes.

Closes #292, closes #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)