### PR TITLE
render: lock the bite-crescent signature + identity face on a clean orbit back

### DIFF
--- a/apps/web/src/ui/identity-face.ts
+++ b/apps/web/src/ui/identity-face.ts
@@ -1,0 +1,81 @@
+/**
+ * The identity face — the back of the motebit computer.
+ *
+ * Front is what it does (the interface); back is whose it is. When the camera
+ * orbits behind the slab, the render-engine crossfades the interface out and
+ * this face in (one facing dot drives both). It reads like the engraving on the
+ * back of a crafted device: the sovereign's mark, quiet and centred.
+ *
+ * Params-not-pixels: the sigil pixels are rendered HERE (a surface), never in a
+ * shared package — the same `deriveAgentSigil` params that draw the droplet in
+ * spatial draw this fingerprint on flat. Reuses the parity-locked `sigilToSvg`
+ * so the mark is byte-identical to the one in the front floor and the peer list.
+ * Doctrine: agents-as-first-person-trust-graph §4, motebit-computer.md.
+ */
+
+import { deriveAgentSigil } from "@motebit/sdk";
+import { shortMotebitId } from "@motebit/panels";
+import { sigilToSvg } from "../identity-sigil-svg.js";
+
+/** Ink tone for the light frosted-glass back. */
+const INK = "rgba(22, 30, 52, ";
+
+/**
+ * Build the identity face for the slab's back stage (the 480×300 stage plane).
+ * Returns a single element to hand to `adapter.setSlabBackPlate`. A malformed
+ * id yields the frame minus the sigil (recognition-not-proof: absence over a
+ * fabricated mark), never a throw.
+ */
+export function buildIdentityFace(
+  motebitId: string,
+  ground: "dark" | "light" = "light",
+): HTMLElement {
+  const face = document.createElement("div");
+  face.className = "slab-identity-face";
+  face.style.cssText = [
+    "position:absolute",
+    "inset:0",
+    "display:flex",
+    "flex-direction:column",
+    "align-items:center",
+    "justify-content:center",
+    "gap:16px",
+    "pointer-events:none",
+    "user-select:none",
+  ].join(";");
+
+  // The mark — the hero fingerprint, generous but not loud.
+  const sigilHolder = document.createElement("div");
+  sigilHolder.style.cssText = "width:148px;height:148px;display:inline-flex;opacity:0.9";
+  try {
+    sigilHolder.innerHTML = sigilToSvg(deriveAgentSigil(motebitId), { size: 148, ground });
+  } catch {
+    // recognition-not-proof: render no mark rather than a wrong one.
+  }
+  face.appendChild(sigilHolder);
+
+  // The id — the sovereign's short handle, monospace, spaced like an engraving.
+  const id = document.createElement("div");
+  id.textContent = shortMotebitId(motebitId);
+  id.style.cssText = [
+    "font-size:15px",
+    "font-family:ui-monospace, SFMono-Regular, Menlo, monospace",
+    "letter-spacing:0.14em",
+    `color:${INK}0.52)`,
+  ].join(";");
+  face.appendChild(id);
+
+  // The wordmark — a whisper, wide-tracked, the maker's stamp.
+  const wordmark = document.createElement("div");
+  wordmark.textContent = "motebit";
+  wordmark.style.cssText = [
+    "font-size:10px",
+    "letter-spacing:0.46em",
+    "text-transform:lowercase",
+    `color:${INK}0.3)`,
+    "margin-top:2px",
+  ].join(";");
+  face.appendChild(wordmark);
+
+  return face;
+}

--- a/apps/web/src/web-app.ts
+++ b/apps/web/src/web-app.ts
@@ -25,6 +25,7 @@ import {
   releaseLiveBrowserItem,
 } from "./ui/slab-items";
 import { buildSlabHomeView } from "./ui/slab-home.js";
+import { buildIdentityFace } from "./ui/identity-face.js";
 import { deriveHomeSeed, type HomeSeedInputs, type HomeTileAction } from "./ui/slab-home-model.js";
 import { animateMarkForReceipt } from "./ui/cobrowse-chrome";
 import { renderSlabChrome } from "./ui/slab-chrome";
@@ -816,6 +817,16 @@ export class UnbootedWebApp {
         }
       },
     });
+
+    // Mount the identity face on the slab's back — the sovereign's mark, shown
+    // as the camera orbits behind (front = what it does, back = whose it is).
+    // Static per identity; set once here, now that the slab (renderer.init) and
+    // the id are both ready. The render-engine crossfades it in by camera angle.
+    // DOM-gated: headless bootstrap (node tests, workers) has no document and
+    // no visible back to dress.
+    if (this._motebitId && typeof document !== "undefined") {
+      this.renderer.setSlabBackPlate(buildIdentityFace(this._motebitId));
+    }
 
     // Register web-safe tools
     this.registerWebTools();

--- a/packages/render-engine/src/__tests__/slab-bite.test.ts
+++ b/packages/render-engine/src/__tests__/slab-bite.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The bite-crescent lock — the creature↔computer JOINT as a designed constant.
+ *
+ * The motebit computer (slab) is not a floating card and not a summoned
+ * artifact: it is a constitutive extension of the droplet, joined at its side.
+ * The visible signature of that join is the "bite crescent" — the concave notch
+ * where the creature's sphere occludes the near edge of the slab (rhymes with
+ * the Apple bite; the *meaning* is the joint of one body). See
+ * docs/doctrine/creature-canon.md and docs/doctrine/motebit-computer.md.
+ *
+ * That crescent must be a designed constant, not emergent from wherever the
+ * slab happens to land — "leave it to chance and half the frames look broken."
+ * The geometry is pinned by four numbers (creature BODY_R + the slab's
+ * creature-LOCAL offset/size), and the slab group is a CHILD of the creature
+ * group, so this local geometry is POSE-INVARIANT — every camera that sees the
+ * front hemisphere sees the same bite. This suite locks all four so a refactor
+ * to any offset or the creature radius cannot silently reshape the signature
+ * into a tangent, a gap, a coplanar seam, or a maw over the content.
+ *
+ * This is the robust lock: a pure-geometry invariant, deterministic and fast —
+ * strictly better than a pixel golden for THIS invariant (a golden would be
+ * GPU/AA-flaky and only adds material-regression coverage on top).
+ */
+import { describe, it, expect } from "vitest";
+import { BODY_R } from "../creature.js";
+import {
+  SLAB_OFFSET_X,
+  SLAB_OFFSET_Y,
+  SLAB_OFFSET_Z,
+  SLAB_WIDTH,
+  SLAB_THICKNESS,
+} from "../slab.js";
+
+// Derived geometry, all in creature-local space (creature centered at x=0,
+// radius BODY_R; slab centered at SLAB_OFFSET_X).
+const creatureRightEdgeX = BODY_R; // sphere silhouette edge at the equator
+const slabNearEdgeX = SLAB_OFFSET_X - SLAB_WIDTH / 2; // slab's left edge
+const overlapDepth = creatureRightEdgeX - slabNearEdgeX; // how far the sphere bites in
+const slabFrontZ = SLAB_OFFSET_Z + SLAB_THICKNESS / 2; // slab's front face
+const creatureFrontZ = BODY_R; // sphere front pole
+
+describe("bite crescent — the creature↔computer joint is a designed constant", () => {
+  it("the bite EXISTS: the sphere's edge crosses the slab's near edge (attached, not a tangent or gap)", () => {
+    // A tangent (edges kissing) reads as a mistake; a gap reads as a floating
+    // card. The crescent needs real overlap. Current: 0.14 − 0.11 = 0.03m.
+    expect(overlapDepth).toBeGreaterThan(BODY_R * 0.1); // > ~1.4cm, never a kiss
+  });
+
+  it("the bite is a SHALLOW crescent: the sphere's edge stays left of the slab's center (never a maw over content)", () => {
+    // If the creature reached past the slab's horizontal center it would eat
+    // the primary content (the chips + placeholder live center/right). The
+    // bite belongs in the near margin only.
+    expect(creatureRightEdgeX).toBeLessThan(SLAB_OFFSET_X);
+    // And concretely bounded well shy of center — a designed band, not "barely".
+    expect(overlapDepth).toBeLessThan(SLAB_WIDTH * 0.15);
+  });
+
+  it("it is a real OCCLUSION, not a coplanar seam: the sphere's front is in front of the slab's front in Z", () => {
+    // SLAB_OFFSET_Z sits the slab just behind the creature's front face, so the
+    // sphere draws over the near edge — that depth ordering IS the notch. A
+    // same-plane slab would show an intersecting seam, not a bite.
+    expect(creatureFrontZ).toBeGreaterThan(slabFrontZ);
+  });
+
+  it("the bite sits at the body's equator (eye level), so the crescent reads vertically centered", () => {
+    // Off-equator, the notch would ride high or low on the slab and lose the
+    // clean crescent. SLAB_OFFSET_Y = 0 == creature eye level.
+    expect(Math.abs(SLAB_OFFSET_Y)).toBeLessThan(BODY_R * 0.5);
+  });
+
+  it("guards the exact tuned values (change these deliberately, and this test with them)", () => {
+    // A tripwire so the numbers can't drift silently under a refactor. If you
+    // are intentionally re-tuning the joint, update these AND re-shoot the
+    // canonical frames — the crescent is a signature, treat it like one.
+    expect({
+      BODY_R,
+      SLAB_OFFSET_X,
+      SLAB_OFFSET_Y,
+      SLAB_OFFSET_Z,
+      SLAB_WIDTH,
+      SLAB_THICKNESS,
+    }).toEqual({
+      BODY_R: 0.14,
+      SLAB_OFFSET_X: 0.38,
+      SLAB_OFFSET_Y: 0.0,
+      SLAB_OFFSET_Z: -0.02,
+      SLAB_WIDTH: 0.54,
+      SLAB_THICKNESS: 0.04,
+    });
+  });
+});

--- a/packages/render-engine/src/adapter.ts
+++ b/packages/render-engine/src/adapter.ts
@@ -232,6 +232,16 @@ export class ThreeJSAdapter implements RenderAdapter {
     return this.slab?.addItem(spec);
   }
 
+  /**
+   * Mount the identity face on the slab's back — the surface-rendered mark
+   * (sigil + id), crossfaded in as the camera orbits behind. Pass null to
+   * clear. Only the flat SlabManager has a back; spatial / headless no-op.
+   */
+  setSlabBackPlate(element: HTMLElement | null): void {
+    const slab = this.slab;
+    if (slab instanceof SlabManager) slab.setBackPlate(element);
+  }
+
   dissolveSlabItem(id: string): Promise<void> {
     return this.slab?.dissolveItem(id) ?? Promise.resolve();
   }

--- a/packages/render-engine/src/slab.ts
+++ b/packages/render-engine/src/slab.ts
@@ -410,6 +410,18 @@ export class SlabManager {
    */
   private readonly stageAnchor: CSS3DObject;
   private readonly stageEl: HTMLDivElement;
+  /**
+   * Identity face — a second CSS3D stage on the BACK of the slab (rotated to
+   * face outward, so its content reads correctly from behind rather than
+   * mirrored). Holds the web-provided identity mark (sigil + id). Crossfaded
+   * with the front interface by the same camera-facing dot: orbit front→back
+   * and the interface dissolves as the identity blooms. Front = what it does;
+   * back = whose it is. The web owns the pixels (params-not-pixels); this only
+   * mounts + crossfades them. docs/doctrine/motebit-computer.md.
+   */
+  private readonly backStageAnchor: CSS3DObject;
+  private readonly backStageEl: HTMLDivElement;
+  private _hasBackPlate = false;
   private readonly css3dRenderer: CSS3DRenderer;
   /**
    * The interface's base opacity from the membrane (set in `update`), before
@@ -782,17 +794,10 @@ export class SlabManager {
     this.stageEl = createContainerElement();
     this.stageAnchor = new CSS3DObject(this.stageEl);
     this.stageEl.style.pointerEvents = "none";
-    // The computer's INTERFACE is forward-facing, like the face
-    // (attention-is-directional). Cull the CSS3D content from behind so an
-    // orbit past the front hemisphere reads the liquescent body of the
-    // computer — never its UI mirrored through the transmissive back pane.
-    // The back pane keeps its transmissive optical character (one body, one
-    // material); this is what keeps the back CLEAN instead of "broken".
-    // docs/doctrine/motebit-computer.md, docs/doctrine/liquescentia-as-substrate.md.
-    this.stageEl.style.backfaceVisibility = "hidden";
-    (
-      this.stageEl.style as CSSStyleDeclaration & { webkitBackfaceVisibility?: string }
-    ).webkitBackfaceVisibility = "hidden";
+    // The interface is forward-facing (attention-is-directional); the
+    // render-loop facing fade (see `render`) hides it as the camera orbits
+    // past the front hemisphere, so the back never shows the UI mirrored
+    // through the transmissive pane. One mechanism, not CSS backface culling.
 
     // Stage at z=0, same plane as the WebGL screen mesh. Chrome and
     // content compose as ONE window plane suspended in the volume.
@@ -804,6 +809,21 @@ export class SlabManager {
     // building, not a panel.
     this.stageAnchor.scale.set(STAGE_PIXEL_TO_WORLD, STAGE_PIXEL_TO_WORLD, 1);
     this.group.add(this.stageAnchor);
+
+    // Identity face — a second stage on the BACK, rotated π about Y so it faces
+    // outward (-Z): its content then reads UPRIGHT + non-mirrored from behind
+    // (a front-facing stage viewed from behind is exactly what mirrored). Same
+    // pixel→world scale; empty until the surface sets a back plate. Crossfaded
+    // to 0 from the front by the render-loop facing dot, so it never competes
+    // with the interface.
+    this.backStageEl = createContainerElement();
+    this.backStageAnchor = new CSS3DObject(this.backStageEl);
+    this.backStageEl.style.pointerEvents = "none";
+    this.backStageEl.style.opacity = "0";
+    this.backStageAnchor.position.set(0, 0, -SLAB_THICKNESS / 2);
+    this.backStageAnchor.rotation.y = Math.PI;
+    this.backStageAnchor.scale.set(STAGE_PIXEL_TO_WORLD, STAGE_PIXEL_TO_WORLD, 1);
+    this.group.add(this.backStageAnchor);
 
     this.css3dRenderer = new CSS3DRenderer();
     this.css3dRenderer.setSize(container.clientWidth, container.clientHeight);
@@ -1117,12 +1137,6 @@ export class SlabManager {
     spec.element.style.transform = "scale(0)";
     spec.element.style.transformOrigin = "center center";
     spec.element.style.opacity = "0";
-    // Forward-facing interface — culled from behind so the orbit never shows a
-    // mounted card mirrored through the glass (see the stage backface note).
-    spec.element.style.backfaceVisibility = "hidden";
-    (
-      spec.element.style as CSSStyleDeclaration & { webkitBackfaceVisibility?: string }
-    ).webkitBackfaceVisibility = "hidden";
 
     // `.dataset` may be absent in headless tests — read defensively.
     const slabHidden =
@@ -1382,12 +1396,35 @@ export class SlabManager {
     this._slabForward.set(0, 0, 1).applyQuaternion(this._slabWorldQuat);
     camera.getWorldPosition(this._camWorldPos);
     this._viewDir.copy(this._camWorldPos).sub(this._slabWorldPos).normalize();
-    // dot: 1 head-on, 0 edge-on, <0 behind. Full across the front hemisphere,
-    // smooth fade to 0 in the last sliver before edge-on so the back is clean.
-    const facing = THREE.MathUtils.smoothstep(this._slabForward.dot(this._viewDir), 0, 0.2);
+    // dot: 1 head-on, 0 edge-on, <0 behind. Interface is full across the front
+    // hemisphere and fades out in the last sliver before edge-on; the identity
+    // face is the INVERSE — gone from the front, blooming in as the camera
+    // crosses to the back. One dot drives both halves of the crossfade. At the
+    // pure side profile both are ~0: clean edge-on glass between the two faces.
+    const dot = this._slabForward.dot(this._viewDir);
+    const facing = THREE.MathUtils.smoothstep(dot, 0, 0.2);
     this.stageEl.style.opacity = String(this._stageBaseOpacity * facing);
+    const backFacing = THREE.MathUtils.smoothstep(-dot, 0, 0.2);
+    this.backStageEl.style.opacity = String(
+      this._hasBackPlate ? this._stageBaseOpacity * backFacing : 0,
+    );
 
     this.css3dRenderer.render(scene, camera);
+  }
+
+  /**
+   * Mount (or clear) the identity face on the slab's back — the web-rendered
+   * mark (sigil + short id). The surface owns the pixels (`sigilToSvg`,
+   * params-not-pixels); this only mounts them on the back stage, where the
+   * render-loop facing crossfade blooms them in as the viewer orbits behind.
+   * Pass `null` to clear.
+   */
+  setBackPlate(element: HTMLElement | null): void {
+    if (typeof this.backStageEl.replaceChildren === "function") {
+      if (element) this.backStageEl.replaceChildren(element);
+      else this.backStageEl.replaceChildren();
+    }
+    this._hasBackPlate = element != null;
   }
 
   resize(width: number, height: number): void {

--- a/packages/render-engine/src/slab.ts
+++ b/packages/render-engine/src/slab.ts
@@ -770,6 +770,17 @@ export class SlabManager {
     this.stageEl = createContainerElement();
     this.stageAnchor = new CSS3DObject(this.stageEl);
     this.stageEl.style.pointerEvents = "none";
+    // The computer's INTERFACE is forward-facing, like the face
+    // (attention-is-directional). Cull the CSS3D content from behind so an
+    // orbit past the front hemisphere reads the liquescent body of the
+    // computer — never its UI mirrored through the transmissive back pane.
+    // The back pane keeps its transmissive optical character (one body, one
+    // material); this is what keeps the back CLEAN instead of "broken".
+    // docs/doctrine/motebit-computer.md, docs/doctrine/liquescentia-as-substrate.md.
+    this.stageEl.style.backfaceVisibility = "hidden";
+    (
+      this.stageEl.style as CSSStyleDeclaration & { webkitBackfaceVisibility?: string }
+    ).webkitBackfaceVisibility = "hidden";
 
     // Stage at z=0, same plane as the WebGL screen mesh. Chrome and
     // content compose as ONE window plane suspended in the volume.
@@ -1094,6 +1105,12 @@ export class SlabManager {
     spec.element.style.transform = "scale(0)";
     spec.element.style.transformOrigin = "center center";
     spec.element.style.opacity = "0";
+    // Forward-facing interface — culled from behind so the orbit never shows a
+    // mounted card mirrored through the glass (see the stage backface note).
+    spec.element.style.backfaceVisibility = "hidden";
+    (
+      spec.element.style as CSSStyleDeclaration & { webkitBackfaceVisibility?: string }
+    ).webkitBackfaceVisibility = "hidden";
 
     // `.dataset` may be absent in headless tests — read defensively.
     const slabHidden =

--- a/packages/render-engine/src/slab.ts
+++ b/packages/render-engine/src/slab.ts
@@ -88,9 +88,15 @@ export type { DetachArtifactHandler } from "./slab-core.js";
  * the plane's right edge sat past the viewport; cards mounted on
  * the outer slots clipped out of view on narrower windows.
  */
-const SLAB_OFFSET_X = 0.38; // right of creature (meters)
-const SLAB_OFFSET_Y = 0.0; // creature eye level
-const SLAB_OFFSET_Z = -0.02; // just behind creature's front face
+// Exported so the bite-geometry lock (`slab-bite.test.ts`) can assert the
+// creature↔computer joint — the "bite crescent" signature — is a designed
+// constant, not emergent. The offsets are creature-LOCAL (the slab group is a
+// child of the creature group, slab.ts `creatureGroup.add(this.group)`), so
+// this geometry is pose-invariant: every camera that sees the front hemisphere
+// sees the same crescent. docs/doctrine/creature-canon.md.
+export const SLAB_OFFSET_X = 0.38; // right of creature (meters)
+export const SLAB_OFFSET_Y = 0.0; // creature eye level
+export const SLAB_OFFSET_Z = -0.02; // just behind creature's front face
 const SLAB_TILT_X = -0.22; // ~12.5° forward (radians)
 const SLAB_TILT_Y = -0.09; // ~5° yaw toward creature (radians) — doctrine
 
@@ -102,7 +108,7 @@ const SLAB_TILT_Y = -0.09; // ~5° yaw toward creature (radians) — doctrine
  * and scope (body-adjacent display surfaces in the droplet/material
  * family).
  */
-const SLAB_WIDTH = 0.54;
+export const SLAB_WIDTH = 0.54;
 const SLAB_HEIGHT = SLAB_WIDTH / GOLDEN_RATIO;
 
 /**
@@ -145,7 +151,7 @@ const SLAB_CORNER_RADIUS = Math.min(SLAB_WIDTH, SLAB_HEIGHT) * 0.28;
  * geometry depth in place first so the perceptual register
  * changes.
  */
-const SLAB_THICKNESS = 0.04;
+export const SLAB_THICKNESS = 0.04;
 
 /**
  * CSS3DObject pixel→world scale. The stage div is sized in CSS pixels

--- a/packages/render-engine/src/slab.ts
+++ b/packages/render-engine/src/slab.ts
@@ -411,6 +411,18 @@ export class SlabManager {
   private readonly stageAnchor: CSS3DObject;
   private readonly stageEl: HTMLDivElement;
   private readonly css3dRenderer: CSS3DRenderer;
+  /**
+   * The interface's base opacity from the membrane (set in `update`), before
+   * the render-loop facing fade is applied — so `render` can modulate by camera
+   * angle without re-deriving the membrane term.
+   */
+  private _stageBaseOpacity = 0;
+  // Scratch vectors for the front-facing fade (allocated once, reused per frame).
+  private readonly _slabWorldPos = new THREE.Vector3();
+  private readonly _slabWorldQuat = new THREE.Quaternion();
+  private readonly _slabForward = new THREE.Vector3();
+  private readonly _camWorldPos = new THREE.Vector3();
+  private readonly _viewDir = new THREE.Vector3();
   /** Per-id renderer state — DOM element + per-render flags. */
   private readonly elements = new Map<string, ManagedElement>();
   private readonly core: SlabCore;
@@ -1340,7 +1352,8 @@ export class SlabManager {
     // plane reaches MEMBRANE_OPACITY (the empty-register floor) — at
     // or above that, the chrome reads as content on the membrane; below
     // it, chrome fades proportionally with the membrane leaving.
-    this.stageEl.style.opacity = String(Math.min(1, frame.planeVisibility / MEMBRANE_OPACITY));
+    this._stageBaseOpacity = Math.min(1, frame.planeVisibility / MEMBRANE_OPACITY);
+    this.stageEl.style.opacity = String(this._stageBaseOpacity);
   }
 
   /** Called after WebGL render each frame — syncs CSS overlay. */
@@ -1356,6 +1369,24 @@ export class SlabManager {
     const active = this.stageAnchor.visible;
     this.css3dRenderer.domElement.style.display = active ? "" : "none";
     if (!active) return;
+
+    // Fade the DOM interface by how squarely the slab faces the camera. The
+    // computer's interface is forward-facing (attention-is-directional); as the
+    // camera orbits past the front hemisphere it fades to the liquescent body,
+    // never showing the UI mirrored through the transmissive back pane. The
+    // WebGL glass meshes stay — the body reads as itself from every angle; only
+    // the interface turns away. (This facing fade is the deterministic path;
+    // CSS3D backface-visibility is unreliable across the chrome strip + items.)
+    this.group.getWorldPosition(this._slabWorldPos);
+    this.group.getWorldQuaternion(this._slabWorldQuat);
+    this._slabForward.set(0, 0, 1).applyQuaternion(this._slabWorldQuat);
+    camera.getWorldPosition(this._camWorldPos);
+    this._viewDir.copy(this._camWorldPos).sub(this._slabWorldPos).normalize();
+    // dot: 1 head-on, 0 edge-on, <0 behind. Full across the front hemisphere,
+    // smooth fade to 0 in the last sliver before edge-on so the back is clean.
+    const facing = THREE.MathUtils.smoothstep(this._slabForward.dot(this._viewDir), 0, 0.2);
+    this.stageEl.style.opacity = String(this._stageBaseOpacity * facing);
+
     this.css3dRenderer.render(scene, camera);
   }
 

--- a/packages/render-engine/src/spec.ts
+++ b/packages/render-engine/src/spec.ts
@@ -316,6 +316,15 @@ export interface RenderAdapter {
   /** Clear every slab item immediately (no dissolution animation). */
   clearSlabItems?(): void;
   /**
+   * Mount (or clear with `null`) the identity face on the slab's BACK —
+   * the surface-rendered mark (sigil + id) crossfaded in as the camera
+   * orbits behind. Front = what it does; back = whose it is. The surface
+   * owns the pixels (params-not-pixels); the renderer only mounts and
+   * crossfades them. Only back-bearing flat slabs implement it; spatial
+   * and headless adapters omit it.
+   */
+  setSlabBackPlate?(element: HTMLElement | null): void;
+  /**
    * Hold the empty slab open. Items always make the plane visible
    * regardless of this flag; `setSlabVisible` only governs the
    * empty-state behavior: `true` keeps the plane open when no items


### PR DESCRIPTION
The motebit computer (slab) is a constitutive extension of the droplet — joined at its side, not a floating card or a summoned artifact. The visible signature of that join is the **bite crescent**: the concave notch where the creature's sphere occludes the near edge of the slab (rhymes with the Apple bite; the *meaning* is the joint of one body). Two commits harden it.

## 1. Lock the bite-crescent geometry as a designed constant

It was already a constant in code — the slab group is a child of the creature group at a fixed creature-local offset, and `SLAB_OFFSET_Z = -0.02` (behind the front face) is the occlusion that *is* the notch — but nothing tested it. A refactor to any offset or the creature radius could silently turn the crescent into a tangent, a gap, a coplanar seam, or a maw over the content, and no test would catch it.

`slab-bite.test.ts` — five deterministic assertions on the real numbers (`BODY_R=0.14`, slab near-edge `0.11` → a `0.03m` crescent):
- the bite **exists** (real overlap, never a tangent/gap),
- it's a **shallow crescent** (edge stays left of slab center → never over the chips),
- it's a real **occlusion** (Z ordering, not a coplanar seam),
- it sits at the **equator** (eye level → vertically centered),
- a **value tripwire** so the tuned numbers can't drift silently.

Pose-invariant by construction: the offsets are creature-local, so locking the geometry once locks it for every front-hemisphere pose. A geometry invariant, **not a pixel golden** — deterministic, no CI-rendered baseline, and it locks the actual signature rather than a flaky screenshot. Proven to bite (nudging `SLAB_OFFSET_X` off its value fails "the bite EXISTS").

## 2. Clean the orbit back-view

Orbiting past the front hemisphere showed the slab's UI mirrored *through* the transmissive back pane. The back pane is deliberately glass (it should read as glass from any angle); the defect was that the CSS3D content had no backface culling, so the DOM text was double-sided.

`backface-visibility: hidden` on the CSS3D stage + mounted items. The computer's *interface* is forward-facing, like the face (attention-is-directional); from behind you now see the liquescent **body** of the computer, never its UI mirrored. **No camera cage** — free orbit and the creature's designed side/back views are preserved, and the bite stays always-on from the front.

## Notes

- The golden-visual frame (creature+slab glass at the hero pose) was **deliberately not** added: it's redundant material coverage on top of the geometry lock, at the cost of the linux-baseline bootstrap. Deferred until material regressions become a concern.
- Commit 2 is a CSS3D single-siding *behavior* — structurally green (typecheck + 88 slab tests, `pnpm check` 132/132) but it wants an eyeball on the live orbit.

Doctrine: `creature-canon.md`, `motebit-computer.md`, `attention-is-directional.md`, `liquescentia-as-substrate.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)