### PR TITLE
fix(ci): declare @motebit/runtime + @motebit/verifier as root deps for the conformance probe

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,6 +188,8 @@
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.0",
     "@microsoft/api-extractor": "^7.58.7",
+    "@motebit/runtime": "workspace:*",
+    "@motebit/verifier": "workspace:*",
     "@motebit/wallet-solana": "workspace:*",
     "@solana/spl-token": "^0.4.9",
     "@solana/web3.js": "^1.95.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,12 @@ importers:
       '@microsoft/api-extractor':
         specifier: ^7.58.7
         version: 7.58.7(@types/node@26.0.1)
+      '@motebit/runtime':
+        specifier: workspace:*
+        version: link:packages/runtime
+      '@motebit/verifier':
+        specifier: workspace:*
+        version: link:packages/verifier
       '@motebit/wallet-solana':
         specifier: workspace:*
         version: link:packages/wallet-solana


### PR DESCRIPTION
## What

Two-line fix for the scheduled **Archetype conformance** workflow, red on main since 07-10 (runs [29107839463](https://github.com/motebit/motebit/actions/runs/29107839463), [29157592255](https://github.com/motebit/motebit/actions/runs/29157592255)).

## Why it broke

The Clerk merge (#301) added a dynamic `import("@motebit/runtime")` to `scripts/archetype-conformance.ts` (the paid-P2P delegation path) and declared `@motebit/wallet-solana` as a root devDependency — but not `@motebit/runtime`. The workflow *builds* runtime (its `--filter` set is correct); the failure is **resolution**: root-level scripts can only resolve root-level deps under pnpm, so all 4 paid-delegation checks fail with `Cannot find package '@motebit/runtime'` (23/27 checks still pass — the breakage is the import, not conformance itself).

`@motebit/verifier` (the script's static import) was resolving by accident of pnpm layout rather than by declaration — made explicit in the same pass (sibling-boundary rule).

## Verification

- `node` + `tsx` resolution of all three script imports from repo root: pass (the exact dynamic-import shapes from `archetype-conformance.ts:159-160` exercised under `npx tsx` after the workflow's own `--filter` build)
- Full pre-push gate suite: green

## Companion (repo settings, no code)

The `archetype-conformance` **label** the failure-alert step files under didn't exist, so red runs were also failing their alert step (`could not add label`). Label created — the pinned-issue alert thread will work from the next scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)