### PR TITLE
fix(deps): drop unsupported semver-major-days from the github-actions cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -212,7 +212,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # cooldown for github-actions supports only default-days — the semver-*
+    # keys are invalid here and an invalid config stops Dependabot processing
+    # (caught by the dependabot-api validation check on PR #291).
     cooldown:
       default-days: 5
-      semver-major-days: 14
     open-pull-requests-limit: 5


### PR DESCRIPTION
Dependabot rejects the whole config over this key (`not supported for the package ecosystem 'github-actions'` — only `default-days` is valid there), and an invalid config stops Dependabot processing entirely. Pre-existing since the cooldown block landed; surfaced by the dependabot-api validation check when #291's merge commit touched the file. One line removed, comment added naming the constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)