### PR TITLE
fix(relay): Phase 0 pinned-local paid dispatch — deliver the task to the worker the delegator paid

### DIFF
--- a/services/relay/src/__tests__/p2p-pinned-dispatch.test.ts
+++ b/services/relay/src/__tests__/p2p-pinned-dispatch.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Phase 0 pinned-local paid dispatch — the single-operator sibling of the
+ * federatedP2pIntent forward.
+ *
+ * A paid direct delegation pins ONE local worker (`target_agent`) and pays it
+ * onchain before submission. Dispatch must go DIRECTLY to that worker — never
+ * through scored routing (a zero-history pair ranks to composite 0 and the
+ * task strands with the worker's money settled: the 2026-07-13 staging
+ * conformance failure), and never through the fan-out fallbacks (an unpaid
+ * worker must not execute a paid task).
+ *
+ * These tests drive the live submission route with a worker that has NO
+ * WebSocket connection — the deployed-service shape (MCP endpoint only) that
+ * WS-connected test workers masked.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createServer } from "node:http";
+import type { Server } from "node:http";
+import type { SyncRelay } from "../index.js";
+// eslint-disable-next-line no-restricted-imports -- tests need direct keypair generation
+import { generateKeypair, bytesToHex } from "@motebit/encryption";
+import {
+  createTestRelay,
+  createAgent,
+  buildP2pPaymentProof,
+  JSON_AUTH,
+  jsonAuthWithIdempotency,
+} from "./test-helpers.js";
+import { toMicro } from "../accounts.js";
+
+const WORKER_SOLANA_ADDR = "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgHkv";
+// Fixed ports below the ephemeral range (feedback_test_fixed_ports_below_ephemeral).
+const PINNED_PORT = 18931;
+const DECOY_PORT = 18933;
+const DEAD_PORT = 18934; // never listened on
+
+function setTrust(
+  db: import("@motebit/persistence").DatabaseDriver,
+  fromId: string,
+  toId: string,
+  trustLevel: string,
+  interactionCount: number,
+): void {
+  db.prepare(
+    `INSERT OR REPLACE INTO agent_trust
+     (motebit_id, remote_motebit_id, trust_level, interaction_count, first_seen_at, last_seen_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(fromId, toId, trustLevel, interactionCount, Date.now(), Date.now());
+}
+
+/** Minimal request-recording HTTP server standing in for a worker's MCP surface. */
+function recordingServer(port: number): { server: Server; requests: string[] } {
+  const requests: string[] = [];
+  const server = createServer((req, res) => {
+    requests.push(`${req.method} ${req.url ?? ""}`);
+    res.setHeader("Content-Type", "application/json");
+    // Enough of an MCP initialize response for forwardTaskViaMcp to proceed;
+    // the test only asserts the dispatch ARRIVED.
+    res.end(JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }));
+  });
+  server.listen(port, "127.0.0.1");
+  return { server, requests };
+}
+
+async function registerP2pWorker(
+  relay: SyncRelay,
+  motebitId: string,
+  endpointUrl: string,
+  capability: string,
+): Promise<void> {
+  await relay.app.request("/api/v1/agents/register", {
+    method: "POST",
+    headers: JSON_AUTH,
+    body: JSON.stringify({
+      motebit_id: motebitId,
+      endpoint_url: endpointUrl,
+      capabilities: [capability],
+      settlement_address: WORKER_SOLANA_ADDR,
+      settlement_modes: "relay,p2p",
+    }),
+  });
+  await relay.app.request(`/api/v1/agents/${motebitId}/listing`, {
+    method: "POST",
+    headers: JSON_AUTH,
+    body: JSON.stringify({
+      capabilities: [capability],
+      pricing: [{ capability, unit_cost: 0.5, currency: "USD", per: "task" }],
+      sla: { max_latency_ms: 5000, availability_guarantee: 0.99 },
+      description: "pinned dispatch test worker",
+      pay_to_address: WORKER_SOLANA_ADDR,
+    }),
+  });
+}
+
+async function submitPinnedPaidTask(
+  relay: SyncRelay,
+  delegatorId: string,
+  workerId: string,
+): Promise<Response> {
+  const proof = buildP2pPaymentProof(relay, {
+    workerAddress: WORKER_SOLANA_ADDR,
+    unitCostMicro: toMicro(0.5),
+  });
+  return relay.app.request(`/agent/${delegatorId}/task`, {
+    method: "POST",
+    headers: { ...jsonAuthWithIdempotency(), "Idempotency-Key": proof.tx_hash },
+    body: JSON.stringify({
+      prompt: "pinned dispatch probe",
+      submitted_by: delegatorId,
+      target_agent: workerId,
+      settlement_mode: "p2p",
+      payment_proof: proof,
+      required_capabilities: ["web_search"],
+    }),
+  });
+}
+
+async function waitFor(cond: () => boolean, ms: number): Promise<boolean> {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (cond()) return true;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return cond();
+}
+
+describe("Phase 0 — pinned-local paid dispatch", () => {
+  let relay: SyncRelay;
+  let delegator: { motebitId: string; deviceId: string };
+  let worker: { motebitId: string; deviceId: string };
+  const servers: Server[] = [];
+
+  beforeEach(async () => {
+    relay = await createTestRelay();
+    const workerKp = await generateKeypair();
+    const delegatorKp = await generateKeypair();
+    worker = await createAgent(relay, bytesToHex(workerKp.publicKey));
+    delegator = await createAgent(relay, bytesToHex(delegatorKp.publicKey));
+  });
+
+  afterEach(async () => {
+    await Promise.all(servers.splice(0).map((s) => new Promise<void>((r) => s.close(() => r()))));
+    await relay.close();
+  });
+
+  it("dispatches directly to the paid worker's MCP endpoint when it has no WebSocket", async () => {
+    const { server, requests } = recordingServer(PINNED_PORT);
+    servers.push(server);
+    await registerP2pWorker(
+      relay,
+      worker.motebitId,
+      `http://127.0.0.1:${PINNED_PORT}/mcp`,
+      "web_search",
+    );
+    // Established pair — the eligibility gate is not under test here.
+    setTrust(relay.moteDb.db, delegator.motebitId, worker.motebitId, "verified", 10);
+
+    const res = await submitPinnedPaidTask(relay, delegator.motebitId, worker.motebitId);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      routing_choice: { selected_agent: string } | null;
+    };
+    // Routing provenance names the PINNED worker — never a ranked alternative.
+    expect(body.routing_choice?.selected_agent).toBe(worker.motebitId);
+
+    // The dispatch must actually arrive at the worker's HTTP surface
+    // (wake GET /health and/or MCP POST — either proves delivery).
+    const arrived = await waitFor(() => requests.length > 0, 3000);
+    expect(arrived).toBe(true);
+  });
+
+  it("never fans a paid task out to a worker the delegator did not pay", async () => {
+    // Pinned worker: registered, but its endpoint is a dead port (no listener,
+    // no WebSocket) — dispatch to it can only fail.
+    await registerP2pWorker(
+      relay,
+      worker.motebitId,
+      `http://127.0.0.1:${DEAD_PORT}/mcp`,
+      "web_search",
+    );
+    setTrust(relay.moteDb.db, delegator.motebitId, worker.motebitId, "verified", 10);
+
+    // Decoy: a DIFFERENT live worker advertising the same capability with a
+    // recording endpoint. Pre-fix, Phase 1 ranking / Phase 3 capability
+    // fallback could hand it the paid task.
+    const decoyKp = await generateKeypair();
+    const decoy = await createAgent(relay, bytesToHex(decoyKp.publicKey));
+    const { server, requests } = recordingServer(DECOY_PORT);
+    servers.push(server);
+    await registerP2pWorker(
+      relay,
+      decoy.motebitId,
+      `http://127.0.0.1:${DECOY_PORT}/mcp`,
+      "web_search",
+    );
+    setTrust(relay.moteDb.db, delegator.motebitId, decoy.motebitId, "verified", 10);
+
+    const res = await submitPinnedPaidTask(relay, delegator.motebitId, worker.motebitId);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      routing_choice: { selected_agent: string } | null;
+    };
+    expect(body.routing_choice?.selected_agent).toBe(worker.motebitId);
+
+    // Give any wrong fan-out a real window to fire, then assert silence.
+    await new Promise((r) => setTimeout(r, 1500));
+    expect(requests).toHaveLength(0);
+  });
+});

--- a/services/relay/src/tasks.ts
+++ b/services/relay/src/tasks.ts
@@ -2308,8 +2308,89 @@ export async function registerTaskRoutes(deps: TasksDeps): Promise<void> {
         }
       | undefined;
 
+    // Phase 0: Pinned-local paid dispatch — the single-operator sibling of the
+    // `federatedP2pIntent` branch below. The delegator already discovered,
+    // priced, and PAID this specific local worker onchain (the 2-leg proof was
+    // validated above); ranking it against the market again is wrong in both
+    // directions — a zero-history pair ranks to composite 0 (task strands with
+    // the worker's money settled: the 2026-07-13 staging conformance failure),
+    // and a re-ranked winner could route the paid task to an agent the
+    // delegator never paid. Dispatch DIRECTLY to the pinned worker: WebSocket
+    // when connected, else HTTP MCP via its registered endpoint. No ranking,
+    // no federation, no fallback broadcast (Phases 1–4 are skipped via
+    // `pinnedLocalHandled` even when dispatch fails — a paid task must never
+    // fan out to a worker the delegator did not pay).
+    let pinnedLocalHandled = false;
+    if (settlementMode === "p2p" && body.target_agent != null && !federatedP2pIntent) {
+      pinnedLocalHandled = true;
+      const pinnedId = body.target_agent;
+      routingChoice = {
+        selected_agent: pinnedId,
+        composite_score: 1,
+        sub_scores: { pinned: 1 },
+        routing_paths: [[pinnedId]],
+        alternatives_considered: 0,
+      };
+      const pinnedPeers = connections.get(pinnedId);
+      if (pinnedPeers && pinnedPeers.length > 0) {
+        for (const peer of pinnedPeers) {
+          peer.ws.send(payload);
+        }
+        routed = true;
+        logger.info("task.p2p_pinned_dispatched", {
+          correlationId: taskId,
+          worker: pinnedId,
+          via: "websocket",
+        });
+      } else {
+        const pinnedReg = moteDb.db
+          .prepare(
+            "SELECT endpoint_url FROM agent_registry WHERE motebit_id = ? AND expires_at > ?",
+          )
+          .get(pinnedId, Date.now()) as { endpoint_url: string } | undefined;
+        if (pinnedReg?.endpoint_url?.trim()) {
+          void forwardTaskViaMcp(
+            pinnedReg.endpoint_url,
+            taskId,
+            body.prompt,
+            pinnedId,
+            taskQueue as Map<string, { task: { status: string }; receipt?: unknown }>,
+            logger,
+            apiToken,
+            async (receiptCandidate: ReceiptCandidate) => {
+              const mcpEntry = taskQueue.get(taskId);
+              if (!mcpEntry || mcpEntry.settled) return;
+              await handleReceiptIngestion(
+                receiptCandidate as unknown as ExecutionReceipt,
+                taskId,
+                mcpEntry.task.motebit_id,
+                mcpEntry,
+                ingestionDeps,
+              );
+            },
+          );
+          routed = true;
+          logger.info("task.p2p_pinned_dispatched", {
+            correlationId: taskId,
+            worker: pinnedId,
+            via: "mcp",
+            endpoint: pinnedReg.endpoint_url,
+          });
+        } else {
+          // Paid task with no reachable worker transport — leave queued (the
+          // worker may reconnect and claim within TTL) but say so LOUDLY:
+          // money has settled onchain and nothing is executing.
+          logger.error("task.p2p_pinned_unroutable", {
+            correlationId: taskId,
+            worker: pinnedId,
+            reason: "no WebSocket connection and no registered endpoint_url",
+          });
+        }
+      }
+    }
+
     // Phase 1: Scored routing — find best service agents from listings
-    if (requiredCaps.length > 0) {
+    if (!pinnedLocalHandled && requiredCaps.length > 0) {
       try {
         const { profiles, requirements } = taskRouter.buildCandidateProfiles(
           requiredCaps[0],
@@ -2716,6 +2797,16 @@ export async function registerTaskRoutes(deps: TasksDeps): Promise<void> {
                     });
                   } else {
                     taskRouter.recordPeerForwardResult(peerEndpoint, false);
+                    // Loud, not silent: this rejection sets `federationAttempted`,
+                    // which suppresses every local fallback phase — an unlogged
+                    // branch here strands the task with zero forensic trail
+                    // (masked the 2026-07-13 staging conformance failure).
+                    logger.warn("task.forward_rejected", {
+                      correlationId: taskId,
+                      peerRelay: peerEndpoint,
+                      targetAgent: selId,
+                      status: resp.status,
+                    });
                   }
                 } catch (fwdErr) {
                   taskRouter.recordPeerForwardResult(peerEndpoint, false);
@@ -2779,7 +2870,9 @@ export async function registerTaskRoutes(deps: TasksDeps): Promise<void> {
     // Phase 2: Broadcast fallback — original behavior.
     // Skip if a federation forward was attempted (even if it timed out) — the peer relay
     // may have accepted the task, and broadcasting locally would cause double-execution.
-    if (!routed && !federationAttempted) {
+    // Also skip for pinned-local paid tasks (Phase 0): fan-out could execute the
+    // paid task on a worker the delegator never paid.
+    if (!pinnedLocalHandled && !routed && !federationAttempted) {
       const peers = connections.get(motebitId);
       if (peers) {
         for (const peer of peers) {
@@ -2795,7 +2888,7 @@ export async function registerTaskRoutes(deps: TasksDeps): Promise<void> {
 
     // Phase 3: HTTP MCP fallback — when no WebSocket routed the task,
     // find a registered agent with matching capabilities and forward via HTTP.
-    if (!routed && !federationAttempted && requiredCaps.length > 0) {
+    if (!pinnedLocalHandled && !routed && !federationAttempted && requiredCaps.length > 0) {
       const now = Date.now();
       const capFilter = requiredCaps[0]!;
       const httpCandidate = moteDb.db
@@ -2834,7 +2927,7 @@ export async function registerTaskRoutes(deps: TasksDeps): Promise<void> {
     // Phase 4: Push wake — when no WebSocket, no HTTP MCP, and no federation routed the task,
     // attempt to wake a mobile device via push notification. Fire-and-forget — the task stays
     // in queue regardless. The device will reconnect via WebSocket and claim the task.
-    if (!routed && !federationAttempted && pushAdapter) {
+    if (!pinnedLocalHandled && !routed && !federationAttempted && pushAdapter) {
       void attemptPushWake(motebitId, { pushAdapter, db: moteDb.db });
     }
 


### PR DESCRIPTION
## The bug (found root-causing the 2026-07-13 staging conformance receipt-timeouts)

A paid single-operator P2P delegation (`target_agent` + `payment_proof`, worker **local**) had no dedicated dispatch branch. The remote case has one — `federatedP2pIntent` forwards directly to the pinned worker (*"No ranking — the delegator already discovered + paid this worker onchain"*) — but the local case fell into **generic scored routing**, which gates delivery on trust-composite ranking:

- A zero-history delegator ranks its own paid worker to composite 0 → nothing dispatches → the task strands in the queue **with the worker's money already settled onchain**. This is exactly what the staging conformance probe hit: `task.submitted` + `task.p2p_settlement` logged, then silence — zero log lines on either worker through two full runs.
- Worse: ranking could select a *different* agent than the one paid — including a federated peer, whose rejection set `federationAttempted` and **silently** suppressed every local fallback phase (that branch logged nothing at all).

## The fix

**Phase 0** — the local sibling of the federated branch: pinned + paid ⇒ dispatch **directly** to the pinned worker (WebSocket when connected, else HTTP MCP via its registered `endpoint_url`, reusing `forwardTaskViaMcp`). Phases 1–4 are skipped even when dispatch fails — a paid task must never fan out to a worker the delegator did not pay. Unroutable pinned tasks log `task.p2p_pinned_unroutable` at error level (money settled, nothing executing — never silent). The silent peer-rejection branch now logs `task.forward_rejected` with the HTTP status.

## Tests

`p2p-pinned-dispatch.test.ts` drives the live route with an MCP-endpoint-only worker (no WebSocket — the deployed-service shape that WS-connected test workers masked):
- dispatch arrives at the pinned worker's HTTP surface; `routing_choice.selected_agent` is the pinned worker
- a live decoy advertising the same capability receives **nothing** when the pinned worker is unreachable

Full relay suite green (1423 passed), typecheck + lint clean, pre-push gates passed.

## Deployment note

Staging conformance stays red on the paid legs until the **staging relay** redeploys with this fix (staging deploys lag main; manual trigger). The archetype workers themselves were never the problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)