### PR TITLE
fix(slate,relay): workers 401 every MCP forward — wire inbound auth + stop swallowing the failure

### DIFF
--- a/scripts/deploy-archetype-slate.ts
+++ b/scripts/deploy-archetype-slate.ts
@@ -73,6 +73,7 @@ export const SLATE: SlateService[] = [
     secrets: (ctx) => ({
       MOTEBIT_SYNC_URL: ctx.relayUrl,
       MOTEBIT_API_TOKEN: ctx.apiToken,
+      MOTEBIT_AUTH_TOKEN: ctx.apiToken, // inbound MCP-forward auth (mcp-server reads this, not API_TOKEN)
       MOTEBIT_UNIT_COST: "0",
       BRAVE_API_KEY: process.env["BRAVE_API_KEY"] ?? "",
     }),
@@ -87,6 +88,7 @@ export const SLATE: SlateService[] = [
     secrets: (ctx) => ({
       MOTEBIT_SYNC_URL: ctx.relayUrl,
       MOTEBIT_API_TOKEN: ctx.apiToken,
+      MOTEBIT_AUTH_TOKEN: ctx.apiToken, // inbound MCP-forward auth (mcp-server reads this, not API_TOKEN)
       MOTEBIT_UNIT_COST: "0",
     }),
   },
@@ -108,6 +110,7 @@ export const SLATE: SlateService[] = [
     secrets: (ctx) => ({
       MOTEBIT_SYNC_URL: ctx.relayUrl,
       MOTEBIT_API_TOKEN: ctx.apiToken,
+      MOTEBIT_AUTH_TOKEN: ctx.apiToken, // inbound MCP-forward auth (mcp-server reads this, not API_TOKEN)
       MOTEBIT_UNIT_COST: "0",
       WEB_SEARCH_URL: ctx.appHost(
         TARGET === "prod" ? "motebit-web-search" : "motebit-web-search-stg",
@@ -124,6 +127,7 @@ export const SLATE: SlateService[] = [
     secrets: (ctx) => ({
       MOTEBIT_SYNC_URL: ctx.relayUrl,
       MOTEBIT_API_TOKEN: ctx.apiToken,
+      MOTEBIT_AUTH_TOKEN: ctx.apiToken, // inbound MCP-forward auth (mcp-server reads this, not API_TOKEN)
       MOTEBIT_UNIT_COST: "0.25",
       MOTEBIT_SETTLEMENT_MODES: "relay,p2p",
       ANTHROPIC_API_KEY: process.env["ANTHROPIC_API_KEY"] ?? "",
@@ -147,6 +151,7 @@ export const SLATE: SlateService[] = [
     secrets: (ctx) => ({
       MOTEBIT_SYNC_URL: ctx.relayUrl,
       MOTEBIT_API_TOKEN: ctx.apiToken,
+      MOTEBIT_AUTH_TOKEN: ctx.apiToken, // inbound MCP-forward auth (mcp-server reads this, not API_TOKEN)
       MOTEBIT_RELAY_URL: ctx.relayUrl,
       MOTEBIT_UNIT_COST: "0.01",
       MOTEBIT_SETTLEMENT_MODES: "relay,p2p",
@@ -162,6 +167,7 @@ export const SLATE: SlateService[] = [
     secrets: (ctx) => ({
       MOTEBIT_SYNC_URL: ctx.relayUrl,
       MOTEBIT_API_TOKEN: ctx.apiToken,
+      MOTEBIT_AUTH_TOKEN: ctx.apiToken, // inbound MCP-forward auth (mcp-server reads this, not API_TOKEN)
       MOTEBIT_UNIT_COST: "0.01",
       MOTEBIT_SETTLEMENT_MODES: "relay,p2p",
       // DRY-RUN-FIRST: the whole metered spine runs at hard-zero (no broadcast,

--- a/services/relay/src/__tests__/forward-mcp-auth.test.ts
+++ b/services/relay/src/__tests__/forward-mcp-auth.test.ts
@@ -1,0 +1,90 @@
+/**
+ * forwardTaskViaMcp observability — a non-2xx from the worker's MCP endpoint
+ * (401 unauthorized, 503 cold-start, …) must be LOGGED, not silently swallowed.
+ *
+ * The 2026-07-13 conformance receipt-timeouts had NO forensic signal for hours
+ * because the forward sailed through initialize → notifications/initialized →
+ * tools/call without checking any response status, parsed null, and returned.
+ * The underlying auth failure (worker's MOTEBIT_AUTH_TOKEN unset ⇒ mcp-server
+ * has no inbound verifier ⇒ 401 on every forward) was invisible. These tests
+ * lock the fix: a paid task's dispatch failure always leaves a trail, and no
+ * receipt is ingested on a rejected forward.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { createServer } from "node:http";
+import type { Server } from "node:http";
+import { forwardTaskViaMcp } from "../task-routing.js";
+
+const PORT = 18941;
+
+interface LogEntry {
+  msg: string;
+  ctx: Record<string, unknown>;
+}
+
+function capturingLogger(): { entries: LogEntry[]; info: LogEntry[]; logger: unknown } {
+  const info: LogEntry[] = [];
+  const entries: LogEntry[] = [];
+  return {
+    entries,
+    info,
+    logger: {
+      info: (msg: string, ctx: Record<string, unknown>) => {
+        info.push({ msg, ctx });
+        entries.push({ msg, ctx });
+      },
+      warn: (msg: string, ctx: Record<string, unknown>) => entries.push({ msg, ctx }),
+    },
+  };
+}
+
+describe("forwardTaskViaMcp — non-2xx is loud, never silent", () => {
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    if (server) await new Promise<void>((r) => server!.close(() => r()));
+    server = undefined;
+  });
+
+  it("logs task.mcp_forward_failed with the status and ingests no receipt on a 401 init", async () => {
+    server = createServer((req, res) => {
+      // /health wake succeeds; the /mcp POST rejects with 401 — the exact
+      // shape of a worker whose inbound verifier is unconfigured.
+      if (req.url === "/health") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end("{}");
+        return;
+      }
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({ error: "unauthorized — set authToken or use a motebit signed token" }),
+      );
+    });
+    await new Promise<void>((r) => server!.listen(PORT, "127.0.0.1", r));
+
+    const cap = capturingLogger();
+    const taskQueue = new Map();
+    let receiptIngested = false;
+
+    await forwardTaskViaMcp(
+      `http://127.0.0.1:${PORT}`,
+      "task-401",
+      "probe",
+      "worker-abc",
+      taskQueue,
+      cap.logger as Parameters<typeof forwardTaskViaMcp>[5],
+      "relay-token",
+      async () => {
+        receiptIngested = true;
+      },
+    );
+
+    const failure = cap.entries.find((e) => e.msg === "task.mcp_forward_failed");
+    expect(failure).toBeDefined();
+    expect(failure!.ctx.status).toBe(401);
+    expect(failure!.ctx.step).toBe("initialize");
+    // No receipt path runs on a rejected forward.
+    expect(receiptIngested).toBe(false);
+    expect(cap.entries.find((e) => e.msg === "task.mcp_forward_completed")).toBeUndefined();
+  });
+});

--- a/services/relay/src/task-routing.ts
+++ b/services/relay/src/task-routing.ts
@@ -998,6 +998,25 @@ export async function forwardTaskViaMcp(
       // the MCP server is ready. 10s was too tight for cold start + TLS + init.
       signal: AbortSignal.timeout(30000),
     });
+    // Fail LOUD on a non-2xx init (auth 401, cold-start 503, …). Without this
+    // the handshake sails on through `notifications/initialized` and
+    // `tools/call`, `parseMcpResponse` returns null, and the function returns
+    // with NO receipt and NO log — the exact silent-swallow that masked the
+    // 2026-07-13 conformance auth failure (worker's MOTEBIT_AUTH_TOKEN unset ⇒
+    // no inbound verifier ⇒ 401 on every forward) for hours. A paid task's
+    // dispatch failure must always leave a trail.
+    if (!initResp.ok) {
+      const detail = await initResp.text().catch(() => "");
+      logger.warn("task.mcp_forward_failed", {
+        correlationId: taskId,
+        agent: agentId,
+        endpoint: mcpEndpoint,
+        step: "initialize",
+        status: initResp.status,
+        detail: detail.slice(0, 200),
+      });
+      return;
+    }
     const sessionId = initResp.headers.get("mcp-session-id");
     if (sessionId) mcpHeaders["Mcp-Session-Id"] = sessionId;
 
@@ -1021,6 +1040,19 @@ export async function forwardTaskViaMcp(
       }),
       signal: AbortSignal.timeout(120000),
     });
+
+    if (!taskResp.ok) {
+      const detail = await taskResp.text().catch(() => "");
+      logger.warn("task.mcp_forward_failed", {
+        correlationId: taskId,
+        agent: agentId,
+        endpoint: mcpEndpoint,
+        step: "tools/call",
+        status: taskResp.status,
+        detail: detail.slice(0, 200),
+      });
+      return;
+    }
 
     // Step 4: Parse JSON-RPC response (SSE or plain JSON)
     const mcpResult = await parseMcpResponse(taskResp, 2);


### PR DESCRIPTION
## The bug (second layer behind the conformance receipt-timeouts)

After #314 fixed dispatch *routing* (the relay now correctly sends paid pinned tasks straight to the worker via `task.p2p_pinned_dispatched via mcp`), the receipt still never came back. Reproducing the relay's exact MCP handshake against the live worker returned:

```
401 unauthorized — set authToken or use a motebit signed token
```

**Root cause:** the worker's mcp-server sources its inbound-auth token from `MOTEBIT_AUTH_TOKEN` (services/\*/helpers `loadConfig` → `serverCfg.authToken` → `StaticTokenVerifier`). The slate deploy only ever set `MOTEBIT_API_TOKEN`, so `authToken` was **null → no verifier configured → the server fail-closes and rejects every inbound bearer with 401.** The relay forwards its raw `apiToken` (not a `motebit:` signed token), landing in exactly that unconfigured branch. The worker logged zero task activity because it rejected at the HTTP auth layer before the tool ever ran.

## Fixes

**1. Deploy wiring** — set `MOTEBIT_AUTH_TOKEN = ctx.apiToken` on every service in `deploy-archetype-slate.ts`. The value is **already on each box** as `MOTEBIT_API_TOKEN` (same relay token used for outbound registration), so this is **zero new secret exposure** — the deploy simply never wired the inbound name the mcp-server reads.

**2. Masking bug** — `forwardTaskViaMcp` never checked `initResp.ok` / `taskResp.ok`. On a 401 it sailed through `notifications/initialized` + `tools/call`, parsed null, and returned with **no receipt and no log** — six hours of "no receipt" with zero forensic signal. Now a non-2xx at either step logs `task.mcp_forward_failed` with the status + body preview and returns early. Regression test drives a 401 worker and asserts the log fires and no receipt is ingested.

## Deferred-with-trigger (sovereign end-game)

The relay should forward a `motebit:`-prefixed **signed** token (its relay identity) instead of a shared static secret — the mcp-server already verifies `motebit:` tokens by default (`mcp-server/service.ts:267`). That removes the shared-secret coupling entirely. Trigger: the next relay↔worker auth arc or a token-rotation incident.

## Deploy note

The fix goes live when the slate deploy runs (which is already required to create `motebit-clerk-stg`) — that single command now fixes **all three** remaining conformance reds: clerk-missing, and the 401 on both molecules.

Typecheck + lint clean, relay suite green, gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)