### PR TITLE
fix(molecule-runner): empty policyOverrides must inherit the R3 floor + summarize pricing

### DIFF
--- a/packages/molecule-runner/src/__tests__/run-molecule.test.ts
+++ b/packages/molecule-runner/src/__tests__/run-molecule.test.ts
@@ -761,6 +761,53 @@ describe("runMolecule", () => {
     expect(overrides.denyAbove).toBe(3);
   });
 
+  it("an EMPTY policyOverrides object still inherits the R3 baseline (not R1_DRAFT)", async () => {
+    // The 2026-07-15 Auditor bug: `policyOverrides: {}` is defined, so the old
+    // `?? DEFAULT` kept it and dropped denyAbove → R1_DRAFT → the R3
+    // relay-forwarded motebit_task was denied and no paid task ever executed.
+    // The floor-merge must fill the empty object with the R3 baseline.
+    const adapters = baseAdapters();
+    const createRuntime = vi.fn().mockImplementation(() => fakeRuntime());
+    adapters.createRuntime = createRuntime;
+
+    await runMolecule(
+      baseConfig(),
+      () => ({ toolRegistry: new InMemoryToolRegistry(), policyOverrides: {} }),
+      adapters,
+    );
+
+    const overrides = createRuntime.mock.calls[0]![3] as {
+      requireApprovalAbove: number;
+      denyAbove: number;
+    };
+    expect(overrides.requireApprovalAbove).toBe(3);
+    expect(overrides.denyAbove).toBe(3);
+  });
+
+  it("a partial policyOverrides raises denyAbove but keeps the baseline for unset keys", async () => {
+    // A task-receiving molecule that legitimately raises its ceiling (e.g. the
+    // Clerk to R4 money) must not lose requireApprovalAbove from the baseline.
+    const adapters = baseAdapters();
+    const createRuntime = vi.fn().mockImplementation(() => fakeRuntime());
+    adapters.createRuntime = createRuntime;
+
+    await runMolecule(
+      baseConfig(),
+      () => ({
+        toolRegistry: new InMemoryToolRegistry(),
+        policyOverrides: { denyAbove: 4 } as never,
+      }),
+      adapters,
+    );
+
+    const overrides = createRuntime.mock.calls[0]![3] as {
+      requireApprovalAbove: number;
+      denyAbove: number;
+    };
+    expect(overrides.denyAbove).toBe(4);
+    expect(overrides.requireApprovalAbove).toBe(3); // from the baseline
+  });
+
   it("build callback is awaited (supports async service assembly)", async () => {
     const adapters = baseAdapters();
     let resolved = false;

--- a/packages/molecule-runner/src/index.ts
+++ b/packages/molecule-runner/src/index.ts
@@ -609,7 +609,19 @@ export async function runMolecule(
 
   // 4. Storage + runtime
   const storage = assembleStorageAdapters(db);
-  const policyOverrides = molecule.policyOverrides ?? DEFAULT_POLICY_OVERRIDES;
+  // MERGE the molecule's overrides ONTO the R3 baseline — never replace it.
+  // `?? DEFAULT` was a footgun: a molecule passing a partial or EMPTY object
+  // (`policyOverrides: {}`, which several services copy-pasted) is defined, so
+  // `??` kept it and dropped `denyAbove: R3_EXECUTE` → default R1_DRAFT → the
+  // relay-forwarded `motebit_task` (always R3) DENIED, and the service silently
+  // never executes a paid task (the 2026-07-15 Auditor conformance failure:
+  // "requires R3_EXECUTE but max allowed is R1_DRAFT"). The baseline is a
+  // floor every task-receiving molecule needs; a molecule can still RAISE
+  // denyAbove (e.g. the Clerk's R4 money path) by setting it explicitly.
+  const policyOverrides: Partial<PolicyConfig> = {
+    ...DEFAULT_POLICY_OVERRIDES,
+    ...molecule.policyOverrides,
+  };
   let runtime: RunnerRuntime;
   if (config.moneyExecution) {
     const makeMoney = adapters.createMoneyRuntime ?? defaultCreateMoneyRuntime;

--- a/services/auditor/src/index.ts
+++ b/services/auditor/src/index.ts
@@ -189,8 +189,10 @@ async function main(): Promise<void> {
       return {
         toolRegistry: registry,
         handleAgentTask,
-        // audit_agent is read-only — public network reads, no side effects.
-        policyOverrides: {},
+        // No policyOverrides: inherit the R3 baseline so the relay-forwarded
+        // motebit_task (R3) executes. audit_agent itself is read-only, but the
+        // ceiling must cover task execution — an empty override here used to
+        // silently drop to R1_DRAFT and deny every forwarded task.
         getServiceListing: () =>
           Promise.resolve({
             capabilities: ["audit_agent"],

--- a/services/summarize/.env.example
+++ b/services/summarize/.env.example
@@ -23,8 +23,10 @@ MOTEBIT_DATA_DIR=./data
 # Public URL advertised to the relay (e.g. https://summarize.fly.dev)
 MOTEBIT_PUBLIC_URL=
 
-# Bearer token for inbound MCP connections (optional — motebit signed
-# tokens are always accepted regardless)
+# Bearer token for inbound MCP connections — the mcp-server accepts this on
+# incoming /mcp calls, and the relay forwards it when dispatching tasks. Set it
+# to the same relay token as MOTEBIT_API_TOKEN. Unset ⇒ no static verifier ⇒
+# every relay forward is rejected 401 (motebit signed tokens still accepted).
 MOTEBIT_AUTH_TOKEN=
 
 # ─── Relay integration (optional) ───────────────────────────────────────
@@ -34,6 +36,10 @@ MOTEBIT_SYNC_URL=
 
 # API token for authenticating to the relay
 MOTEBIT_API_TOKEN=
+
+# Listed unit price for summarize_search, in USD. Zero-cost atom until the
+# multi-hop settlement arc; listed (even at 0) so the market renders it priced.
+MOTEBIT_UNIT_COST=0
 
 # ─── Downstream delegation (web-search) ─────────────────────────────────
 

--- a/services/summarize/src/index.ts
+++ b/services/summarize/src/index.ts
@@ -39,6 +39,9 @@ function loadConfig() {
     authToken: process.env["MOTEBIT_AUTH_TOKEN"],
     syncUrl: process.env["MOTEBIT_SYNC_URL"],
     apiToken: process.env["MOTEBIT_API_TOKEN"],
+    // Zero-cost atom until the multi-hop settlement arc; listed so the market
+    // renders it as priced (conformance "pricing listed").
+    unitCost: parseFloat(process.env["MOTEBIT_UNIT_COST"] ?? "0"),
     /** Externally-reachable URL the relay advertises for routing. Must be
      *  set to the Fly hostname in production. */
     publicUrl: process.env["MOTEBIT_PUBLIC_URL"],
@@ -184,15 +187,27 @@ async function main(): Promise<void> {
         getServiceListing: () =>
           Promise.resolve({
             capabilities: ["summarize_search"],
-            pricing: [],
+            // List the capability's price (zero-cost atom until the multi-hop
+            // settlement arc) — a non-empty pricing array is what makes the
+            // service render as "priced"/discoverable in the market, matching
+            // the sibling atoms (web-search, read-url). An empty array read as
+            // "unpriced" and failed conformance.
+            pricing: [
+              {
+                capability: "summarize_search",
+                unit_cost: config.unitCost,
+                currency: "USD",
+                per: "task",
+              },
+            ],
             sla: { max_latency_ms: 60_000, availability_guarantee: 0.95 },
             description:
               "Summarize atom: delegates a web search and condenses the results, returning the summary with the search's signed receipt nested in its own.",
           }),
-        // summarize_search is read-only — no R3 approval default needed.
-        // Minimal policy preserves original semantics (the previous
-        // hand-rolled boot passed {} as policy overrides).
-        policyOverrides: {},
+        // No policyOverrides: inherit the R3 baseline so the relay-forwarded
+        // motebit_task executes. summarize_search is read-only, but the ceiling
+        // must cover task execution (an empty override silently dropped to
+        // R1_DRAFT — same footgun the Auditor hit).
         onStop: () => {
           void webSearchAdapter.disconnect().catch(() => {
             /* best-effort cleanup */


### PR DESCRIPTION
## The third bug behind the conformance paid legs — surfaced ONLY because #316 made the forward loud

With the auth fix (#316) deployed, the validation run showed **research and clerk paid legs fully green** (paid → receipt → sovereign binding → nested receipts → citation chain → provenance). Two reds remained — and the observability fix immediately named the auditor's:

```
task.mcp_forward_receipt_invalid: Policy denied: motebit_task requires R3_EXECUTE but max allowed is R1_DRAFT
```

**Root cause:** `const policyOverrides = molecule.policyOverrides ?? DEFAULT_POLICY_OVERRIDES`. An empty object `{}` is *defined*, so `??` keeps it and drops the baseline `denyAbove: R3_EXECUTE` → default R1_DRAFT → every R3 tool denied, including the relay-forwarded `motebit_task` (always R3). The **Auditor and Summarize both copy-pasted `policyOverrides: {}`** (the comment even admits "the previous hand-rolled boot passed {}"), so both silently could never execute a paid task. Research/Clerk set nothing → got the R3 default → worked. The molecule-runner comment already documented this exact class but only fixed the *default*, never guarded against a molecule *overriding* it badly.

## Fix

**Floor-merge:** `{ ...DEFAULT_POLICY_OVERRIDES, ...molecule.policyOverrides }`. The R3 baseline is a floor every task-receiving molecule needs; a molecule can still **raise** `denyAbove` (the Clerk → R4 money) by setting it explicitly, but a partial or empty override can no longer silently drop below R3. Removed the now-misleading `policyOverrides: {}` from auditor + summarize.

Tests: empty-override inherits R3; partial-override raises `denyAbove` but keeps the baseline `requireApprovalAbove`.

## Also — summarize pricing (the other red)

`summarize.getServiceListing` returned `pricing: []` → failed the `pricing listed` check (the check requires a non-empty pricing array). Its sibling atoms list a `unit_cost: 0` entry and pass. Fixed: list `summarize_search` at `config.unitCost` (0, zero-cost atom until multi-hop settlement), added `unitCost` to config + documented `MOTEBIT_UNIT_COST` and the `MOTEBIT_AUTH_TOKEN` 401-warning in `.env.example` (check-deploy-parity).

## Result

After this deploys, **all six services execute paid delegations end-to-end.** Research + clerk are already green; auditor + summarize were the last two reds.

Tests green (molecule-runner 41, auditor 46, summarize 8), typecheck + all pre-push gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)