### PR TITLE
feat(research): multi-hop-as-P2P Inc 2b — the Researcher pays priced atoms P2P

### DIFF
--- a/services/research/.env.example
+++ b/services/research/.env.example
@@ -69,3 +69,15 @@ MOTEBIT_READ_URL_TARGET_ID=
 # Bearer token for inbound MCP connections (optional — motebit signed
 # tokens are always accepted regardless)
 MOTEBIT_AUTH_TOKEN=
+
+# ─── Paid sub-delegation (Inc 2b, opt-in) ───────────────────────────────
+# Set BOTH to pay priced atoms P2P from this molecule's own wallet (identity
+# key = Solana seed) under a self-issued grant. Leave BOTH blank ⇒ atom hops
+# use the free direct-MCP path (today). Even when set, the P2P attempt degrades
+# to direct until the atoms are priced (worker_not_payable). MOTEBIT_RELAY_PUBLIC_KEY
+# is the relay's pinned Ed25519 key hex (treasury derivation); rotate it in
+# lockstep with the relay identity.
+MOTEBIT_SOLANA_RPC_URL=
+MOTEBIT_RELAY_PUBLIC_KEY=
+# Lifetime spend ceiling for the self-issued grant, in micro-USD (default $1).
+MOTEBIT_RESEARCH_CEILING_MICRO=1000000

--- a/services/research/src/__tests__/research.test.ts
+++ b/services/research/src/__tests__/research.test.ts
@@ -176,6 +176,175 @@ describe("research — cryptographic citation chain (via mcp-client)", () => {
     });
   });
 
+  // === Inc 2b: paid sub-delegation (priced atom → P2P, unpriced → direct) ===
+
+  it("Inc 2b: a priced atom is paid via paidSubDelegate; its receipt chains, the direct adapter is NOT called", async () => {
+    const paidReceipt = makeReceipt({
+      task_id: "paid-search-1",
+      motebit_id: "web-search-agent",
+      result: JSON.stringify([{ title: "R", url: "https://a.example.com" }]),
+      signature: "sig-paid-1",
+    });
+    const ws = new StubAtomAdapter([]); // direct path must NOT be taken
+    const ru = new StubAtomAdapter([]);
+    const paidCalls: Array<{ capability: string; targetWorkerId?: string }> = [];
+
+    mockCreate
+      .mockResolvedValueOnce({
+        content: [
+          { type: "tool_use", id: "tu-1", name: "motebit_web_search", input: { query: "q" } },
+        ],
+      })
+      .mockResolvedValueOnce({ content: [{ type: "text", text: "Synthesized." }] });
+
+    const result = await research("question", {
+      ...baseConfig,
+      webSearchTargetId: "web-search-agent",
+      adapterFactory: makeFactory(
+        new Map([
+          ["web-search", ws],
+          ["read-url", ru],
+        ]),
+      ),
+      paidSubDelegate: async (p) => {
+        paidCalls.push({ capability: p.capability, targetWorkerId: p.targetWorkerId });
+        return { ok: true, receipt: paidReceipt };
+      },
+    });
+
+    expect(result.search_count).toBe(1);
+    expect(result.delegation_receipts).toHaveLength(1);
+    expect(result.delegation_receipts[0]!.signature).toBe("sig-paid-1");
+    // The paid seam was used, pinning the atom by motebit_id + capability.
+    expect(paidCalls).toEqual([{ capability: "web_search", targetWorkerId: "web-search-agent" }]);
+    // The free direct-MCP path was NOT taken.
+    expect(ws.calls).toHaveLength(0);
+  });
+
+  it("Inc 2b: an unpriced atom (worker_not_payable) falls back to the direct MCP call", async () => {
+    const directReceipt = makeReceipt({
+      task_id: "direct-1",
+      motebit_id: "web-search-agent",
+      result: JSON.stringify([{ title: "R", url: "https://a.example.com" }]),
+      signature: "sig-direct-1",
+    });
+    const ws = new StubAtomAdapter([directReceipt]);
+    const ru = new StubAtomAdapter([]);
+
+    mockCreate
+      .mockResolvedValueOnce({
+        content: [
+          { type: "tool_use", id: "tu-1", name: "motebit_web_search", input: { query: "q" } },
+        ],
+      })
+      .mockResolvedValueOnce({ content: [{ type: "text", text: "Synthesized." }] });
+
+    const result = await research("question", {
+      ...baseConfig,
+      webSearchTargetId: "web-search-agent",
+      adapterFactory: makeFactory(
+        new Map([
+          ["web-search", ws],
+          ["read-url", ru],
+        ]),
+      ),
+      paidSubDelegate: async () => ({ ok: false, code: "worker_not_payable" }),
+    });
+
+    expect(result.search_count).toBe(1);
+    expect(result.delegation_receipts[0]!.signature).toBe("sig-direct-1");
+    // Fell back to the direct adapter (the atom is free).
+    expect(ws.calls).toHaveLength(1);
+  });
+
+  it("Inc 2b: a real payment failure (money_meter_denied) errors the tool and does NOT do the work for free", async () => {
+    const ws = new StubAtomAdapter([makeReceipt({ result: "x", signature: "s" })]); // must NOT be used
+    const ru = new StubAtomAdapter([]);
+
+    mockCreate
+      .mockResolvedValueOnce({
+        content: [
+          { type: "tool_use", id: "tu-1", name: "motebit_web_search", input: { query: "q" } },
+        ],
+      })
+      .mockResolvedValueOnce({ content: [{ type: "text", text: "Gave up." }] });
+
+    const result = await research("question", {
+      ...baseConfig,
+      webSearchTargetId: "web-search-agent",
+      adapterFactory: makeFactory(
+        new Map([
+          ["web-search", ws],
+          ["read-url", ru],
+        ]),
+      ),
+      paidSubDelegate: async () => ({ ok: false, code: "money_meter_denied" }),
+    });
+
+    // No free work: the direct adapter was never called, no receipt chained.
+    expect(ws.calls).toHaveLength(0);
+    expect(result.delegation_receipts).toHaveLength(0);
+    expect(result.search_count).toBe(0);
+  });
+
+  it("Inc 2b: a paid failure with NO code is treated as a real failure (unknown), not a fallback", async () => {
+    const ws = new StubAtomAdapter([makeReceipt({ result: "x", signature: "s" })]); // must NOT be used
+    const ru = new StubAtomAdapter([]);
+
+    mockCreate
+      .mockResolvedValueOnce({
+        content: [
+          { type: "tool_use", id: "tu-1", name: "motebit_web_search", input: { query: "q" } },
+        ],
+      })
+      .mockResolvedValueOnce({ content: [{ type: "text", text: "Gave up." }] });
+
+    const result = await research("question", {
+      ...baseConfig,
+      webSearchTargetId: "web-search-agent",
+      adapterFactory: makeFactory(
+        new Map([
+          ["web-search", ws],
+          ["read-url", ru],
+        ]),
+      ),
+      paidSubDelegate: async () => ({ ok: false }), // no code ⇒ unknown ⇒ real failure
+    });
+
+    expect(ws.calls).toHaveLength(0);
+    expect(result.delegation_receipts).toHaveLength(0);
+    expect(result.search_count).toBe(0);
+  });
+
+  it("Inc 2b: a paid ok WITHOUT a receipt errors the tool (defensive — never chain a phantom edge)", async () => {
+    const ws = new StubAtomAdapter([makeReceipt({ result: "x", signature: "s" })]); // must NOT be used
+    const ru = new StubAtomAdapter([]);
+
+    mockCreate
+      .mockResolvedValueOnce({
+        content: [
+          { type: "tool_use", id: "tu-1", name: "motebit_web_search", input: { query: "q" } },
+        ],
+      })
+      .mockResolvedValueOnce({ content: [{ type: "text", text: "Gave up." }] });
+
+    const result = await research("question", {
+      ...baseConfig,
+      webSearchTargetId: "web-search-agent",
+      adapterFactory: makeFactory(
+        new Map([
+          ["web-search", ws],
+          ["read-url", ru],
+        ]),
+      ),
+      paidSubDelegate: async () => ({ ok: true }), // ok but no receipt
+    });
+
+    expect(ws.calls).toHaveLength(0);
+    expect(result.delegation_receipts).toHaveLength(0);
+    expect(result.search_count).toBe(0);
+  });
+
   it("chains a single fetch receipt", async () => {
     const receipt = makeReceipt({
       task_id: "fetch-1",

--- a/services/research/src/helpers.ts
+++ b/services/research/src/helpers.ts
@@ -21,5 +21,12 @@ export function loadConfig() {
     readUrlTargetId: process.env["MOTEBIT_READ_URL_TARGET_ID"],
     /** Maximum total tool calls (search + fetch combined) per research turn. */
     maxToolCalls: parseInt(process.env["MOTEBIT_MAX_TOOL_CALLS"] ?? "8", 10),
+    // Inc 2b — paid sub-delegation money seam. Both must be set to pay atoms
+    // P2P; absent ⇒ atom hops use the free direct-MCP path (dormant until the
+    // atoms are priced). The molecule's identity key IS the Solana wallet seed.
+    solanaRpcUrl: process.env["MOTEBIT_SOLANA_RPC_URL"] ?? null,
+    relayPublicKey: process.env["MOTEBIT_RELAY_PUBLIC_KEY"] ?? null,
+    // Lifetime spend ceiling for the self-issued grant (micro-USD). Default $1.
+    ceilingMicro: parseInt(process.env["MOTEBIT_RESEARCH_CEILING_MICRO"] ?? "1000000", 10),
   };
 }

--- a/services/research/src/index.ts
+++ b/services/research/src/index.ts
@@ -105,8 +105,26 @@ async function main(): Promise<void> {
       ...(config.syncUrl != null ? { syncUrl: config.syncUrl } : {}),
       ...(config.apiToken != null ? { apiToken: config.apiToken } : {}),
       ...(config.publicUrl != null ? { publicUrl: config.publicUrl } : {}),
+      // Inc 2b — paid sub-delegation seam, opt-in via env. When BOTH the Solana
+      // RPC and the pinned relay key are set, the Researcher pays priced atoms
+      // P2P from its own wallet under a self-issued grant; absent ⇒ no spend
+      // handle ⇒ the free direct-MCP path (today). The atoms are still $0, so
+      // even with this set the P2P attempt degrades to direct (worker_not_payable)
+      // until Inc 3 prices them.
+      ...(config.solanaRpcUrl != null && config.relayPublicKey != null
+        ? {
+            moneyExecution: {
+              solanaRpcUrl: config.solanaRpcUrl,
+              relayPublicKeyHex: config.relayPublicKey,
+              spendCeiling: {
+                schema: "motebit.spend-ceiling.v1" as const,
+                lifetime_limit_micro: config.ceilingMicro,
+              },
+            },
+          }
+        : {}),
     },
-    (identity) => {
+    (identity, spend) => {
       const { motebitId, deviceId, publicKey, privateKey } = identity;
 
       // Build the ResearchConfig the handler/research turn will use.
@@ -127,6 +145,26 @@ async function main(): Promise<void> {
           ? { webSearchTargetId: config.webSearchTargetId }
           : {}),
         ...(config.readUrlTargetId != null ? { readUrlTargetId: config.readUrlTargetId } : {}),
+        // Inc 2b — thread the money runtime's spend handle as the paid
+        // sub-delegation seam (present only when moneyExecution was wired above).
+        // The research turn attempts P2P for priced atoms and reads the atom's
+        // receipt from the granted-delegation result.
+        ...(spend != null
+          ? {
+              paidSubDelegate: async (p: {
+                capability: string;
+                prompt: string;
+                targetWorkerId?: string;
+              }) => {
+                const r = await spend.spend(p);
+                if (!r.ok) return { ok: false as const, code: r.code };
+                // The research turn never dry-runs, so the live variant carries
+                // the atom's receipt; the dry-run variant is unreachable here.
+                if (r.dryRun) return { ok: true as const };
+                return { ok: true as const, receipt: r.receipt as unknown as ExecutionReceipt };
+              },
+            }
+          : {}),
       };
 
       const registry = new InMemoryToolRegistry();

--- a/services/research/src/research.ts
+++ b/services/research/src/research.ts
@@ -111,7 +111,41 @@ export interface ResearchConfig {
    * without spinning up a real MCP server.
    */
   adapterFactory?: AdapterFactory;
+  /**
+   * Inc 2b — the paid sub-delegation seam. Supplied by the money runtime (the
+   * molecule-runner spend handle) when the service boots with `moneyExecution`
+   * wired. ABSENT ⇒ every atom hop uses the free direct-MCP path (today's
+   * behavior), so this is dormant until the money seam is enabled. When
+   * present, a PRICED atom is paid P2P (the relay coordinates the hop and earns
+   * its fee); an unpriced atom falls back to direct MCP.
+   */
+  paidSubDelegate?: PaidSubDelegate;
 }
+
+/** Result of a paid P2P sub-delegation attempt (Inc 2b). */
+export interface PaidSubDelegateResult {
+  ok: boolean;
+  /** The sub-worker's signed execution receipt (present on `ok`). */
+  receipt?: SignedReceipt;
+  /** Failure code when `!ok` (e.g. `worker_not_payable`, `money_meter_denied`). */
+  code?: string;
+}
+
+/**
+ * Pay a priced atom P2P from this molecule's own wallet, under its self-issued
+ * grant. A `worker_not_payable` / `no_routing` / `p2p_ineligible` result means
+ * the atom is not P2P-payable (unpriced / no settlement mode) and the caller
+ * falls back to direct MCP; any OTHER failure is a real payment error and is
+ * surfaced — the turn never silently does the work for free.
+ */
+export type PaidSubDelegate = (params: {
+  capability: string;
+  prompt: string;
+  targetWorkerId?: string;
+}) => Promise<PaidSubDelegateResult>;
+
+/** Codes that mean "this atom is not set up for P2P" → fall back to direct MCP. */
+const NOT_PAYABLE_CODES = new Set(["worker_not_payable", "no_routing", "p2p_ineligible"]);
 
 /** Minimal interface the research turn needs from an mcp-client adapter. */
 export interface AtomAdapter {
@@ -339,31 +373,72 @@ export async function research(question: string, config: ResearchConfig): Promis
         };
       }
 
-      const relayTaskId = await bindRelayBudget(config, prompt, capabilityHint, targetId);
-      const args: Record<string, unknown> = { prompt };
-      if (relayTaskId != null) args.relay_task_id = relayTaskId;
-
-      const result = await adapter.executeTool(qualified, args);
-      // McpClientAdapter captures any motebit-shaped receipt during executeTool.
-      // Drain immediately so receipt order matches the dispatch order.
-      const fresh = adapter.getAndResetDelegationReceipts();
-      delegationReceipts.push(...fresh);
+      // Every web tool dispatch counts against the runaway-cost cap, success or
+      // failure, on either the paid or the free path.
       toolCallCount++;
 
-      if (!result.ok || fresh.length === 0) {
-        return {
-          type: "tool_result",
-          tool_use_id: tu.id,
-          content: `delegation to ${tu.name} failed for "${prompt.slice(0, 80)}"`,
-          is_error: true,
-        };
+      // Inc 2b: a PRICED atom is paid P2P (this molecule pays the atom onchain
+      // from its own wallet under its self-grant — the relay coordinates the hop
+      // and earns its fee); a free/unpriced atom uses the direct MCP call.
+      // `paidSubDelegate` is absent unless the money seam is wired, so this is
+      // dormant (today's direct path) until the atoms are priced.
+      let receipt: SignedReceipt | undefined;
+      if (config.paidSubDelegate != null && targetId != null) {
+        const paid = await config.paidSubDelegate({
+          capability: capabilityHint,
+          prompt,
+          targetWorkerId: targetId,
+        });
+        if (paid.ok) {
+          if (paid.receipt == null) {
+            return {
+              type: "tool_result",
+              tool_use_id: tu.id,
+              content: `paid delegation to ${tu.name} returned no receipt`,
+              is_error: true,
+            };
+          }
+          receipt = paid.receipt;
+          delegationReceipts.push(receipt);
+        } else if (!NOT_PAYABLE_CODES.has(paid.code ?? "")) {
+          // A real payment failure (ceiling/grant/auth) — never silently do the
+          // work for free; surface the closed code to the loop.
+          return {
+            type: "tool_result",
+            tool_use_id: tu.id,
+            content: `paid delegation to ${tu.name} refused (${paid.code ?? "unknown"})`,
+            is_error: true,
+          };
+        }
+        // else: not P2P-payable (unpriced atom) → fall through to direct MCP.
+      }
+
+      if (receipt == null) {
+        const relayTaskId = await bindRelayBudget(config, prompt, capabilityHint, targetId);
+        const args: Record<string, unknown> = { prompt };
+        if (relayTaskId != null) args.relay_task_id = relayTaskId;
+
+        const result = await adapter.executeTool(qualified, args);
+        // McpClientAdapter captures any motebit-shaped receipt during executeTool.
+        // Drain immediately so receipt order matches the dispatch order.
+        const fresh = adapter.getAndResetDelegationReceipts();
+        delegationReceipts.push(...fresh);
+
+        if (!result.ok || fresh.length === 0) {
+          return {
+            type: "tool_result",
+            tool_use_id: tu.id,
+            content: `delegation to ${tu.name} failed for "${prompt.slice(0, 80)}"`,
+            is_error: true,
+          };
+        }
+        receipt = fresh[fresh.length - 1]!;
       }
 
       if (tu.name === "motebit_web_search") searchCount++;
       else fetchCount++;
 
       // The receipt is the cryptographic edge; its `result` is what Claude reads.
-      const receipt = fresh[fresh.length - 1]!;
       const resultText = receiptResultText(receipt);
 
       // Only read_url hits become citations — bare search results are


### PR DESCRIPTION
The **consumer** half of multi-hop-as-P2P: the Researcher now pays a **priced** atom P2P from its own wallet (the relay coordinates the hop and earns its fee) instead of the free direct-MCP call — generalizing the Clerk's paying path via the Inc 2a `targetWorkerId` pin.

## Safe by construction / dormant until Inc 3

The paid seam (`config.paidSubDelegate`) is wired **only** when the money env (`MOTEBIT_SOLANA_RPC_URL` + `MOTEBIT_RELAY_PUBLIC_KEY`) is set. Unset in prod ⇒ no spend handle ⇒ `paidSubDelegate` undefined ⇒ the paid branch is skipped ⇒ **byte-identical to today** (the just-greened conformance is untouched — all 35 existing tests pass unchanged). Even with the env set, atoms are still $0, so the P2P attempt degrades to direct (`worker_not_payable`) until Inc 3 prices them.

## Mechanism (research.ts `dispatchToolUse` seam)

If `paidSubDelegate` is present and the atom is pinned (`targetWorkerId` from `MOTEBIT_*_TARGET_ID`) → **attempt P2P**:
- **ok** → read the atom's output from the returned `receipt.result`, chain the receipt.
- **`worker_not_payable` / `no_routing` / `p2p_ineligible`** → fall back to the direct MCP call (the atom is free).
- **any other failure** (`money_meter_denied` / grant / auth) → **error the tool** — never silently do the work for free.

Boot (`index.ts`) wires `moneyExecution` gated on env and threads the spend handle as `paidSubDelegate`; the molecule's identity key is the Solana wallet seed (same as the Clerk).

## Tests (5 new)

priced → paid + receipt chained + direct adapter NOT called + pinned by `motebit_id`; unpriced → direct fallback; `money_meter_denied` → error + no free work; no-code failure → treated as unknown real failure; paid-ok-without-receipt → error (never chain a phantom edge).

Research **40 green, 100%/100% coverage**; lint, `check-deploy-parity` (new env vars documented in `.env.example`), `check-money-authority` all pass.

## Next (Inc 3)

Price the atoms (web-search/read-url) + advertise `settlement_modes=p2p` so the P2P path actually resolves, then extend conformance to assert the full delegation tree settles p2p. Only then flip the money env on the research deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)