### PR TITLE
feat(research): sub-hop path observability — make the paid-vs-direct decision loud

### DIFF
--- a/services/research/src/research.ts
+++ b/services/research/src/research.ts
@@ -383,7 +383,12 @@ export async function research(question: string, config: ResearchConfig): Promis
       // `paidSubDelegate` is absent unless the money seam is wired, so this is
       // dormant (today's direct path) until the atoms are priced.
       let receipt: SignedReceipt | undefined;
+      // Observability — the sub-hop path is otherwise invisible from outside;
+      // log which lane fires (paid P2P vs free direct MCP) and, on fallback,
+      // the exact not-payable code. Same "make the silent decision loud"
+      // discipline as the relay's mcp-forward logging.
       if (config.paidSubDelegate != null && targetId != null) {
+        console.log(`[research] sub-hop: attempting P2P cap=${capabilityHint} target=${targetId}`);
         const paid = await config.paidSubDelegate({
           capability: capabilityHint,
           prompt,
@@ -391,6 +396,7 @@ export async function research(question: string, config: ResearchConfig): Promis
         });
         if (paid.ok) {
           if (paid.receipt == null) {
+            console.log(`[research] sub-hop: paid ok but NO receipt cap=${capabilityHint}`);
             return {
               type: "tool_result",
               tool_use_id: tu.id,
@@ -398,19 +404,32 @@ export async function research(question: string, config: ResearchConfig): Promis
               is_error: true,
             };
           }
+          console.log(`[research] sub-hop: PAID P2P cap=${capabilityHint}`);
           receipt = paid.receipt;
           delegationReceipts.push(receipt);
         } else if (!NOT_PAYABLE_CODES.has(paid.code ?? "")) {
           // A real payment failure (ceiling/grant/auth) — never silently do the
           // work for free; surface the closed code to the loop.
+          console.log(
+            `[research] sub-hop: paid FAILED cap=${capabilityHint} code=${paid.code ?? "unknown"}`,
+          );
           return {
             type: "tool_result",
             tool_use_id: tu.id,
             content: `paid delegation to ${tu.name} refused (${paid.code ?? "unknown"})`,
             is_error: true,
           };
+        } else {
+          // Not P2P-payable (unpriced atom / no route) → fall through to direct
+          // MCP. `paid.code` is guaranteed a not-payable code here (it passed
+          // NOT_PAYABLE_CODES.has above).
+          console.log(
+            `[research] sub-hop: fallback DIRECT cap=${capabilityHint} code=${paid.code}`,
+          );
         }
-        // else: not P2P-payable (unpriced atom) → fall through to direct MCP.
+      } else {
+        // No paid seam (money env unset) or no pinned target → free direct MCP.
+        console.log(`[research] sub-hop: DIRECT (no paid seam) cap=${capabilityHint}`);
       }
 
       if (receipt == null) {


### PR DESCRIPTION
The Researcher chooses per atom hop between paying P2P and the free direct-MCP fallback (Inc 2b), and that decision was **invisible from outside** — a green conformance run looked identical whether the atoms got paid or silently did the work for free. This logs each sub-hop's lane and, on fallback, the exact not-payable code — the same "make the silent decision loud" discipline as the relay's mcp-forward logging.

## This instrument cracked the multi-hop last-mile blocker

Deployed to staging, it gave definitive ground truth in one run: research **attempts** P2P for both atom hops (paid seam wired, target correct) and both return `code=p2p_ineligible`. A second instrument on the runtime's eligibility fetch showed why: **`status=401 body={"error":"Token verification failed"}`** on the eligibility pre-flight.

**Root cause (systemic, all molecules):** a molecule mints its outbound token via `makeAuthTokenMinter` (signed by its identity key) but registers **service-mode** via `/api/v1/agents/register` → `agent_registry`. The relay's `verifySignedTokenForDevice` on the market:listing routes reads only the **device store**, not `agent_registry`, so the molecule's key can't verify its token → 401 → `p2p_ineligible` → Inc 2b fallback. The Clerk (same money seam) hits the identical 401; its conformance "refusal is a signed denial `code=p2p_ineligible`" has been **masking this bug** as an expected refusal.

**The fix (next increment):** give the relay's `verifySignedTokenForDevice` the same **sibling fallback** the mcp-server's inbound verifier already has (`mcp-server/service.ts:306-315` — check both `agent_registry.public_key` and the device store; the comment calls it "sibling fallback, not a protocol fork"). Then molecule tokens verify → eligibility 200 → the ack unlocks → research broadcasts → the tree settles P2P.

Research 40 tests green, 100% coverage, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)