### PR TITLE
fix(relay): verify service-mode molecule tokens against agent_registry (Inc 3c)

### DIFF
--- a/services/relay/src/__tests__/auth.test.ts
+++ b/services/relay/src/__tests__/auth.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { parseTokenPayloadUnsafe } from "../auth.js";
+import { generateKeypair, createSignedToken, bytesToHex } from "@motebit/crypto";
+import type { IdentityManager } from "@motebit/core-identity";
+import type { TokenAudience } from "@motebit/protocol";
+import { parseTokenPayloadUnsafe, verifySignedTokenForDevice } from "../auth.js";
 
 /** Encode a payload object into the base64.signature format expected by parseTokenPayloadUnsafe. */
 function makeToken(payload: unknown): string {
@@ -114,5 +117,124 @@ describe("parseTokenPayloadUnsafe", () => {
   it("returns null for string payload", () => {
     const b64 = btoa('"just a string"');
     expect(parseTokenPayloadUnsafe(`${b64}.sig`)).toBeNull();
+  });
+});
+
+describe("verifySignedTokenForDevice — agent-registry sibling fallback", () => {
+  const mid = "motebit-molecule-1";
+  const did = "device-molecule-1";
+
+  /** IdentityManager whose device store has no row for anyone (service-mode caller). */
+  const noDeviceIM = {
+    loadDeviceById: async () => null,
+  } as unknown as IdentityManager;
+
+  /** IdentityManager with a device row carrying the given public key. */
+  function deviceIM(publicKeyHex: string): IdentityManager {
+    return {
+      loadDeviceById: async () => ({ public_key: publicKeyHex }),
+    } as unknown as IdentityManager;
+  }
+
+  async function mintToken(privateKey: Uint8Array, aud: TokenAudience = "market:listing") {
+    // exp is compared against Date.now() (ms) in verifySignedToken — use ms.
+    const now = Date.now();
+    return createSignedToken(
+      { mid, did, iat: now, exp: now + 300_000, jti: "jti-molecule-1", aud },
+      privateKey,
+    );
+  }
+
+  it("rejects a service-mode molecule's token WITHOUT the fallback (reproduces the bug)", async () => {
+    const kp = await generateKeypair();
+    const token = await mintToken(kp.privateKey);
+    // No device row, no agentKeyLookup → the pre-fix behavior: silent 401.
+    const ok = await verifySignedTokenForDevice(token, mid, noDeviceIM, "market:listing");
+    expect(ok).toBe(false);
+  });
+
+  it("accepts the same token WITH the agent-registry fallback", async () => {
+    const kp = await generateKeypair();
+    const token = await mintToken(kp.privateKey);
+    const lookup = (m: string) => (m === mid ? bytesToHex(kp.publicKey) : null);
+    const ok = await verifySignedTokenForDevice(
+      token,
+      mid,
+      noDeviceIM,
+      "market:listing",
+      undefined,
+      undefined,
+      lookup,
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("still rejects a wrong-audience token even via the fallback", async () => {
+    const kp = await generateKeypair();
+    const token = await mintToken(kp.privateKey, "task:submit");
+    const lookup = (m: string) => (m === mid ? bytesToHex(kp.publicKey) : null);
+    const ok = await verifySignedTokenForDevice(
+      token,
+      mid,
+      noDeviceIM,
+      "market:listing",
+      undefined,
+      undefined,
+      lookup,
+    );
+    expect(ok).toBe(false);
+  });
+
+  it("still rejects a revoked agent before consulting the fallback", async () => {
+    const kp = await generateKeypair();
+    const token = await mintToken(kp.privateKey);
+    const lookup = (m: string) => (m === mid ? bytesToHex(kp.publicKey) : null);
+    const ok = await verifySignedTokenForDevice(
+      token,
+      mid,
+      noDeviceIM,
+      "market:listing",
+      undefined,
+      () => true, // agentRevokedCheck → revoked
+      lookup,
+    );
+    expect(ok).toBe(false);
+  });
+
+  it("rejects a token signed by a key that is NOT the registry key (forged)", async () => {
+    const real = await generateKeypair();
+    const forger = await generateKeypair();
+    const token = await mintToken(forger.privateKey);
+    // Registry holds the REAL key; the token was signed by the forger.
+    const lookup = (m: string) => (m === mid ? bytesToHex(real.publicKey) : null);
+    const ok = await verifySignedTokenForDevice(
+      token,
+      mid,
+      noDeviceIM,
+      "market:listing",
+      undefined,
+      undefined,
+      lookup,
+    );
+    expect(ok).toBe(false);
+  });
+
+  it("prefers the device store when a device row exists (fallback not consulted)", async () => {
+    const kp = await generateKeypair();
+    const token = await mintToken(kp.privateKey);
+    // Device row has the right key; lookup would throw if consulted — proving precedence.
+    const lookup = () => {
+      throw new Error("agentKeyLookup must not be consulted when a device row exists");
+    };
+    const ok = await verifySignedTokenForDevice(
+      token,
+      mid,
+      deviceIM(bytesToHex(kp.publicKey)),
+      "market:listing",
+      undefined,
+      undefined,
+      lookup,
+    );
+    expect(ok).toBe(true);
   });
 });

--- a/services/relay/src/auth.ts
+++ b/services/relay/src/auth.ts
@@ -108,6 +108,7 @@ export async function verifySignedTokenForDevice(
   expectedAudience: TokenAudience,
   blacklistCheck?: (jti: string, motebitId: string) => boolean,
   agentRevokedCheck?: (motebitId: string) => boolean,
+  agentKeyLookup?: (motebitId: string) => string | null,
 ): Promise<boolean> {
   const claims = parseTokenPayloadUnsafe(token);
   if (!claims || claims.mid !== motebitId || !claims.did) return false;
@@ -118,10 +119,23 @@ export async function verifySignedTokenForDevice(
   // Check if this specific token's jti has been blacklisted
   if (blacklistCheck && claims.jti && blacklistCheck(claims.jti, motebitId)) return false;
 
+  // Resolve the verifying public key. Device-mode motebits (web/mobile/desktop)
+  // have a device row keyed by `did`. Service-mode motebits (molecules) register
+  // into `agent_registry` via /api/v1/agents/register and have NO device row —
+  // their outbound token is signed by the same identity key that landed in the
+  // registry. Check the device store first, then fall back to the agent registry
+  // by motebit_id. This is the same sibling fallback the mcp-server's inbound
+  // verifier already performs (`mcp-server/service.ts` — "sibling fallback, not a
+  // protocol fork"): both tables are siblings of the one identity surface, and
+  // checking only the device store silently 401s every service-mode caller.
   const device = await identityManager.loadDeviceById(claims.did, motebitId);
-  if (!device || !device.public_key) return false;
+  let pubKeyHex: string | null = device?.public_key ?? null;
+  if (pubKeyHex === null && agentKeyLookup) {
+    pubKeyHex = agentKeyLookup(motebitId);
+  }
+  if (pubKeyHex === null) return false;
 
-  const pubKeyBytes = hexToBytes(device.public_key);
+  const pubKeyBytes = hexToBytes(pubKeyHex);
   const payload = await verifySignedToken(token, pubKeyBytes);
   if (payload === null || payload.mid !== motebitId) return false;
 

--- a/services/relay/src/index.ts
+++ b/services/relay/src/index.ts
@@ -634,6 +634,38 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
     }, {}),
   });
 
+  // Service-mode motebits (molecules) register into `agent_registry`, not the
+  // device store, so their signed tokens (market:listing, task:submit, …) have
+  // no device row to verify against. This db-backed lookup gives
+  // `verifySignedTokenForDevice` the agent-registry sibling fallback (see
+  // auth.ts); bound once here and injected at every auth site so a service-mode
+  // caller is verified uniformly rather than 401'd on the routes that happen to
+  // omit the fallback.
+  const agentRegistryKeyLookup = (mid: string): string | null => {
+    const row = moteDb.db
+      .prepare("SELECT public_key FROM agent_registry WHERE motebit_id = ?")
+      .get(mid) as { public_key?: string } | undefined;
+    return row?.public_key ?? null;
+  };
+  const verifySignedTokenForDeviceWithFallback: typeof verifySignedTokenForDevice = (
+    token,
+    mid,
+    im,
+    aud,
+    blacklistCheck,
+    agentRevokedCheck,
+    agentKeyLookup,
+  ) =>
+    verifySignedTokenForDevice(
+      token,
+      mid,
+      im,
+      aud,
+      blacklistCheck,
+      agentRevokedCheck,
+      agentKeyLookup ?? agentRegistryKeyLookup,
+    );
+
   // --- Middleware (rate limiting, CORS, security headers, auth, error handling, health) ---
   const { allLimiters, wsLimiter } = registerMiddleware({
     app,
@@ -645,7 +677,7 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
     getFreezeReason,
     isTokenBlacklisted,
     isAgentRevoked,
-    verifySignedTokenForDevice,
+    verifySignedTokenForDevice: verifySignedTokenForDeviceWithFallback,
     parseTokenPayloadUnsafe,
     getShuttingDown: config.getShuttingDown,
     getConnectionCount: () => getConnectionCount(),
@@ -790,7 +822,7 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
     wsLimiter,
     isTokenBlacklisted,
     isAgentRevoked,
-    verifySignedTokenForDevice,
+    verifySignedTokenForDevice: verifySignedTokenForDeviceWithFallback,
     parseTokenPayloadUnsafe,
     logger,
     onCommandResponse: handleCommandResponse,
@@ -809,7 +841,7 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
     apiToken,
     identityManager,
     parseTokenPayloadUnsafe,
-    verifySignedTokenForDevice,
+    verifySignedTokenForDevice: verifySignedTokenForDeviceWithFallback,
     isTokenBlacklisted,
     isAgentRevoked,
   });
@@ -833,7 +865,7 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
     getFreezeReason,
     isTokenBlacklisted,
     isAgentRevoked,
-    verifySignedTokenForDevice,
+    verifySignedTokenForDevice: verifySignedTokenForDeviceWithFallback,
     parseTokenPayloadUnsafe,
   });
 
@@ -1178,7 +1210,7 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
     apiToken,
     identityManager,
     parseTokenPayloadUnsafe,
-    verifySignedTokenForDevice,
+    verifySignedTokenForDevice: verifySignedTokenForDeviceWithFallback,
     isTokenBlacklisted,
     isAgentRevoked,
   });
@@ -1316,7 +1348,7 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
     federationConfig,
     federationQueryCache,
     parseTokenPayloadUnsafe,
-    verifySignedTokenForDevice,
+    verifySignedTokenForDevice: verifySignedTokenForDeviceWithFallback,
     isTokenBlacklisted,
     isAgentRevoked,
   });
@@ -1740,7 +1772,7 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
     maxTasksPerSubmitter: MAX_TASKS_PER_SUBMITTER,
     x402Config: x402Config,
     parseTokenPayloadUnsafe,
-    verifySignedTokenForDevice,
+    verifySignedTokenForDevice: verifySignedTokenForDeviceWithFallback,
     isTokenBlacklisted,
     isAgentRevoked,
     platformFeeRate,


### PR DESCRIPTION
## The endgame fix for multi-hop-as-P2P

The multi-hop settlement tree (Researcher molecule → web-search / read-url atoms) shipped across Inc 0–3b but **never actually settled P2P** — every atom hop silently fell back to the free direct-MCP path. PR #323's sub-hop observability localized it: the runtime's `p2p-eligibility` pre-flight got **`401 "Token verification failed"`**, so each priced atom read as `p2p_ineligible` (an Inc 2b not-payable code → direct fallback).

### Root cause (systemic — every molecule)

A molecule mints its outbound token (`market:listing`, `task:submit`, …) signed by its **identity key**, but registers **service-mode** via `/api/v1/agents/register` → `agent_registry` — it has **no device row**. The relay's `verifySignedTokenForDevice` resolved the verifying key **only** from the device store (`loadDeviceById`), so a service-mode caller's token had no key to verify against → `false` → 401.

The Clerk archetype (same money seam) hits the identical 401; its conformance asserts the resulting `p2p_ineligible` as an **"expected refusal"** — which is why this has been green-masked as a signed denial rather than surfaced as a bug.

### The fix

Give `verifySignedTokenForDevice` the same **sibling fallback** the mcp-server's INBOUND verifier already performs (`mcp-server/service.ts` — *"sibling fallback, not a protocol fork"*): resolve the key from the device store first, then from `agent_registry.public_key` by `motebit_id`. The molecule's registry key **is** the key that signed the token, so the signature verifies.

Bound **once** at the `index.ts` injection boundary (db-backed `agentRegistryKeyLookup`) and threaded through **all 7** auth-site injections — a service-mode caller is now verified uniformly, per the sibling-boundary rule, not via per-route patches.

### Security invariants preserved (and tested)

- Revocation (`agentRevokedCheck`) and audience binding run **before** key resolution — a revoked or wrong-audience token still 401s via the fallback path.
- A token signed by a key that is **not** the registry key is rejected (forged-key test).
- The device store **takes precedence** when a row exists (the fallback is never consulted).

Six new real-crypto tests in `auth.test.ts`: reproduce-without-fallback (the bug), fix-with-fallback, forged-key, wrong-audience, revoked, device-precedence. Full auth surface (auth / listing-auth / forward-mcp-auth / admin-auth-parity) = 56 tests green; relay typecheck + build clean.

### After merge

Redeploy the relay, then dispatch a research validation run to confirm the tree settles P2P (research SOL drops, research appears as delegator, atoms receive USDC) and extend `archetype-conformance.ts` to assert each atom hop settled `p2p`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)