### PR TITLE
fix(molecule-runner,research): thread network USDC mint to the sovereign rail (Inc 3d)

### DIFF
--- a/packages/molecule-runner/src/__tests__/run-molecule.test.ts
+++ b/packages/molecule-runner/src/__tests__/run-molecule.test.ts
@@ -468,8 +468,12 @@ describe("runMolecule", () => {
   it("SPEND sweep: env-gated; on boot sweeps the identity wallet to MOTEBIT_SWEEP_ADDRESS", async () => {
     const prevAddr = process.env.MOTEBIT_SWEEP_ADDRESS;
     const prevRpc = process.env.MOTEBIT_SOLANA_RPC_URL;
+    const prevMint = process.env.MOTEBIT_SOLANA_USDC_MINT;
     const DEST = "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgHkv";
     try {
+      // Devnet mint set → the sweep rail's mint read resolves to it (covers the
+      // present-and-non-empty branch of the network-mint plumbing).
+      process.env.MOTEBIT_SOLANA_USDC_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
       const send = vi.fn().mockResolvedValue({ signature: "sweep-sig" });
       const createSweepWallet = vi.fn(() => ({
         isAvailable: vi.fn().mockResolvedValue(true),
@@ -536,6 +540,8 @@ describe("runMolecule", () => {
       else process.env.MOTEBIT_SWEEP_ADDRESS = prevAddr;
       if (prevRpc == null) delete process.env.MOTEBIT_SOLANA_RPC_URL;
       else process.env.MOTEBIT_SOLANA_RPC_URL = prevRpc;
+      if (prevMint == null) delete process.env.MOTEBIT_SOLANA_USDC_MINT;
+      else process.env.MOTEBIT_SOLANA_USDC_MINT = prevMint;
       delete process.env.MOTEBIT_SWEEP_INTERVAL_MS;
       delete process.env.MOTEBIT_SWEEP_MIN_MICRO;
     }

--- a/packages/molecule-runner/src/index.ts
+++ b/packages/molecule-runner/src/index.ts
@@ -186,6 +186,16 @@ export interface MoleculeConfig {
     solanaRpcUrl: string;
     /** The relay operator's PINNED Ed25519 public key (hex) — P2P treasury root. */
     relayPublicKeyHex: string;
+    /**
+     * The USDC SPL mint the sovereign rail transacts in. MUST match the network
+     * behind `solanaRpcUrl` and the relay's configured settlement mint — the
+     * wallet rail reads its own balance against THIS mint before broadcasting,
+     * so a devnet molecule left on the mainnet-USDC default reads an empty ATA
+     * and fails every live hop with `insufficient_balance`. Omit only for
+     * mainnet (the rail defaults to mainnet USDC). Set to the devnet USDC mint
+     * on devnet/staging.
+     */
+    usdcMint?: string;
     /** The self-imposed signed spend ceiling this molecule commits to. */
     spendCeiling: SpendCeilingV1;
     /** Grant lifetime from issue, ms (default 90 days). */
@@ -506,6 +516,10 @@ export function defaultCreateMoneyRuntime(
   const wallet = createSolanaWalletRail({
     rpcUrl: money.solanaRpcUrl,
     identitySeed: identity.privateKey,
+    // Match the rail's mint to the network — else a devnet molecule reads the
+    // (empty) mainnet-USDC ATA and every live hop fails `insufficient_balance`.
+    // Undefined passes through to the rail's mainnet-USDC default.
+    usdcMint: money.usdcMint,
   });
   const runtime = new MotebitRuntime(
     {
@@ -731,9 +745,18 @@ export async function runMolecule(
   ) {
     const minMicro = BigInt(process.env.MOTEBIT_SWEEP_MIN_MICRO ?? "10000"); // $0.01 floor
     const intervalMs = Number(process.env.MOTEBIT_SWEEP_INTERVAL_MS ?? `${30 * 60 * 1000}`); // 30 min
+    // Same mint-must-match-network rule as the money rail above: on devnet the
+    // sweep rail must read the devnet-USDC ATA, not the mainnet default. Empty
+    // or unset → undefined → the rail's mainnet-USDC default. Read here (a
+    // covered boot line) so the fallback construction below stays branch-free.
+    const sweepUsdcMint = process.env.MOTEBIT_SOLANA_USDC_MINT?.trim() || undefined;
     const wallet =
       adapters.createSweepWallet?.(sweepRpcUrl, identity.privateKey) ??
-      createSolanaWalletRail({ rpcUrl: sweepRpcUrl, identitySeed: identity.privateKey });
+      createSolanaWalletRail({
+        rpcUrl: sweepRpcUrl,
+        identitySeed: identity.privateKey,
+        usdcMint: sweepUsdcMint,
+      });
     const doSweep = async (): Promise<void> => {
       try {
         const r = await sweepWalletRail(wallet, sweepAddress, minMicro);

--- a/services/research/.env.example
+++ b/services/research/.env.example
@@ -79,5 +79,12 @@ MOTEBIT_AUTH_TOKEN=
 # lockstep with the relay identity.
 MOTEBIT_SOLANA_RPC_URL=
 MOTEBIT_RELAY_PUBLIC_KEY=
+# USDC SPL mint the sovereign wallet rail transacts in. MUST match the network
+# behind MOTEBIT_SOLANA_RPC_URL and the relay's settlement mint — the rail reads
+# its own balance against THIS mint before broadcasting, so a devnet molecule
+# left blank reads the (empty) mainnet-USDC default and every hop fails with
+# `insufficient_balance`. Devnet USDC = 4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU.
+# Leave blank ONLY on a mainnet deployment (rail defaults to mainnet USDC).
+MOTEBIT_SOLANA_USDC_MINT=
 # Lifetime spend ceiling for the self-issued grant, in micro-USD (default $1).
 MOTEBIT_RESEARCH_CEILING_MICRO=1000000

--- a/services/research/src/helpers.ts
+++ b/services/research/src/helpers.ts
@@ -26,6 +26,10 @@ export function loadConfig() {
     // atoms are priced). The molecule's identity key IS the Solana wallet seed.
     solanaRpcUrl: process.env["MOTEBIT_SOLANA_RPC_URL"] ?? null,
     relayPublicKey: process.env["MOTEBIT_RELAY_PUBLIC_KEY"] ?? null,
+    // USDC SPL mint for the sovereign wallet rail — MUST match the network
+    // behind MOTEBIT_SOLANA_RPC_URL (devnet USDC on staging). Absent ⇒ the rail
+    // defaults to mainnet USDC (only correct on a mainnet deployment).
+    solanaUsdcMint: process.env["MOTEBIT_SOLANA_USDC_MINT"] ?? null,
     // Lifetime spend ceiling for the self-issued grant (micro-USD). Default $1.
     ceilingMicro: parseInt(process.env["MOTEBIT_RESEARCH_CEILING_MICRO"] ?? "1000000", 10),
   };

--- a/services/research/src/index.ts
+++ b/services/research/src/index.ts
@@ -116,6 +116,10 @@ async function main(): Promise<void> {
             moneyExecution: {
               solanaRpcUrl: config.solanaRpcUrl,
               relayPublicKeyHex: config.relayPublicKey,
+              // Match the wallet rail's USDC mint to the network behind the RPC
+              // (devnet on staging) — else the balance pre-check reads the empty
+              // mainnet-USDC ATA and every hop fails `insufficient_balance`.
+              ...(config.solanaUsdcMint != null ? { usdcMint: config.solanaUsdcMint } : {}),
               spendCeiling: {
                 schema: "motebit.spend-ceiling.v1" as const,
                 lifetime_limit_micro: config.ceilingMicro,


### PR DESCRIPTION
## The true last-mile blocker for multi-hop-as-P2P

With the relay's service-mode-token fix deployed (#324), a live research run finally got **past** eligibility (401→200, proven in staging logs) and reached the actual P2P payment build — where it failed every hop with **`insufficient_balance`**, despite the wallet holding 4 devnet USDC.

### Root cause

The sovereign wallet rail reads its own USDC balance against `this.mint` before broadcasting (`web3js-adapter.sendUsdc`), and `createSolanaWalletRail` **defaults `usdcMint` to MAINNET USDC** (`web3js-adapter.ts:104` — `config.usdcMint ?? USDC_MINT_MAINNET`). The molecule constructed its rail with **no mint**, so a devnet-funded molecule read the (empty) *mainnet*-USDC ATA → balance 0 → `InsufficientUsdcBalanceError` → `insufficient_balance`.

It stayed hidden because every molecule's P2P attempt used to 401 at the relay and fall back to direct MCP **before** the payment build ran. Fixing the relay verifier exposed this.

### Fix

Thread a `usdcMint` through `MoleculeConfig.moneyExecution` → `createSolanaWalletRail`; the research service reads it from `MOTEBIT_SOLANA_USDC_MINT` (devnet value documented in `.env.example`). The **sweep rail** gets the same env for the identical reason (sibling-boundary rule). `undefined` passes through to the rail's mainnet default, so mainnet deployments are unchanged.

### Tests

molecule-runner 39 + research 40 green; coverage clean — the sweep test now sets the devnet mint so the network-mint read is exercised both ways.

### Deploy note

`MOTEBIT_SOLANA_USDC_MINT` travels with the money-seam env (`MOTEBIT_SOLANA_RPC_URL` / `MOTEBIT_RELAY_PUBLIC_KEY`) at the Inc 3b flip — set manually, not in the slate script (which deliberately excludes money-seam env). Devnet USDC mint = `4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU`.

Depends on #324 (relay verifier fix) for the tree to settle end-to-end; correct as a standalone fix regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)