### PR TITLE
fix(memory-graph): inject the embedder so supersede tests don't load the ONNX model

### DIFF
--- a/packages/memory-graph/src/__tests__/bitemporal.test.ts
+++ b/packages/memory-graph/src/__tests__/bitemporal.test.ts
@@ -31,6 +31,12 @@ const SCORING: ScoringConfig = {
 };
 const EMB = [1, 0, 0, 0, 0, 0, 0, 0];
 
+// Injected embedder for the supersede path — deterministic and instant, so
+// these tests never lazy-load the ~90MB ONNX model (which under a starved CI
+// runner blows the timeout). The real embedText path stays covered by
+// index.test.ts.
+const fastEmbed = async (): Promise<number[]> => EMB;
+
 function makeNode(id: string, validFrom: number, validUntil: number | null): MemoryNode {
   return {
     node_id: id,
@@ -137,7 +143,7 @@ describe("supersession is invalidation-with-provenance + emits validity on the w
       captured.push(e as (typeof captured)[number]);
       return origAppend(e);
     };
-    const graph = new MemoryGraph(storage, eventStore, "m");
+    const graph = new MemoryGraph(storage, eventStore, "m", undefined, fastEmbed);
 
     const cand = (content: string): AttributedMemoryCandidate => ({
       content,
@@ -223,7 +229,13 @@ describe("supersede intervals abut EXACTLY under clock jitter (no temporal hole 
   it("consolidateAndForm UPDATE: new.valid_from === old.valid_until (no gap)", async () => {
     await withJumpingClock(async () => {
       const storage = new InMemoryMemoryStorage();
-      const graph = new MemoryGraph(storage, new EventStore(new InMemoryEventStore()), "m");
+      const graph = new MemoryGraph(
+        storage,
+        new EventStore(new InMemoryEventStore()),
+        "m",
+        undefined,
+        fastEmbed,
+      );
       const a = await graph.formMemory(cand("home=Paris"), EMB);
       const provider: ConsolidationProvider = {
         classify: () =>
@@ -243,7 +255,13 @@ describe("supersede intervals abut EXACTLY under clock jitter (no temporal hole 
   it("supersedeMemoryByNodeId: new.valid_from === old.valid_until (no overlap)", async () => {
     await withJumpingClock(async () => {
       const storage = new InMemoryMemoryStorage();
-      const graph = new MemoryGraph(storage, new EventStore(new InMemoryEventStore()), "m");
+      const graph = new MemoryGraph(
+        storage,
+        new EventStore(new InMemoryEventStore()),
+        "m",
+        undefined,
+        fastEmbed,
+      );
       const a = await graph.formMemory(cand("home=Paris"), EMB);
       const newId = await graph.supersedeMemoryByNodeId(a.node_id, "home=Lyon", "moved");
       const aAfter = (await storage.getNode(a.node_id))!;

--- a/packages/memory-graph/src/__tests__/trinity-integration.test.ts
+++ b/packages/memory-graph/src/__tests__/trinity-integration.test.ts
@@ -56,10 +56,15 @@ describe("Memory Trinity — end-to-end composition", () => {
   let eventStore: EventStore;
   let graph: MemoryGraph;
 
+  // Injected embedder for the supersede path — deterministic and instant, so
+  // these tests never lazy-load the ~90MB ONNX model. The real embedText path
+  // stays covered by index.test.ts.
+  const fastEmbed = async (): Promise<number[]> => [0.1, 0.1, 0.1];
+
   beforeEach(() => {
     storage = new InMemoryMemoryStorage();
     eventStore = new EventStore(new InMemoryEventStore());
-    graph = new MemoryGraph(storage, eventStore, MOTEBIT_ID);
+    graph = new MemoryGraph(storage, eventStore, MOTEBIT_ID, undefined, fastEmbed);
   });
 
   /**
@@ -87,112 +92,106 @@ describe("Memory Trinity — end-to-end composition", () => {
     );
   }
 
-  // Wider timeout than the vitest 5s default — this test composes seven
-  // graph operations end-to-end (form / reinforce / promote / index /
-  // rewrite / supersede / verify) plus several embedding round-trips.
-  // Local runs land in ~500ms, but CI runners under turbo's concurrency
-  // 4 occasionally cross the 5s default while the embedding worker is
-  // contended (saw timeouts on commit 87e2f174's CI run despite local
-  // green). Same shape as `feedback_prepush_hardware_flake` — under
-  // resource contention, behaviorally-correct tests false-fail at the
-  // default timeout. Raising to 15s gives headroom without masking a
-  // real regression (a real regression would blow past 15s too).
-  it(
-    "forms → reinforces → promotes → indexes absolute → rewrites → supersedes cleanly",
-    { timeout: 15000 },
-    async () => {
-      // 1. Form two memories. Use a baseline confidence safely below the
-      //    0.95 threshold so we can observe the crossing.
-      const nodeA = await graph.formMemory(
-        {
-          content: "User prefers TypeScript",
-          confidence: 0.75,
-          sensitivity: SensitivityLevel.None,
-          source: "user_stated",
-        },
-        [0.1, 0.2, 0.3],
-      );
-      const nodeB = await graph.formMemory(
-        {
-          content: "User lives in SF",
-          confidence: 0.75,
-          sensitivity: SensitivityLevel.None,
-          source: "user_stated",
-        },
-        [0.4, 0.5, 0.6],
-      );
+  // This test composes seven graph operations end-to-end (form / reinforce /
+  // promote / index / rewrite / supersede / verify). It used to false-fail on
+  // contended CI at a raised 15s timeout — but the real culprit was the
+  // supersede path lazy-loading the ~90MB ONNX embedding model under a starved
+  // runner, not the arithmetic. With `fastEmbed` injected (above) there is no
+  // model load, so the test runs in milliseconds and inherits the shared 30s
+  // default (the old explicit 15s override was, after the shared default rose
+  // to 30s, silently capping this test BELOW everyone else's ceiling).
+  it("forms → reinforces → promotes → indexes absolute → rewrites → supersedes cleanly", async () => {
+    // 1. Form two memories. Use a baseline confidence safely below the
+    //    0.95 threshold so we can observe the crossing.
+    const nodeA = await graph.formMemory(
+      {
+        content: "User prefers TypeScript",
+        confidence: 0.75,
+        sensitivity: SensitivityLevel.None,
+        source: "user_stated",
+      },
+      [0.1, 0.2, 0.3],
+    );
+    const nodeB = await graph.formMemory(
+      {
+        content: "User lives in SF",
+        confidence: 0.75,
+        sensitivity: SensitivityLevel.None,
+        source: "user_stated",
+      },
+      [0.4, 0.5, 0.6],
+    );
 
-      // Sanity check: neither is above the threshold yet.
-      const after0 = await storage.getNode(nodeA.node_id);
-      expect(after0!.confidence).toBeLessThan(PROMOTION_CONFIDENCE_THRESHOLD);
+    // Sanity check: neither is above the threshold yet.
+    const after0 = await storage.getNode(nodeA.node_id);
+    expect(after0!.confidence).toBeLessThan(PROMOTION_CONFIDENCE_THRESHOLD);
 
-      // 2. Reinforce A three times. Motebit boosts confidence by +0.1
-      //    per reinforcement: 0.75 → 0.85 → 0.95 → 1.0. Promotion crosses
-      //    the threshold on the second reinforcement.
-      await reinforceOnto(nodeA.node_id, "Once more, TypeScript preference");
-      await reinforceOnto(nodeA.node_id, "Again, TypeScript");
-      await reinforceOnto(nodeA.node_id, "Yet again");
+    // 2. Reinforce A three times. Motebit boosts confidence by +0.1
+    //    per reinforcement: 0.75 → 0.85 → 0.95 → 1.0. Promotion crosses
+    //    the threshold on the second reinforcement.
+    await reinforceOnto(nodeA.node_id, "Once more, TypeScript preference");
+    await reinforceOnto(nodeA.node_id, "Again, TypeScript");
+    await reinforceOnto(nodeA.node_id, "Yet again");
 
-      // 3. memory_promoted emitted exactly once — idempotent past threshold.
-      const promotions = await countEventsOfType(eventStore, EventType.MemoryPromoted);
-      expect(promotions).toHaveLength(1);
-      expect(promotions[0]!.payload).toMatchObject({
-        node_id: nodeA.node_id,
-        to_confidence: expect.any(Number),
-      });
-      expect(promotions[0]!.payload.to_confidence).toBeGreaterThanOrEqual(
-        PROMOTION_CONFIDENCE_THRESHOLD,
-      );
+    // 3. memory_promoted emitted exactly once — idempotent past threshold.
+    const promotions = await countEventsOfType(eventStore, EventType.MemoryPromoted);
+    expect(promotions).toHaveLength(1);
+    expect(promotions[0]!.payload).toMatchObject({
+      node_id: nodeA.node_id,
+      to_confidence: expect.any(Number),
+    });
+    expect(promotions[0]!.payload.to_confidence).toBeGreaterThanOrEqual(
+      PROMOTION_CONFIDENCE_THRESHOLD,
+    );
 
-      // 4. Index reflects the absolute certainty label.
-      //    Build directly with current storage snapshot.
-      const nodes = await storage.getAllNodes(MOTEBIT_ID);
-      const edges = await storage.getAllEdges(MOTEBIT_ID);
-      const indexV1 = buildMemoryIndex(nodes, edges);
+    // 4. Index reflects the absolute certainty label.
+    //    Build directly with current storage snapshot.
+    const nodes = await storage.getAllNodes(MOTEBIT_ID);
+    const edges = await storage.getAllEdges(MOTEBIT_ID);
+    const indexV1 = buildMemoryIndex(nodes, edges);
 
-      expect(indexV1).toContain("User prefers TypeScript");
-      expect(indexV1).toContain("User lives in SF");
-      expect(indexV1).toMatch(/User prefers TypeScript.*\(absolute, from:user\)/);
-      expect(indexV1).toMatch(/User lives in SF.*\(confident, from:user\)/);
+    expect(indexV1).toContain("User prefers TypeScript");
+    expect(indexV1).toContain("User lives in SF");
+    expect(indexV1).toMatch(/User prefers TypeScript.*\(absolute, from:user\)/);
+    expect(indexV1).toMatch(/User lives in SF.*\(confident, from:user\)/);
 
-      // 5. Agent decides the memory was wrong and rewrites via the
-      //    tool path.
-      const newNodeId = await graph.supersedeMemoryByNodeId(
-        nodeA.node_id,
-        "User actually prefers Rust now",
-        "user correction mid-conversation",
-      );
+    // 5. Agent decides the memory was wrong and rewrites via the
+    //    tool path.
+    const newNodeId = await graph.supersedeMemoryByNodeId(
+      nodeA.node_id,
+      "User actually prefers Rust now",
+      "user correction mid-conversation",
+    );
 
-      // 6. Event-log audit — original, replacement, and supersede bridge.
-      const formed = await countEventsOfType(eventStore, EventType.MemoryFormed);
-      // Two original formations + one from the supersede path = 3 total.
-      // Every reinforcement skips the formMemory call (REINFORCE boosts
-      // in place, no new node), so only the supersede adds.
-      expect(formed).toHaveLength(3);
-      const formedIds = formed.map((e) => e.payload.node_id);
-      expect(formedIds).toContain(nodeA.node_id); // original preserved (append-only)
-      expect(formedIds).toContain(nodeB.node_id);
-      expect(formedIds).toContain(newNodeId);
+    // 6. Event-log audit — original, replacement, and supersede bridge.
+    const formed = await countEventsOfType(eventStore, EventType.MemoryFormed);
+    // Two original formations + one from the supersede path = 3 total.
+    // Every reinforcement skips the formMemory call (REINFORCE boosts
+    // in place, no new node), so only the supersede adds.
+    expect(formed).toHaveLength(3);
+    const formedIds = formed.map((e) => e.payload.node_id);
+    expect(formedIds).toContain(nodeA.node_id); // original preserved (append-only)
+    expect(formedIds).toContain(nodeB.node_id);
+    expect(formedIds).toContain(newNodeId);
 
-      const consolidations = await countEventsOfType(eventStore, EventType.MemoryConsolidated);
-      const supersedeEvent = consolidations.find((e) => e.payload.action === "supersede");
-      expect(supersedeEvent).toBeDefined();
-      expect(supersedeEvent!.payload).toMatchObject({
-        action: "supersede",
-        existing_node_id: nodeA.node_id,
-        new_node_id: newNodeId,
-      });
+    const consolidations = await countEventsOfType(eventStore, EventType.MemoryConsolidated);
+    const supersedeEvent = consolidations.find((e) => e.payload.action === "supersede");
+    expect(supersedeEvent).toBeDefined();
+    expect(supersedeEvent!.payload).toMatchObject({
+      action: "supersede",
+      existing_node_id: nodeA.node_id,
+      new_node_id: newNodeId,
+    });
 
-      // 7. Index rebuilds with the new content; old is gone from live view.
-      const nodes2 = await storage.getAllNodes(MOTEBIT_ID);
-      const edges2 = await storage.getAllEdges(MOTEBIT_ID);
-      const indexV2 = buildMemoryIndex(nodes2, edges2);
-      expect(indexV2).not.toContain("User prefers TypeScript");
-      expect(indexV2).toContain("User actually prefers Rust now");
-      // User lives in SF remains untouched.
-      expect(indexV2).toContain("User lives in SF");
-    },
-  );
+    // 7. Index rebuilds with the new content; old is gone from live view.
+    const nodes2 = await storage.getAllNodes(MOTEBIT_ID);
+    const edges2 = await storage.getAllEdges(MOTEBIT_ID);
+    const indexV2 = buildMemoryIndex(nodes2, edges2);
+    expect(indexV2).not.toContain("User prefers TypeScript");
+    expect(indexV2).toContain("User actually prefers Rust now");
+    // User lives in SF remains untouched.
+    expect(indexV2).toContain("User lives in SF");
+  });
 
   it("MemoryGraph.getMemoryIndex wraps buildMemoryIndex over live storage", async () => {
     // Empty graph produces the empty-state string.

--- a/packages/memory-graph/src/index.ts
+++ b/packages/memory-graph/src/index.ts
@@ -6,6 +6,9 @@ import type { ConsolidationProvider, ConsolidationDecision } from "./consolidati
 import { shouldPromote, buildPromotionPayload } from "./promotion.js";
 import { buildMemoryIndex as buildMemoryIndexFn } from "./memory-index.js";
 import type { EventStore } from "@motebit/event-log";
+// Local import for the default embedder (the `export … from` below only
+// re-exports for consumers; it does not bring the name into this module scope).
+import { embedText } from "./embeddings.js";
 
 export {
   embedText,
@@ -614,6 +617,15 @@ export class MemoryGraph {
     private eventStore: EventStore,
     private motebitId: string,
     scoringConfig?: Partial<ScoringConfig>,
+    /**
+     * Text embedder for internal re-embedding (the supersede rewrite embeds new
+     * content, which callers pass as a string, not a vector). Defaults to the
+     * model-backed `embedText`. Injectable — adapter-everywhere — so a test can
+     * supply a fast deterministic embedder instead of lazy-loading the ~90MB
+     * ONNX model, which otherwise makes `supersedeMemoryByNodeId` a
+     * contention-flaky unit test (a 30s+ model load under a starved CI runner).
+     */
+    private embed: (text: string) => Promise<number[]> = embedText,
   ) {
     this.scoringConfig = { ...DEFAULT_SCORING_CONFIG, ...scoringConfig };
   }
@@ -1316,9 +1328,9 @@ export class MemoryGraph {
 
     // Embed the new content so retrieval works against the replacement
     // immediately. Sensitivity + memory_type inherit from the old node —
-    // the rewrite is a correction, not a re-classification.
-    const { embedText } = await import("./embeddings.js");
-    const embedding = await embedText(newContent);
+    // the rewrite is a correction, not a re-classification. Uses the injected
+    // embedder (defaults to the model-backed `embedText`).
+    const embedding = await this.embed(newContent);
 
     // Stamp once, BEFORE forming the new node, so the new node's `valid_from`
     // equals the old node's `valid_until` exactly — intervals abut with no


### PR DESCRIPTION
## The flake that's reddening unrelated PRs

`bitemporal` + `trinity-integration` have been false-failing on contended CI — including on PRs that don't touch memory-graph (e.g. #328, a dormant `@motebit/semiring` change). The failures looked like assertion failures but were **30s timeouts**: vitest points at the `it()` line on a timeout, and the CI durations were **30038ms / 45034ms** — the 30s ceiling firing under a starved runner.

## Root cause — not the clock, the model

The supersede *code* is correct: it stamps a single `now` (`index.ts:1326`) and passes it to both the old node's `valid_until` and the new node's `valid_from`, so the intervals abut regardless of jitter. The real culprit: **`supersedeMemoryByNodeId` lazy-loads the ~90MB `@xenova/transformers` ONNX model** via `embedText` to re-embed the rewritten content. Under a contended CI runner that load blows the timeout. Only *supersede*-based tests flaked — `formMemory` / `consolidateAndForm` take the embedding as a parameter and never load the model.

## The fix — adapter-everywhere, not a bigger number

`MemoryGraph` gains an optional injected `embed` (default the model-backed `embedText`); `supersedeMemoryByNodeId` uses `this.embed` instead of a hardcoded dynamic import. The two flaky suites inject a fast deterministic stub — **no model load, 466ms instead of 30s+**. The real `embedText` path stays covered by `index.test.ts` (left on the default). Backward-compatible: the one production caller (`runtime`) is unchanged and gets the default.

Also removed trinity's stale explicit `{ timeout: 15000 }` — written when the shared default was 5s, it now silently caps that one test *below* the current 30s shared default. Moot with the model load gone, but a below-default cap is a latent trap.

## Result

memory-graph 262 tests green; coverage clean (stmts 96.8 / branch 88.6 / lines 99.6, all above threshold). This closes the supersede contention-flake class — unblocking #328 and any future PR whose CI happened to catch a slow runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)