### PR TITLE
fix(market): activate multi-hop settlement — a newcomer earns its first job, live onchain

### DIFF
--- a/packages/runtime/src/motebit-runtime.ts
+++ b/packages/runtime/src/motebit-runtime.ts
@@ -4950,6 +4950,16 @@ export class MotebitRuntime {
           result.error.code === "money_meter_denied"
             ? (result.error.denial ?? "money_meter_denied")
             : result.error.code;
+        // Operator-side observability: the CALLER gets a bare code (refusal
+        // honesty), but the operator needs the message to debug a failed hop.
+        // A meter denial still redacts its message (overage never leaks).
+        this._logger.warn("delegation.paid_failed", {
+          code,
+          capability: params.capability,
+          ...(result.error.code !== "money_meter_denied" && "message" in result.error
+            ? { message: result.error.message }
+            : {}),
+        });
         return { ok: false, code };
       }
       return {

--- a/services/relay/src/__tests__/p2p-settlement.test.ts
+++ b/services/relay/src/__tests__/p2p-settlement.test.ts
@@ -9,6 +9,7 @@ import type { SyncRelay } from "../index.js";
 import { generateKeypair, bytesToHex, signDisputeRequest } from "@motebit/encryption";
 import { SOLANA_MAINNET_CAIP2 } from "@motebit/wallet-solana";
 import { evaluateSettlementEligibility } from "../task-routing.js";
+import { getListingUnitCost } from "../tasks.js";
 import { deriveSovereignMotebitId } from "@motebit/crypto";
 import { AUTH_HEADER, createTestRelay } from "./test-helpers.js";
 
@@ -501,5 +502,71 @@ describe("P2P disputes (trust-layer)", () => {
       body: JSON.stringify(signed),
     });
     expect(res.status).toBe(404);
+  });
+});
+
+describe("getListingUnitCost — capability-aware pricing (the multi-hop sub-hop fix)", () => {
+  let relay: SyncRelay;
+  beforeEach(async () => {
+    relay = await createTestRelay({ enableDeviceAuth: false });
+  });
+  afterEach(async () => {
+    await relay.close();
+  });
+
+  function seedListing(
+    motebitId: string,
+    pricing: Array<{ capability: string; unit_cost: number }>,
+  ) {
+    relay.moteDb.db
+      .prepare(
+        `INSERT INTO relay_service_listings
+         (listing_id, motebit_id, capabilities, pricing, sla_max_latency_ms, sla_availability, description, pay_to_address, regulatory_risk, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        `lst-${motebitId}`,
+        motebitId,
+        JSON.stringify(pricing.map((p) => p.capability)),
+        JSON.stringify(pricing),
+        5000,
+        0.99,
+        "",
+        null,
+        null,
+        Date.now(),
+      );
+  }
+
+  it("prices the SPECIFIC capability, not the SUM of a multi-capability agent's listings", () => {
+    // A web-search+read-url atom: summing (the pre-fix bug) would price a
+    // read_url hop at 0.005, not 0.002.
+    seedListing("atom", [
+      { capability: "web_search", unit_cost: 0.003 },
+      { capability: "read_url", unit_cost: 0.002 },
+    ]);
+    expect(getListingUnitCost(relay.moteDb, "atom", "read_url")).toBe(0.002);
+    expect(getListingUnitCost(relay.moteDb, "atom", "web_search")).toBe(0.003);
+    // No capability ⇒ legacy sum (correct only for single-capability agents).
+    expect(getListingUnitCost(relay.moteDb, "atom")).toBeCloseTo(0.005, 6);
+  });
+
+  it("prices the WORKER's capability, never the delegator's — a $0.25 researcher paying a $0.003 atom is $0.003", () => {
+    // The bug: a P2P sub-hop was priced against the URL agent (the DELEGATOR),
+    // so a $0.25 researcher paying a $0.003 atom was checked against $0.25.
+    seedListing("researcher", [{ capability: "research", unit_cost: 0.25 }]);
+    seedListing("atom", [
+      { capability: "web_search", unit_cost: 0.003 },
+      { capability: "read_url", unit_cost: 0.002 },
+    ]);
+    // Pricing the WORKER (atom) for the pinned capability — NOT the delegator's $0.25.
+    expect(getListingUnitCost(relay.moteDb, "atom", "web_search")).toBe(0.003);
+    expect(getListingUnitCost(relay.moteDb, "researcher", "research")).toBe(0.25);
+  });
+
+  it("returns 0 for an unknown agent or a capability the agent does not list", () => {
+    seedListing("atom", [{ capability: "web_search", unit_cost: 0.003 }]);
+    expect(getListingUnitCost(relay.moteDb, "atom", "read_url")).toBe(0); // not listed
+    expect(getListingUnitCost(relay.moteDb, "ghost", "web_search")).toBe(0); // no listing
   });
 });

--- a/services/relay/src/tasks.ts
+++ b/services/relay/src/tasks.ts
@@ -203,7 +203,18 @@ export function extractMotebitIdFromPath(path: string): string | null {
   return match ? match[1]! : null;
 }
 
-function getListingUnitCost(moteDb: MotebitDatabase, agentId: string): number {
+/**
+ * The listing unit_cost an agent charges. When `capability` is given, price THAT
+ * capability (a delegation is for one capability); otherwise sum all capabilities
+ * (legacy behavior, correct only for single-capability agents). Summing a
+ * multi-capability agent — a web-search+read-url atom — over-charges a
+ * single-capability hop, so the P2P sub-hop path always passes the capability.
+ */
+export function getListingUnitCost(
+  moteDb: MotebitDatabase,
+  agentId: string,
+  capability?: string,
+): number {
   const row = moteDb.db
     .prepare(
       "SELECT pricing FROM relay_service_listings WHERE motebit_id = ? ORDER BY updated_at DESC LIMIT 1",
@@ -212,6 +223,9 @@ function getListingUnitCost(moteDb: MotebitDatabase, agentId: string): number {
   if (!row) return 0;
   try {
     const pricing = JSON.parse(row.pricing) as CapabilityPrice[];
+    if (capability != null) {
+      return pricing.find((p) => p.capability === capability)?.unit_cost ?? 0;
+    }
     return pricing.reduce((sum, p) => sum + (p.unit_cost ?? 0), 0);
   } catch {
     return 0;
@@ -1973,10 +1987,25 @@ export async function registerTaskRoutes(deps: TasksDeps): Promise<void> {
     const submittedBy = callerMotebitId ?? body.submitted_by;
 
     // Snapshot the listing price at submission time so the settlement audit
-    // matches what x402 actually charged. If the agent updates pricing between
-    // submission and receipt delivery, the snapshot ensures consistency.
+    // matches what the delegator actually paid. Price against the WORKER, not
+    // the URL agent: a P2P proof submission carries `target_agent` (the worker)
+    // and POSTs to the DELEGATOR's own endpoint, so `motebitId` (the URL) is the
+    // delegator here — pricing by it would validate the hop against the
+    // delegator's own listing (e.g. a $0.25 researcher paying a $0.003 atom
+    // would be checked against $0.25). And price the SPECIFIC capability the
+    // delegation pins, not the sum of the worker's listings. A non-P2P task has
+    // no `target_agent` and prices the URL agent (the worker) as before.
     // unit_cost is in dollars from the listing JSON. Convert to micro-units for accounting.
-    const unitCostAtSubmission = getListingUnitCost(moteDb, motebitId);
+    const isP2pProofSubmission =
+      typeof body.target_agent === "string" && body.target_agent.length > 0;
+    const pricingAgent = isP2pProofSubmission ? (body.target_agent as string) : motebitId;
+    const pricingCapability =
+      isP2pProofSubmission &&
+      Array.isArray(body.required_capabilities) &&
+      body.required_capabilities.length === 1
+        ? String(body.required_capabilities[0])
+        : undefined;
+    const unitCostAtSubmission = getListingUnitCost(moteDb, pricingAgent, pricingCapability);
     const priceSnapshot =
       unitCostAtSubmission > 0
         ? toMicro(computeGrossAmount(unitCostAtSubmission, platformFeeRate)) // gross in micro-units
@@ -2144,7 +2173,10 @@ export async function registerTaskRoutes(deps: TasksDeps): Promise<void> {
         if (unitCostMicro != null && proof.amount_micro !== unitCostMicro) {
           throw new TaskError(
             "TASK_P2P_AMOUNT_MISMATCH",
-            `Payment amount ${proof.amount_micro} does not match expected ${priceSnapshot}`,
+            // Report the NET worker-leg amount the check actually compares against
+            // (`unitCostMicro`), not the gross `priceSnapshot` — the earlier
+            // message showed the gross and misled the diagnosis.
+            `Payment worker-leg amount ${proof.amount_micro} does not match expected ${unitCostMicro} for capability "${pricingCapability ?? "?"}"`,
             400,
           );
         }

--- a/services/research/src/__tests__/research.test.ts
+++ b/services/research/src/__tests__/research.test.ts
@@ -221,6 +221,50 @@ describe("research — cryptographic citation chain (via mcp-client)", () => {
     expect(ws.calls).toHaveLength(0);
   });
 
+  it("Inc 3: UNPINNED — a priced atom is still paid, WITHOUT a target (the runtime ranks the market)", async () => {
+    const paidReceipt = makeReceipt({
+      task_id: "paid-search-2",
+      motebit_id: "ranked-agent",
+      result: JSON.stringify([{ title: "R", url: "https://a.example.com" }]),
+      signature: "sig-paid-2",
+    });
+    const ws = new StubAtomAdapter([]);
+    const ru = new StubAtomAdapter([]);
+    const paidCalls: Array<{ capability: string; targetWorkerId?: string }> = [];
+
+    mockCreate
+      .mockResolvedValueOnce({
+        content: [
+          { type: "tool_use", id: "tu-1", name: "motebit_web_search", input: { query: "q" } },
+        ],
+      })
+      .mockResolvedValueOnce({ content: [{ type: "text", text: "Synthesized." }] });
+
+    const result = await research("question", {
+      ...baseConfig,
+      // NO webSearchTargetId — unpinned: the paid seam is still attempted, and the
+      // runtime's first-person ranker chooses among discovered providers.
+      adapterFactory: makeFactory(
+        new Map([
+          ["web-search", ws],
+          ["read-url", ru],
+        ]),
+      ),
+      paidSubDelegate: async (p) => {
+        paidCalls.push({ capability: p.capability, targetWorkerId: p.targetWorkerId });
+        return { ok: true, receipt: paidReceipt };
+      },
+    });
+
+    expect(result.delegation_receipts).toHaveLength(1);
+    expect(result.delegation_receipts[0]!.signature).toBe("sig-paid-2");
+    // The paid seam ran with NO pinned target — the market ranks.
+    expect(paidCalls).toHaveLength(1);
+    expect(paidCalls[0]!.capability).toBe("web_search");
+    expect(paidCalls[0]!.targetWorkerId).toBeUndefined();
+    expect(ws.calls).toHaveLength(0);
+  });
+
   it("Inc 2b: an unpriced atom (worker_not_payable) falls back to the direct MCP call", async () => {
     const directReceipt = makeReceipt({
       task_id: "direct-1",

--- a/services/research/src/research.ts
+++ b/services/research/src/research.ts
@@ -387,12 +387,18 @@ export async function research(question: string, config: ResearchConfig): Promis
       // log which lane fires (paid P2P vs free direct MCP) and, on fallback,
       // the exact not-payable code. Same "make the silent decision loud"
       // discipline as the relay's mcp-forward logging.
-      if (config.paidSubDelegate != null && targetId != null) {
-        console.log(`[research] sub-hop: attempting P2P cap=${capabilityHint} target=${targetId}`);
+      if (config.paidSubDelegate != null) {
+        // Attempt paid P2P for any PRICED capability — pinned to `targetId` when
+        // one is configured, otherwise UNPINNED so the runtime's first-person
+        // ranker chooses among the discovered providers (the market). A
+        // not-payable code still falls through to direct MCP below.
+        console.log(
+          `[research] sub-hop: attempting P2P cap=${capabilityHint}${targetId ? ` target=${targetId}` : " (ranked)"}`,
+        );
         const paid = await config.paidSubDelegate({
           capability: capabilityHint,
           prompt,
-          targetWorkerId: targetId,
+          ...(targetId != null ? { targetWorkerId: targetId } : {}),
         });
         if (paid.ok) {
           if (paid.receipt == null) {
@@ -428,7 +434,7 @@ export async function research(question: string, config: ResearchConfig): Promis
           );
         }
       } else {
-        // No paid seam (money env unset) or no pinned target → free direct MCP.
+        // No paid seam (money env unset) → free direct MCP.
         console.log(`[research] sub-hop: DIRECT (no paid seam) cap=${capabilityHint}`);
       }
 


### PR DESCRIPTION
Activating the `read_url` market (two providers, `read_url` unpinned) surfaced three real defects a single-provider demo would have hidden — the "instrument, don't guess" payoff. With all three fixed, **a newcomer earned its first job, live onchain.**

## The proof

`6ea37cc3` (the dedicated read-url atom) had **never been paid** — research always pinned `read_url` to `5054798e`. Unpinned + fixed:
```
sub-hop: attempting P2P cap=read_url (ranked)
routing.worker_selected {"selected":"6ea37cc3…","candidates":2,"strength":1,"explored":false,"quality":0.908}
sub-hop: PAID P2P cap=read_url
```
Onchain: **`6ea37cc3` 0.0 → 0.002 USDC** (first-ever payment); `5054798e` +0.003 (web_search hop settles too). Conformance **green** (promotion clock safe). `explored:false` — the newcomer won on *merit* (cheaper, once unpinned), not a lucky draw.

## The three defects (all masked until the paid path reached submit-validation)

1. **Relay priced the sub-hop against the DELEGATOR, not the worker.** A P2P sub-hop POSTs to `/agent/{delegator}/task` carrying `target_agent` (the worker); the relay resolved the worker via `target_agent` but *priced* via the URL agent (`motebitId` = delegator) — so a \$0.25 researcher paying a \$0.003 atom was checked against \$0.25 → `TASK_P2P_AMOUNT_MISMATCH`. Fix: price against `target_agent`. Existing tests missed it (they POST to `/agent/{worker}/task` where URL == `target_agent`; production POSTs to the delegator). Fix is robust to both.
2. **`getListingUnitCost` summed all capabilities** — a web-search+read-url atom priced at \$0.005, not the requested capability's \$0.003. Made capability-aware; the sub-hop passes the pinned capability. (3 unit tests; `getListingUnitCost` exported.)
3. **Research gated the paid path on `targetId != null`** — so *unpinning* a capability dropped it to free direct-MCP instead of ranking the market. Now attempts paid P2P for any priced capability, pinning only when configured; unpinned ⇒ the first-person ranker chooses. (unpinned test added.)

## Also

- The `TASK_P2P_AMOUNT_MISMATCH` message reported the **gross** `priceSnapshot` while the check compares the **net** `unitCostMicro` — which sent the first diagnosis chasing the treasury key. Now reports the net amount + capability.
- Operator-side `delegation.paid_failed` log carries the failure **message** (the caller still gets a bare code — refusal honesty; a meter denial still redacts its overage) — that's how #1 was found.

relay p2p-settlement 21 + research 41 green; typecheck clean across runtime/relay/research. Deployed to staging and validated live (above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)