### PR TITLE
fix(wallet-solana): retry P2P broadcast with a fresh blockhash on expiry (unblock the promotion clock)

### DIFF
--- a/packages/wallet-solana/src/__tests__/web3js-adapter.test.ts
+++ b/packages/wallet-solana/src/__tests__/web3js-adapter.test.ts
@@ -559,6 +559,83 @@ describe("Web3JsRpcAdapter.sendUsdc", () => {
     expect(result.signature).toBe("sigErr");
     expect(result.slot).toBe(99);
   });
+
+  // ── Blockhash-expiry retry (the devnet flake that resets the promotion clock) ──
+  it("retries with a FRESH blockhash on 'block height exceeded' and succeeds", async () => {
+    const adapter = makeAdapterForTx();
+    const conn = adapter.getConnection();
+    getAccountMock
+      .mockResolvedValueOnce({ amount: 10_000_000n }) // balance
+      .mockResolvedValueOnce({ amount: 0n }); // dest exists
+    const blockhashSpy = vi.spyOn(conn, "getLatestBlockhash").mockResolvedValue({
+      blockhash: validBlockhash(),
+      lastValidBlockHeight: 100,
+    });
+    const sendSpy = vi
+      .spyOn(conn, "sendRawTransaction")
+      .mockResolvedValueOnce("sigExpired")
+      .mockResolvedValue("sigFresh");
+    vi.spyOn(conn, "confirmTransaction")
+      // First attempt: the blockhash expired before confirmation (the flake).
+      .mockRejectedValueOnce(new Error("Signature sigExpired has expired: block height exceeded."))
+      // Retry with a fresh blockhash lands.
+      .mockResolvedValue({ context: { slot: 51 }, value: { err: null } });
+
+    const result = await adapter.sendUsdc({
+      toAddress: validBase58Address(),
+      microAmount: 1_000_000n,
+    });
+    // The retry settled — and on the fresh signature, never the expired one.
+    expect(result).toEqual({ signature: "sigFresh", slot: 51, confirmed: true });
+    // A FRESH blockhash was fetched for the retry (not a re-send of the dead tx).
+    expect(blockhashSpy).toHaveBeenCalledTimes(2);
+    expect(sendSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after BROADCAST_MAX_ATTEMPTS when the expiry never clears", async () => {
+    const adapter = makeAdapterForTx();
+    const conn = adapter.getConnection();
+    getAccountMock
+      .mockResolvedValueOnce({ amount: 10_000_000n })
+      .mockResolvedValueOnce({ amount: 0n });
+    const blockhashSpy = vi.spyOn(conn, "getLatestBlockhash").mockResolvedValue({
+      blockhash: validBlockhash(),
+      lastValidBlockHeight: 100,
+    });
+    vi.spyOn(conn, "sendRawTransaction").mockResolvedValue("sig");
+    const confirmSpy = vi
+      .spyOn(conn, "confirmTransaction")
+      .mockRejectedValue(new Error("Signature sig has expired: block height exceeded."));
+
+    await expect(
+      adapter.sendUsdc({ toAddress: validBase58Address(), microAmount: 1n }),
+    ).rejects.toThrow("block height exceeded");
+    // Bounded: exactly 3 attempts, no infinite loop against a wedged cluster.
+    expect(blockhashSpy).toHaveBeenCalledTimes(3);
+    expect(confirmSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("does NOT retry a non-expiry error — a confirmation timeout may still land (no double-spend)", async () => {
+    const adapter = makeAdapterForTx();
+    const conn = adapter.getConnection();
+    getAccountMock
+      .mockResolvedValueOnce({ amount: 10_000_000n })
+      .mockResolvedValueOnce({ amount: 0n });
+    const blockhashSpy = vi.spyOn(conn, "getLatestBlockhash").mockResolvedValue({
+      blockhash: validBlockhash(),
+      lastValidBlockHeight: 100,
+    });
+    vi.spyOn(conn, "sendRawTransaction").mockResolvedValue("sig");
+    vi.spyOn(conn, "confirmTransaction").mockRejectedValue(
+      new Error("Transaction was not confirmed in 30.00 seconds"),
+    );
+
+    await expect(
+      adapter.sendUsdc({ toAddress: validBase58Address(), microAmount: 1n }),
+    ).rejects.toThrow("not confirmed");
+    // Single-shot: a timeout is NOT the known-safe retry (the tx might land).
+    expect(blockhashSpy).toHaveBeenCalledTimes(1);
+  });
 });
 
 // ── sendUsdcBatch ─────────────────────────────────────────────────────────
@@ -662,6 +739,36 @@ describe("Web3JsRpcAdapter.sendUsdcBatch", () => {
     expect(results[8]!.ok).toBe(false);
     expect(results[8]!.reason).toBe("prior chunk failed");
     expect(results[8]!.signature).toBeNull();
+  });
+
+  it("the atomic multi-output P2P tx retries with a fresh blockhash on expiry (the conformance flake)", async () => {
+    // This is exactly the failure that reset the promotion clock: the 2-leg
+    // (worker + treasury) atomic P2P payment expired before confirmation. It must
+    // rebuild with a fresh blockhash and settle both legs in ONE new tx.
+    const adapter = makeAdapterForTx();
+    const conn = adapter.getConnection();
+    getAccountMock.mockImplementation(async () => ({ amount: 10_000_000n }));
+    const blockhashSpy = vi.spyOn(conn, "getLatestBlockhash").mockResolvedValue({
+      blockhash: validBlockhash(),
+      lastValidBlockHeight: 200,
+    });
+    vi.spyOn(conn, "sendRawTransaction")
+      .mockResolvedValueOnce("sigExpired")
+      .mockResolvedValue("sigFresh");
+    vi.spyOn(conn, "confirmTransaction")
+      .mockRejectedValueOnce(new Error("Signature sigExpired has expired: block height exceeded."))
+      .mockResolvedValue({ context: { slot: 210 }, value: { err: null } });
+
+    const results = await adapter.sendUsdcBatch([
+      { toAddress: validBase58Address(), microAmount: 3000n }, // worker leg
+      { toAddress: validBase58Address(), microAmount: 158n }, // treasury fee leg
+    ]);
+    // Both legs settled atomically on the fresh signature.
+    expect(results).toEqual([
+      { ok: true, signature: "sigFresh", slot: 210, reason: null },
+      { ok: true, signature: "sigFresh", slot: 210, reason: null },
+    ]);
+    expect(blockhashSpy).toHaveBeenCalledTimes(2);
   });
 
   it("aborts the batch when an invalid mid-batch address is encountered", async () => {

--- a/packages/wallet-solana/src/web3js-adapter.ts
+++ b/packages/wallet-solana/src/web3js-adapter.ts
@@ -18,7 +18,14 @@
  * different domain — both are Ed25519 public keys.
  */
 
-import { Connection, Keypair, PublicKey, Transaction, type Commitment } from "@solana/web3.js";
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Transaction,
+  type TransactionInstruction,
+  type Commitment,
+} from "@solana/web3.js";
 import { base58Encode } from "@motebit/protocol";
 
 /**
@@ -75,6 +82,33 @@ import {
  * and derive this from a small registry.
  */
 const ASSET_NAME_USDC = "USDC";
+
+/**
+ * Broadcast attempts before giving up. A Solana transaction is signed over a
+ * recent blockhash that expires after ~151 blocks (~60-90s); on a slow or
+ * congested cluster (devnet especially) the confirmation can miss that window,
+ * surfacing as a `TransactionExpiredBlockheightExceededError` ("... has expired:
+ * block height exceeded"). Bounded so a genuinely-down RPC still fails fast.
+ */
+const BROADCAST_MAX_ATTEMPTS = 3;
+
+/**
+ * True only for the AUTHORITATIVE permanent-expiry signal: the transaction's
+ * blockhash passed its `lastValidBlockHeight` without confirming, so it was NOT
+ * and can NEVER be included. That is the one broadcast failure known safe to
+ * retry — a rebuild with a fresh blockhash produces a NEW signature the expired
+ * one can never race, so there is no double-spend window.
+ *
+ * Deliberately NOT a generic "expired"/"timeout" match: a confirmation TIMEOUT
+ * ("was not confirmed in N seconds") means the transaction may still land, so
+ * re-broadcasting it WOULD risk a double-spend. Match the message string
+ * (web3.js's `TransactionExpiredBlockheightExceededError`) rather than
+ * `instanceof` to stay resilient across web3.js minor versions.
+ */
+function isBlockhashExpiry(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes("block height exceeded");
+}
 
 export interface Web3JsRpcAdapterConfig {
   rpcUrl: string;
@@ -186,8 +220,8 @@ export class Web3JsRpcAdapter implements SolanaRpcAdapter {
     const sourceAta = await getAssociatedTokenAddress(this.mint, this.keypair.publicKey);
     const destAta = await getAssociatedTokenAddress(this.mint, recipient);
 
-    // 4. Build the transaction. Auto-create destination ATA if missing.
-    const tx = new Transaction();
+    // 4. Build the instructions. Auto-create destination ATA if missing.
+    const instructions: TransactionInstruction[] = [];
 
     let destExists = false;
     try {
@@ -197,7 +231,7 @@ export class Web3JsRpcAdapter implements SolanaRpcAdapter {
       if (!(err instanceof TokenAccountNotFoundError)) throw err;
     }
     if (!destExists) {
-      tx.add(
+      instructions.push(
         createAssociatedTokenAccountInstruction(
           this.keypair.publicKey, // payer
           destAta,
@@ -207,30 +241,62 @@ export class Web3JsRpcAdapter implements SolanaRpcAdapter {
       );
     }
 
-    tx.add(createTransferInstruction(sourceAta, destAta, this.keypair.publicKey, args.microAmount));
-
-    // 5. Fetch a recent blockhash and sign.
-    const latest = await this.connection.getLatestBlockhash(this.commitment);
-    tx.recentBlockhash = latest.blockhash;
-    tx.feePayer = this.keypair.publicKey;
-    tx.sign(this.keypair);
-
-    // 6. Submit and wait for confirmation.
-    const signature = await this.connection.sendRawTransaction(tx.serialize());
-    const confirmation = await this.connection.confirmTransaction(
-      {
-        signature,
-        blockhash: latest.blockhash,
-        lastValidBlockHeight: latest.lastValidBlockHeight,
-      },
-      this.commitment,
+    instructions.push(
+      createTransferInstruction(sourceAta, destAta, this.keypair.publicKey, args.microAmount),
     );
 
-    return {
-      signature,
-      slot: confirmation.context.slot,
-      confirmed: confirmation.value.err === null,
-    };
+    // 5-6. Fetch a fresh blockhash, sign, submit, confirm — retrying with a new
+    // blockhash on the (safe) permanent-expiry flake. See signSendConfirm.
+    return this.signSendConfirm(instructions);
+  }
+
+  /**
+   * Build a transaction from `instructions`, sign it over a FRESH recent
+   * blockhash, broadcast, and await confirmation — retrying with a new blockhash
+   * on a `TransactionExpiredBlockheightExceededError` (the permanent-expiry
+   * flake). Each attempt rebuilds the transaction from the instructions so no
+   * stale blockhash/signature state carries over; the expired attempt can never
+   * land (`isBlockhashExpiry`), so the retry cannot double-spend. Any non-expiry
+   * error propagates immediately (conservative — only the known-safe failure is
+   * retried).
+   */
+  private async signSendConfirm(
+    instructions: readonly TransactionInstruction[],
+  ): Promise<SendUsdcResult> {
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= BROADCAST_MAX_ATTEMPTS; attempt++) {
+      try {
+        const tx = new Transaction();
+        for (const ix of instructions) tx.add(ix);
+        const latest = await this.connection.getLatestBlockhash(this.commitment);
+        tx.recentBlockhash = latest.blockhash;
+        tx.feePayer = this.keypair.publicKey;
+        tx.sign(this.keypair);
+
+        const signature = await this.connection.sendRawTransaction(tx.serialize());
+        const confirmation = await this.connection.confirmTransaction(
+          {
+            signature,
+            blockhash: latest.blockhash,
+            lastValidBlockHeight: latest.lastValidBlockHeight,
+          },
+          this.commitment,
+        );
+        return {
+          signature,
+          slot: confirmation.context.slot,
+          confirmed: confirmation.value.err === null,
+        };
+      } catch (err) {
+        lastErr = err;
+        // Retry ONLY the authoritative permanent-expiry, and only with attempts
+        // left. A fresh blockhash is the fix; the expired tx can never race it.
+        if (attempt < BROADCAST_MAX_ATTEMPTS && isBlockhashExpiry(err)) continue;
+        throw err;
+      }
+    }
+    // Unreachable: the loop returns on success or throws on the final attempt.
+    throw lastErr;
   }
 
   /**
@@ -275,7 +341,7 @@ export class Web3JsRpcAdapter implements SolanaRpcAdapter {
       }
 
       try {
-        const tx = new Transaction();
+        const instructions: TransactionInstruction[] = [];
         const sourceAta = await getAssociatedTokenAddress(this.mint, this.keypair.publicKey);
 
         for (let i = start; i < end; i++) {
@@ -296,7 +362,7 @@ export class Web3JsRpcAdapter implements SolanaRpcAdapter {
             if (!(err instanceof TokenAccountNotFoundError)) throw err;
           }
           if (!destExists) {
-            tx.add(
+            instructions.push(
               createAssociatedTokenAccountInstruction(
                 this.keypair.publicKey,
                 destAta,
@@ -305,36 +371,23 @@ export class Web3JsRpcAdapter implements SolanaRpcAdapter {
               ),
             );
           }
-          tx.add(
+          instructions.push(
             createTransferInstruction(sourceAta, destAta, this.keypair.publicKey, item.microAmount),
           );
         }
 
-        const latest = await this.connection.getLatestBlockhash(this.commitment);
-        tx.recentBlockhash = latest.blockhash;
-        tx.feePayer = this.keypair.publicKey;
-        tx.sign(this.keypair);
-
-        const signature = await this.connection.sendRawTransaction(tx.serialize());
-        const confirmation = await this.connection.confirmTransaction(
-          {
-            signature,
-            blockhash: latest.blockhash,
-            lastValidBlockHeight: latest.lastValidBlockHeight,
-          },
-          this.commitment,
-        );
-
-        const ok = confirmation.value.err === null;
+        // Same fresh-blockhash retry as the single-leg path — the atomic P2P
+        // multi-output tx is exactly what the devnet expiry flake was killing.
+        const { signature, slot, confirmed } = await this.signSendConfirm(instructions);
         for (let i = start; i < end; i++) {
           results[i] = {
-            ok,
+            ok: confirmed,
             signature,
-            slot: confirmation.context.slot,
-            reason: ok ? null : "tx failed",
+            slot,
+            reason: confirmed ? null : "tx failed",
           };
         }
-        if (!ok) aborted = true;
+        if (!confirmed) aborted = true;
       } catch (err) {
         const reason = err instanceof Error ? err.message : String(err);
         for (let i = start; i < end; i++) {


### PR DESCRIPTION
## The problem

The paid archetype conformance probe **resets the staging→prod promotion clock** whenever devnet is slow. A Solana transaction is signed over a recent blockhash that expires after ~151 blocks (~60-90s); on a congested cluster the confirmation misses that window, surfacing as:

```
payment_broadcast_failed: ... Signature <sig> has expired: block height exceeded
```

Observed live on **2026-07-16** — the auditor *and* clerk legs both failed on it, zeroing the 5-consecutive-scheduled-green count that gates production promotion.

The broadcast was single-shot: `sendUsdc` and the atomic multi-output `sendUsdcBatch` (the 2-3-leg P2P worker+treasury tx) each did `getLatestBlockhash → sign → send → confirm` exactly once, with no retry.

## The fix

A bounded (`BROADCAST_MAX_ATTEMPTS = 3`) retry that rebuilds the transaction over a **fresh blockhash** — on, and *only* on, the authoritative permanent-expiry signal. Both send paths share one `signSendConfirm` helper.

### Why it's safe (no double-spend)

`block height exceeded` means the network passed the blockhash's `lastValidBlockHeight` without confirming, so that transaction is **permanently un-includable**. Re-signing over a fresh blockhash yields a *new* signature the expired one can never race — only the retry can settle.

Deliberately **not** retried: a confirmation **timeout** (`not confirmed in N seconds`), which is *not* authoritative — the tx may still land, so re-broadcasting it would risk a double-spend. That path stays single-shot.

## Tests

- single-leg: expiry → fresh-blockhash → success (asserts a **second** blockhash fetch, and settlement on the fresh sig — never the expired one)
- bounded give-up after 3 attempts (no infinite loop against a wedged cluster)
- a timeout is single-shot (no retry — the double-spend guard)
- the **atomic 2-leg P2P path** retries and settles both legs in one fresh tx (the exact conformance flake)

wallet-solana 172 tests, coverage green; all 132 gates pass; pre-push gauntlet passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)