### PR TITLE
fix(memory): supersede is invalidation-with-provenance — never tombstone; unify current-beliefs everywhere

### DIFF
--- a/packages/memory-graph/src/__tests__/bitemporal.test.ts
+++ b/packages/memory-graph/src/__tests__/bitemporal.test.ts
@@ -195,6 +195,48 @@ describe("supersession is invalidation-with-provenance + emits validity on the w
     const consolidated = captured.find((e) => e.event_type === EventType.MemoryConsolidated);
     expect(consolidated?.payload.superseded_valid_until).toBe(aAfter!.valid_until);
   });
+
+  it("the rewrite_memory TOOL path is invalidation-with-provenance too — as-of recall still reconstructs it", async () => {
+    // The untested divergence: `supersedeMemoryByNodeId` (the user-facing tool)
+    // used to TOMBSTONE the old node, so as-of recall could not reconstruct a
+    // tool-revised belief — while the consolidation UPDATE path (above) kept it
+    // live. This pins that both paths now behave identically.
+    const storage = new InMemoryMemoryStorage();
+    const eventStore = new EventStore(new InMemoryEventStore());
+    const graph = new MemoryGraph(storage, eventStore, "m", undefined, fastEmbed);
+
+    const a = await graph.formMemory(
+      {
+        content: "user lives in NYC",
+        source: "user_stated",
+        confidence: 0.9,
+        sensitivity: SensitivityLevel.None,
+        memory_type: MemoryType.Semantic,
+      },
+      EMB,
+    );
+    const newId = await graph.supersedeMemoryByNodeId(a.node_id, "user lives in SF", "user moved");
+
+    // Invalidated but PRESERVED — matches the consolidation path, not tombstoned.
+    const aAfter = await graph.getNode(a.node_id);
+    expect(aAfter!.tombstoned).toBe(false);
+    expect(typeof aAfter!.valid_until).toBe("number");
+
+    // History-inclusive recall STILL reaches the superseded belief. A tombstoned
+    // node is dropped by queryNodes' default filter, so this is the assertion the
+    // old behavior silently failed.
+    const withHistory = await graph.recallRelevant(EMB, {
+      includeExpired: true,
+      expandEdges: false,
+    });
+    expect(withHistory.map((n) => n.node_id)).toContain(a.node_id);
+
+    // Current recall shows only the new belief; the superseded one has expired.
+    const current = await graph.recallRelevant(EMB, { expandEdges: false });
+    const currentIds = current.map((n) => n.node_id);
+    expect(currentIds).toContain(newId);
+    expect(currentIds).not.toContain(a.node_id);
+  });
 });
 
 describe("supersede intervals abut EXACTLY under clock jitter (no temporal hole or overlap)", () => {

--- a/packages/memory-graph/src/__tests__/curiosity.test.ts
+++ b/packages/memory-graph/src/__tests__/curiosity.test.ts
@@ -66,6 +66,23 @@ describe("findCuriosityTargets", () => {
     expect(results[0]!.curiosityScore).toBeGreaterThan(0);
   });
 
+  it("does NOT get curious about an invalidated (superseded) belief — it's settled, not open", () => {
+    const now = Date.now();
+    // Same decaying shape that WOULD be a curiosity target, but superseded
+    // (valid_until in the past, not tombstoned). A revised belief is settled
+    // history — re-investigating it is wasted proactive work.
+    const superseded = makeNode({
+      content: "fact the user already corrected",
+      confidence: 0.8,
+      created_at: now - 25 * DAY,
+      last_accessed: now - 25 * DAY,
+      half_life: HALF_LIFE,
+      valid_from: now - 25 * DAY,
+      valid_until: now - DAY,
+    });
+    expect(findCuriosityTargets([superseded])).toEqual([]);
+  });
+
   it("ranks by curiosityScore descending", () => {
     const now = Date.now();
     // Node A: older, more decayed

--- a/packages/memory-graph/src/__tests__/memory-index.test.ts
+++ b/packages/memory-graph/src/__tests__/memory-index.test.ts
@@ -65,6 +65,33 @@ describe("rankIndexEntries — scoring and ordering", () => {
     expect(entries.map((e) => e.node.node_id)).toEqual(["live-1"]);
   });
 
+  it("excludes invalidated (superseded) nodes — the index shows CURRENT beliefs only", () => {
+    // A belief superseded by either the consolidation UPDATE path or the
+    // rewrite_memory tool has `valid_until` set but is NOT tombstoned. It must
+    // not resurface in the always-loaded index, or the agent sees a stale belief
+    // every turn. Filtering by tombstone alone (the old behavior) missed this.
+    const current = makeNode({ node_id: "current-1" as NodeId, content: "lives in SF" });
+    const superseded = makeNode({
+      node_id: "superseded-1" as NodeId,
+      content: "lived in NYC",
+      valid_from: NOW - 100_000,
+      valid_until: NOW - 10_000, // invalidated 10s ago, still live (not tombstoned)
+    });
+
+    const entries = rankIndexEntries([current, superseded], [], { nowMs: NOW });
+    expect(entries.map((e) => e.node.node_id)).toEqual(["current-1"]);
+  });
+
+  it("keeps a still-valid node whose interval is open (valid_until null)", () => {
+    const openValid = makeNode({
+      node_id: "open-1" as NodeId,
+      valid_from: NOW - 100_000,
+      valid_until: null,
+    });
+    const entries = rankIndexEntries([openValid], [], { nowMs: NOW });
+    expect(entries.map((e) => e.node.node_id)).toEqual(["open-1"]);
+  });
+
   it("classifies certainty by decayed confidence", () => {
     const absolute = makeNode({ node_id: "a-1" as NodeId, confidence: 0.98 });
     const confident = makeNode({ node_id: "c-1" as NodeId, confidence: 0.8 });

--- a/packages/memory-graph/src/__tests__/notability.test.ts
+++ b/packages/memory-graph/src/__tests__/notability.test.ts
@@ -122,6 +122,19 @@ describe("rankNotableMemories", () => {
     expect(rankNotableMemories([a, b, c], edges, { nowMs: NOW })).toEqual([]);
   });
 
+  it("excludes an invalidated (superseded) node — notable is a current-beliefs claim", () => {
+    // A high-confidence isolated belief would normally rank (phantom axis), but
+    // once superseded (valid_until in the past, not tombstoned) it is settled
+    // history and must not resurface as notable.
+    const superseded = makeNode({
+      content: "used to believe this strongly",
+      confidence: 0.95,
+      valid_from: NOW - 100_000,
+      valid_until: NOW - 10_000,
+    });
+    expect(rankNotableMemories([superseded], [], { nowMs: NOW })).toEqual([]);
+  });
+
   it("ranks phantom certainties above connected nodes", () => {
     const isolated = makeNode({ content: "isolated belief", confidence: 0.95 });
     const connected1 = makeNode({ content: "connected 1" });

--- a/packages/memory-graph/src/__tests__/trinity-integration.test.ts
+++ b/packages/memory-graph/src/__tests__/trinity-integration.test.ts
@@ -241,14 +241,14 @@ describe("Memory Trinity — end-to-end composition", () => {
     expect(notFound).toEqual({ kind: "not_found" });
   });
 
-  it("superseding a non-existent or tombstoned node throws a usable error", async () => {
+  it("superseding a non-existent or already-superseded node throws a usable error", async () => {
     await expect(
       graph.supersedeMemoryByNodeId("not-a-real-node", "whatever", "testing"),
     ).rejects.toThrow(/No memory node/);
 
     const node = await graph.formMemory(
       {
-        content: "Will tombstone this",
+        content: "Will supersede this",
         confidence: 0.8,
         sensitivity: SensitivityLevel.None,
         source: "user_stated",
@@ -256,12 +256,17 @@ describe("Memory Trinity — end-to-end composition", () => {
       [0.1, 0.1, 0.1],
     );
 
-    // Supersede once — node gets tombstoned.
+    // Supersede once — the old node is INVALIDATED (valid_until set) but kept
+    // live, never tombstoned (history is preserved for as-of recall).
     await graph.supersedeMemoryByNodeId(node.node_id, "Replacement", "first");
+    const superseded = await graph.getNode(node.node_id);
+    expect(superseded!.tombstoned).toBe(false);
+    expect(superseded!.valid_until).not.toBeNull();
 
-    // Supersede again against the now-tombstoned node should fail cleanly.
+    // Superseding the now-invalidated node again should fail cleanly (you rewrite
+    // the CURRENT belief, not an already-closed interval).
     await expect(
       graph.supersedeMemoryByNodeId(node.node_id, "Second replacement", "second"),
-    ).rejects.toThrow(/already tombstoned/);
+    ).rejects.toThrow(/already superseded/);
   });
 });

--- a/packages/memory-graph/src/index.ts
+++ b/packages/memory-graph/src/index.ts
@@ -157,6 +157,10 @@ export function findCuriosityTargets(
 
   for (const node of nodes) {
     if (node.tombstoned || node.pinned) continue;
+    // Don't get curious about a belief we've already revised: an invalidated
+    // (superseded) node is settled history, not an open question. Same
+    // current-beliefs invariant as the index / notability / retrieval lenses.
+    if (node.valid_until != null && node.valid_until <= now) continue;
     if (node.confidence < minOriginalConfidence) continue;
 
     const elapsed = now - node.created_at;
@@ -1308,14 +1312,24 @@ export class MemoryGraph {
    * consolidation LLM classifier because the agent has already
    * decided the rewrite is correct. Preserves the original
    * `memory_formed` event (append-only; §3.1) — the old node is
-   * tombstoned + marked `valid_until` now, a fresh node carries the
-   * new content, a Supersedes edge links them, and a
-   * `memory_consolidated` event with `action: "supersede"` is
-   * emitted for the sync layer.
+   * INVALIDATED (`valid_until` set to now) but kept LIVE, a fresh node
+   * carries the new content, a Supersedes edge links them, and a
+   * `memory_consolidated` event with `action: "supersede"` is emitted
+   * for the sync layer.
    *
-   * Returns the new node id. Throws when `oldNodeId` is unknown or
-   * already tombstoned — the tool handler turns that into a
-   * user-surface error.
+   * Invalidation-with-provenance, never destruction: the superseded
+   * node is NOT tombstoned, so as-of-`T` recall can still reconstruct
+   * what was believed inside `[valid_from, valid_until)` (doctrine
+   * `memory-architecture.md` invariant #2 — "history is preserved").
+   * This makes the one supersede mechanism identical to the
+   * consolidation `UPDATE` path, and matches what syncing peers apply
+   * (they close the interval via `superseded_valid_until`, they do not
+   * tombstone) — so a tool-superseded node no longer ends up tombstoned
+   * locally yet live on every peer.
+   *
+   * Returns the new node id. Throws when `oldNodeId` is unknown, already
+   * superseded (`valid_until` set), or tombstoned (deleted) — the tool
+   * handler turns that into a user-surface error.
    */
   async supersedeMemoryByNodeId(
     oldNodeId: string,
@@ -1325,6 +1339,11 @@ export class MemoryGraph {
     const oldNode = await this.storage.getNode(oldNodeId);
     if (!oldNode) throw new Error(`No memory node with id ${oldNodeId}`);
     if (oldNode.tombstoned) throw new Error(`Memory ${oldNodeId} is already tombstoned`);
+    // Guard against re-superseding an already-superseded belief — that would
+    // re-close an already-closed interval and orphan the intermediate node.
+    // (The tombstone flag used to cover this incidentally; now that supersession
+    // keeps the node live, guard on the interval directly.)
+    if (oldNode.valid_until != null) throw new Error(`Memory ${oldNodeId} is already superseded`);
 
     // Embed the new content so retrieval works against the replacement
     // immediately. Sensitivity + memory_type inherit from the old node —
@@ -1354,8 +1373,12 @@ export class MemoryGraph {
       now,
     );
 
+    // Invalidate the old belief WITHOUT tombstoning it: `valid_until` alone
+    // removes it from current recall (every lens filters `valid_until > now`),
+    // while keeping the node live so as-of recall inside its interval — and the
+    // Supersedes edge below — can still reach it. Tombstoning here (the prior
+    // bug) made it invisible to `queryNodes` and so silently unreconstructable.
     oldNode.valid_until = now;
-    oldNode.tombstoned = true;
     await this.storage.saveNode(oldNode);
 
     await this.link(newNode.node_id, oldNodeId, RT.Supersedes);

--- a/packages/memory-graph/src/memory-index.ts
+++ b/packages/memory-graph/src/memory-index.ts
@@ -32,6 +32,7 @@
 import type { MemoryNode, MemoryEdge } from "@motebit/sdk";
 import { MEMORY_SOURCE_MARKERS, MEMORY_SOURCE_MARKER_UNKNOWN } from "@motebit/sdk";
 import { computeDecayedConfidence } from "./index.js";
+import { isValidAt } from "./retrieval.js";
 
 /**
  * Target byte budget for the rendered index. Defaults to 2 KB — small
@@ -121,7 +122,14 @@ export function rankIndexEntries(
 ): MemoryIndexEntry[] {
   const o = resolveOptions(options);
 
-  const liveNodes = nodes.filter((n) => !n.tombstoned);
+  // The index is the agent's always-loaded view of what it CURRENTLY believes,
+  // so it must exclude both deleted nodes (tombstoned) AND invalidated ones —
+  // a belief superseded by either the consolidation UPDATE path or the
+  // `rewrite_memory` tool has `valid_until` set and must not resurface in the
+  // system prompt. Filter by the same `isValidAt` predicate every retrieval lens
+  // uses, never by the tombstone flag alone (which misses live-but-superseded
+  // nodes and once masked this leak only because the tool path over-tombstoned).
+  const liveNodes = nodes.filter((n) => !n.tombstoned && isValidAt(n, o.nowMs));
   const edgeCounts = new Map<string, number>();
   for (const edge of edges) {
     edgeCounts.set(edge.source_id, (edgeCounts.get(edge.source_id) ?? 0) + 1);

--- a/packages/memory-graph/src/notability.ts
+++ b/packages/memory-graph/src/notability.ts
@@ -151,7 +151,13 @@ export function rankNotableMemories(
   options?: NotabilityOptions,
 ): NotableMemory[] {
   const o = resolve(options);
-  const live = nodes.filter((n) => !n.tombstoned);
+  // "Notable" is a claim about what the agent CURRENTLY holds, so exclude both
+  // deleted (tombstoned) and invalidated (superseded, `valid_until` passed)
+  // beliefs — a fact the user revised must not resurface as notable. Same
+  // current-beliefs invariant the memory index and retrieval lenses enforce.
+  const live = nodes.filter(
+    (n) => !n.tombstoned && (n.valid_until == null || n.valid_until > o.nowMs),
+  );
   const liveIds = new Set(live.map((n) => n.node_id));
   const nodeMap = new Map(live.map((n) => [n.node_id, n]));
 


### PR DESCRIPTION
## The bug

Sovereign memory is **bi-temporal**: revising a belief sets `valid_until` on the old node and keeps it *live*, so as-of-`T` recall can still answer "what did I believe then" (doctrine `memory-architecture.md` invariant #2 — *"history is preserved… never tombstoning of the old node"*). The internal consolidation `UPDATE` path does this correctly.

The **user-facing `rewrite_memory` tool** (`supersedeMemoryByNodeId`) did **not** — it set `valid_until` *and* tombstoned the old node. That's incoherent (records "valid until T" then makes it permanently unseeable), and it had three consequences:

1. **As-of recall could never reconstruct a belief the user revised** — tombstoned nodes are dropped by `queryNodes`' default filter, so the headline bi-temporal capability silently failed for exactly the human-facing path.
2. It **violated the stated doctrine invariant #2**.
3. It **desynced devices** — peers apply a supersede via `superseded_valid_until` (interval close), never a tombstone, so a tool-superseded node was tombstoned locally yet **live on every peer**.

**Fix:** drop the tombstone. `valid_until` alone invalidates (every recall lens filters it out of *current* recall) while preserving the node and its `Supersedes` edge. The tombstone had also been the incidental "can't supersede twice" guard, so I added an explicit `valid_until != null` → *"already superseded"* guard.

## Sibling sweep

The tombstone was doubling as "not a current belief," so several surfaces conflated **deletion** with **invalidity** — and this **pre-dated** the tool bug, since the consolidation path never tombstoned either:

- **`rankIndexEntries`** — the always-loaded Layer-1 memory index injected into **every system prompt** — filtered `!tombstoned` only, so a superseded belief resurfaced in the agent's context *every turn*. Now filters by the shared `isValidAt`.
- **`rankNotableMemories`** and **`findCuriosityTargets`** — "notable"/"curious" is a claim about *current* beliefs; a revised fact must not rank as notable or drive proactive re-investigation of settled history.

The code now matches the doctrine (which was already right); no doctrine change. `memory-graph` is private — no changeset.

## Tests

- Tool-path **as-of reconstruction** — the untested divergence: a rewritten belief stays reachable via `includeExpired`, absent from current recall, not tombstoned.
- Index / notability / curiosity each **exclude an invalidated-but-live node**.
- Updated the trinity supersede assertion to the corrected semantics.

267 memory-graph tests, coverage clean; runtime builds + memory tests green; all 132 gates pass; pre-push gauntlet passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)