### PR TITLE
feat(memory): include_history recall — every version of a belief, current vs superseded labelled

### DIFF
--- a/.changeset/memory-recall-include-history.md
+++ b/.changeset/memory-recall-include-history.md
@@ -1,0 +1,7 @@
+---
+"motebit": minor
+---
+
+History memory recall — the `recall_memories` tool gains an optional `include_history` flag to return every version of a belief at once (current and since-superseded), each labelled.
+
+Completes the bi-temporal recall surface alongside `as_of`. Where `as_of` gives a point-in-time snapshot, `include_history` returns all versions with a per-entry `[current]` / `[superseded <date>]` label so a revised belief can never be read as current fact; the two modes are mutually exclusive. Also corrects the `rewrite_memory` tool description: a superseded memory is no longer described as "tombstoned" — it is kept and reconstructable via `as_of` / `include_history`, matching the actual (non-destructive) supersede behavior.

--- a/apps/cli/src/runtime-factory.ts
+++ b/apps/cli/src/runtime-factory.ts
@@ -352,14 +352,22 @@ export function buildToolRegistry(
   registry.register(readUrlDefinition, createReadUrlHandler());
 
   // Deferred handlers for memory/events (need runtime, which needs registry)
-  const memorySearchFn = async (query: string, opts: { limit: number; asOf?: number }) => {
+  const memorySearchFn = async (
+    query: string,
+    opts: { limit: number; asOf?: number; includeExpired?: boolean },
+  ) => {
     if (!runtimeRef.current) return [];
     const queryEmbedding = await embedText(query);
     const nodes = await runtimeRef.current.memory.recallRelevant(queryEmbedding, {
       limit: opts.limit,
       ...(opts.asOf != null ? { asOf: opts.asOf } : {}),
+      ...(opts.includeExpired ? { includeExpired: true } : {}),
     });
-    return nodes.map((n) => ({ content: n.content, confidence: n.confidence }));
+    return nodes.map((n) => ({
+      content: n.content,
+      confidence: n.confidence,
+      ...(n.valid_until != null ? { supersededAt: n.valid_until } : {}),
+    }));
   };
   const eventQueryFn = async (limit: number, eventType?: string) => {
     if (!runtimeRef.current) return [];

--- a/apps/desktop/src/desktop-tools.ts
+++ b/apps/desktop/src/desktop-tools.ts
@@ -85,8 +85,13 @@ export function registerDesktopTools(
       const nodes = await runtime.memory.recallRelevant(queryEmbedding, {
         limit: opts.limit,
         ...(opts.asOf != null ? { asOf: opts.asOf } : {}),
+        ...(opts.includeExpired ? { includeExpired: true } : {}),
       });
-      return nodes.map((n) => ({ content: n.content, confidence: n.confidence }));
+      return nodes.map((n) => ({
+        content: n.content,
+        confidence: n.confidence,
+        ...(n.valid_until != null ? { supersededAt: n.valid_until } : {}),
+      }));
     },
     eventQueryFn: async (limit, eventType) => {
       const events = await runtime.events.query({

--- a/apps/mobile/src/mobile-app.ts
+++ b/apps/mobile/src/mobile-app.ts
@@ -1159,8 +1159,13 @@ export class MobileApp {
         const nodes = await runtime.memory.recallRelevant(queryEmbedding, {
           limit: opts.limit,
           ...(opts.asOf != null ? { asOf: opts.asOf } : {}),
+          ...(opts.includeExpired ? { includeExpired: true } : {}),
         });
-        return nodes.map((n) => ({ content: n.content, confidence: n.confidence }));
+        return nodes.map((n) => ({
+          content: n.content,
+          confidence: n.confidence,
+          ...(n.valid_until != null ? { supersededAt: n.valid_until } : {}),
+        }));
       },
       eventQueryFn: async (limit, eventType) => {
         const filter: EventFilter = { motebit_id: runtime.motebitId, limit };

--- a/apps/web/src/web-app.ts
+++ b/apps/web/src/web-app.ts
@@ -984,8 +984,13 @@ export class UnbootedWebApp {
         const nodes = await runtime.memory.recallRelevant(embedding, {
           limit: opts.limit,
           ...(opts.asOf != null ? { asOf: opts.asOf } : {}),
+          ...(opts.includeExpired ? { includeExpired: true } : {}),
         });
-        return nodes.map((n) => ({ content: n.content, confidence: n.confidence }));
+        return nodes.map((n) => ({
+          content: n.content,
+          confidence: n.confidence,
+          ...(n.valid_until != null ? { supersededAt: n.valid_until } : {}),
+        }));
       },
       eventQueryFn: async (limit, eventType) => {
         const events = await runtime.events.query({

--- a/packages/tools/src/__tests__/builtins.test.ts
+++ b/packages/tools/src/__tests__/builtins.test.ts
@@ -1043,6 +1043,50 @@ describe("recall_memories", () => {
     expect(result.data as string).toContain("No memories were valid as of");
   });
 
+  it("include_history threads includeExpired and labels current vs superseded per entry", async () => {
+    const supersededAt = Date.parse("2026-06-01");
+    const searchFn = vi.fn().mockResolvedValue([
+      { content: "user lives in SF", confidence: 0.9 }, // current (no supersededAt)
+      { content: "user lives in NYC", confidence: 0.9, supersededAt }, // superseded
+    ]);
+    const handler = createRecallMemoriesHandler(searchFn);
+    const result = await handler({ query: "where does the user live", include_history: true });
+
+    expect(searchFn).toHaveBeenCalledWith("where does the user live", {
+      limit: 5,
+      includeExpired: true,
+    });
+    expect(result.ok).toBe(true);
+    const data = result.data as string;
+    // Each entry disambiguated so a revised belief can't read as current fact.
+    expect(data).toContain("[current] [confidence=0.90] user lives in SF");
+    expect(data).toContain(
+      `[superseded ${new Date(supersededAt).toISOString()}] [confidence=0.90] user lives in NYC`,
+    );
+    expect(data).toContain("A [superseded] entry is NOT current fact");
+  });
+
+  it("current recall carries NO per-entry status label (only history mode does)", async () => {
+    const searchFn = vi.fn().mockResolvedValue([{ content: "user likes TS", confidence: 0.9 }]);
+    const handler = createRecallMemoriesHandler(searchFn);
+    const result = await handler({ query: "prefs" });
+    expect(result.data as string).not.toContain("[current]");
+    expect(result.data as string).not.toContain("[superseded");
+  });
+
+  it("rejects as_of + include_history together — they are different questions", async () => {
+    const searchFn = vi.fn();
+    const handler = createRecallMemoriesHandler(searchFn);
+    const result = await handler({
+      query: "test",
+      as_of: "2026-06-01",
+      include_history: true,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Use as_of OR include_history");
+    expect(searchFn).not.toHaveBeenCalled();
+  });
+
   it("returns message when no memories found", async () => {
     const searchFn = vi.fn().mockResolvedValue([]);
 

--- a/packages/tools/src/builtins/index.ts
+++ b/packages/tools/src/builtins/index.ts
@@ -68,7 +68,7 @@ import { writeFileDefinition, createWriteFileHandler } from "./write-file.js";
 import { shellExecDefinition, createShellExecHandler } from "./shell-exec.js";
 import { undoWriteDefinition, createUndoWriteHandler } from "./undo-write.js";
 import { recallMemoriesDefinition, createRecallMemoriesHandler } from "./recall-memories.js";
-import type { RecallMemoriesOptions } from "./recall-memories.js";
+import type { RecallMemoriesOptions, RecallMemoriesResult } from "./recall-memories.js";
 import {
   rewriteMemoryDefinition,
   createRewriteMemoryHandler,
@@ -91,10 +91,7 @@ export interface BuiltinToolOptions {
   /** Directory for write_file pre-write backups. */
   backupDir?: string;
   searchProvider?: SearchProvider;
-  memorySearchFn?: (
-    query: string,
-    opts: RecallMemoriesOptions,
-  ) => Promise<Array<{ content: string; confidence: number }>>;
+  memorySearchFn?: (query: string, opts: RecallMemoriesOptions) => Promise<RecallMemoriesResult[]>;
   eventQueryFn?: (
     limit: number,
     eventType?: string,

--- a/packages/tools/src/builtins/recall-memories.ts
+++ b/packages/tools/src/builtins/recall-memories.ts
@@ -11,6 +11,24 @@ export interface RecallMemoriesOptions {
    * valid_until)` around this time. See spec/memory-delta-v1.md §3.5.
    */
   asOf?: number;
+  /**
+   * History recall: return ALL versions of a belief — current AND
+   * since-superseded — instead of just the current ones. Each result then
+   * carries `supersededAt` so the caller can tell them apart. Distinct from
+   * `asOf` (a point-in-time snapshot); the two are mutually exclusive.
+   */
+  includeExpired?: boolean;
+}
+
+/**
+ * One recalled memory. `supersededAt` is present ONLY when the belief has been
+ * invalidated (its `valid_until`, Unix ms) — its absence means the belief is
+ * current. Surfaces map it straight from `MemoryNode.valid_until`.
+ */
+export interface RecallMemoriesResult {
+  content: string;
+  confidence: number;
+  supersededAt?: number;
 }
 
 /** @internal */
@@ -19,11 +37,13 @@ export const recallMemoriesDefinition: ToolDefinition = {
   mode: "api",
   description:
     "Search your own memory graph for relevant information. Use when you need to " +
-    "remember something about the user or past conversations. Pass `as_of` (an ISO " +
-    'date, e.g. "2026-06-01") to reconstruct what you believed AS OF that date ' +
-    "instead of now: the results are beliefs that were valid then — including ones " +
-    "you have since revised — so report them as what you believed at that time, " +
-    "never as current fact.",
+    "remember something about the user or past conversations. Two optional " +
+    "bi-temporal modes (mutually exclusive): pass `as_of` (an ISO date, e.g. " +
+    '"2026-06-01") to reconstruct what you believed AS OF that date; pass ' +
+    "`include_history: true` to see ALL versions of a belief at once — current " +
+    "beliefs and the ones they replaced, each labelled. In both modes some results " +
+    "are beliefs you have since revised, so report them as past belief, never as " +
+    "current fact.",
   inputSchema: {
     type: "object",
     properties: {
@@ -33,8 +53,15 @@ export const recallMemoriesDefinition: ToolDefinition = {
         type: "string",
         description:
           "Optional ISO 8601 date/datetime. Reconstruct beliefs valid AS OF this " +
-          "point in time (bi-temporal recall), including since-superseded ones. " +
+          "point in time (a snapshot). Mutually exclusive with include_history. " +
           "Omit for current recall.",
+      },
+      include_history: {
+        type: "boolean",
+        description:
+          "Optional. Return ALL versions of a belief — current and since-" +
+          "superseded — each labelled [current] or [superseded <date>]. Use to " +
+          "see how a belief changed. Mutually exclusive with as_of.",
       },
     },
     required: ["query"],
@@ -42,15 +69,14 @@ export const recallMemoriesDefinition: ToolDefinition = {
 };
 
 export function createRecallMemoriesHandler(
-  searchFn: (
-    query: string,
-    opts: RecallMemoriesOptions,
-  ) => Promise<Array<{ content: string; confidence: number }>>,
+  searchFn: (query: string, opts: RecallMemoriesOptions) => Promise<RecallMemoriesResult[]>,
 ): ToolHandler {
   return async (args) => {
     const query = args.query as string;
     if (!query) return { ok: false, error: "Missing required parameter: query" };
     const limit = (args.limit as number) ?? 5;
+
+    const includeHistory = args.include_history === true;
 
     // Parse the optional as-of instant. An unparseable date is a HARD error —
     // never silently fall back to current recall, which would quietly answer a
@@ -71,8 +97,23 @@ export function createRecallMemoriesHandler(
       asOf = parsed;
     }
 
+    // as_of and include_history answer different questions (a snapshot at T vs.
+    // every version now) and internally take different filter paths, so refuse
+    // the ambiguous combination rather than silently pick one.
+    if (asOf != null && includeHistory) {
+      return {
+        ok: false,
+        error:
+          "Use as_of OR include_history, not both: as_of is a point-in-time snapshot; include_history returns every version.",
+      };
+    }
+
     try {
-      const memories = await searchFn(query, { limit, ...(asOf != null ? { asOf } : {}) });
+      const memories = await searchFn(query, {
+        limit,
+        ...(asOf != null ? { asOf } : {}),
+        ...(includeHistory ? { includeExpired: true } : {}),
+      });
       if (memories.length === 0) {
         return {
           ok: true,
@@ -93,16 +134,27 @@ export function createRecallMemoriesHandler(
           .replace(/\[MEMORY_DATA\b/g, "[ESCAPED_MEMORY")
           .replace(/\[\/MEMORY_DATA\]/g, "[/ESCAPED_MEMORY]")
           .replace(/\[from:/g, "[escaped-from:");
+      // Typed-truth framing (docs/doctrine/typed-truth-perception.md): in history
+      // mode each line is labelled current vs superseded so a revised belief can
+      // never be read as present fact; in as-of mode the WHOLE batch is a T
+      // snapshot, framed once below (no per-line label — they were all current at
+      // T). Plain current recall carries neither.
       const formatted = memories
-        .map((m, i) => `${i + 1}. [confidence=${m.confidence.toFixed(2)}] ${escape(m.content)}`)
+        .map((m, i) => {
+          const status = includeHistory
+            ? m.supersededAt != null
+              ? `[superseded ${new Date(m.supersededAt).toISOString()}] `
+              : "[current] "
+            : "";
+          return `${i + 1}. ${status}[confidence=${m.confidence.toFixed(2)}] ${escape(m.content)}`;
+        })
         .join("\n");
-      // Typed-truth framing (docs/doctrine/typed-truth-perception.md): an as-of
-      // recall reconstructs PAST beliefs, some since superseded. Mark the batch so
-      // the model reports "as of <date> you believed…", never as present fact.
-      const data =
-        asOf != null
-          ? `As of ${new Date(asOf).toISOString()}, you believed (historical snapshot — some may since have been superseded):\n${formatted}`
-          : formatted;
+      let data = formatted;
+      if (asOf != null) {
+        data = `As of ${new Date(asOf).toISOString()}, you believed (historical snapshot — some may since have been superseded):\n${formatted}`;
+      } else if (includeHistory) {
+        data = `All versions found — current beliefs and the ones they replaced. A [superseded] entry is NOT current fact:\n${formatted}`;
+      }
       return { ok: true, data };
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/packages/tools/src/builtins/rewrite-memory.ts
+++ b/packages/tools/src/builtins/rewrite-memory.ts
@@ -33,8 +33,10 @@ export const rewriteMemoryDefinition: ToolDefinition = {
     "Use when you discover a previously-formed memory is wrong — the user corrected " +
     "something, a newer fact contradicts an older one, or you realize your prior " +
     "claim was mistaken. Pass the 8-char short node id shown in the memory index " +
-    "(the `[xxxxxxxx]` prefix). The original memory is tombstoned but preserved in " +
-    "the event log for audit.",
+    "(the `[xxxxxxxx]` prefix). The original memory is not destroyed — it is " +
+    "superseded (marked no longer current) but kept, so it drops out of current " +
+    "recall yet can still be reconstructed via `recall_memories` with `as_of` or " +
+    "`include_history`.",
   inputSchema: {
     type: "object",
     properties: {

--- a/packages/tools/src/web-safe.ts
+++ b/packages/tools/src/web-safe.ts
@@ -12,7 +12,7 @@ import {
   recallMemoriesDefinition,
   createRecallMemoriesHandler,
 } from "./builtins/recall-memories.js";
-import type { RecallMemoriesOptions } from "./builtins/recall-memories.js";
+import type { RecallMemoriesOptions, RecallMemoriesResult } from "./builtins/recall-memories.js";
 import { currentTimeDefinition, createCurrentTimeHandler } from "./builtins/current-time.js";
 import { listEventsDefinition, createListEventsHandler } from "./builtins/list-events.js";
 import {
@@ -103,10 +103,7 @@ export interface BrowserSafeBuiltinOptions {
    * ATS/CORS gate. `readUrlProxy` still takes precedence when set.
    */
   readUrlFetcher?: ReadUrlFetcher;
-  memorySearchFn?: (
-    query: string,
-    opts: RecallMemoriesOptions,
-  ) => Promise<Array<{ content: string; confidence: number }>>;
+  memorySearchFn?: (query: string, opts: RecallMemoriesOptions) => Promise<RecallMemoriesResult[]>;
   eventQueryFn?: (
     limit: number,
     eventType?: string,


### PR DESCRIPTION
## Gap 3 — the deferred half of bi-temporal recall

`#339` shipped `as_of` (a point-in-time snapshot). `include_history` was held back **on purpose**: a history recall that hands the agent an undisambiguable mix of current and revised beliefs is worse than none. Now delivered with the return shape that makes it honest.

- **`recall_memories` gains `include_history: true`** — returns ALL versions of a belief (current + since-superseded) via `recallRelevant({ includeExpired })`.
- **Return shape enriched:** `RecallMemoriesResult.supersededAt?` (a belief's `valid_until`, present iff invalidated). The handler labels each entry `[current]` or `[superseded <date>]` (typed-truth-perception), so a revised belief can never read as current fact. Plain current recall carries no label; `as_of` frames the whole batch as a snapshot (no per-line label — all were current at T).
- **`as_of` and `include_history` are mutually exclusive** — different questions, and `includeExpired` internally bypasses the as-of filter, so passing both is a hard error, not a silent pick.
- **One-pass across surfaces:** the `memorySearchFn` return widens to `RecallMemoriesResult[]`; all four (cli/web/desktop/mobile) map `supersededAt` from `MemoryNode.valid_until` and forward `includeExpired`. Graph layer unchanged.

## Sibling fix

`rewrite_memory`'s tool description still said the original memory is **"tombstoned"** — stale since `#338` made supersede non-destructive. Corrected to *"superseded but kept, reconstructable via `as_of` / `include_history`"*, so the tool's self-description matches its actual behavior.

## Tests

`include_history` threads `includeExpired` and labels current/superseded per entry; current recall carries no label; `as_of` + `include_history` is rejected. tools 138 tests + coverage green; all four surfaces typecheck; 132 gates pass; pre-push gauntlet passed. `motebit` CLI gains the capability → minor changeset.

This closes the bi-temporal memory arc: `#338` (stop destroying revised history) → `#339` (`as_of` reconstruction) → this (`include_history`, the full evolution of a belief).

🤖 Generated with [Claude Code](https://claude.com/claude-code)