### PR TITLE
perf(web): calm loading state + shader pre-warm for the creature's first frame

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -605,6 +605,51 @@
         white-space: nowrap;
       }
 
+      /* Creature loading placeholder — a calm breath where the creature will
+         appear, faded out the instant the first WebGL frame paints
+         (renderer.onFirstFrame). The canvas shows only its clear color until the
+         creature's first frame compiles its shaders; this fills that window
+         calmly. No spinner — calm software. */
+      #creature-loading {
+        position: fixed;
+        inset: 0;
+        z-index: 5; /* above the canvas clear color, below the chat chrome */
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        pointer-events: none;
+        opacity: 1;
+        transition: opacity 0.9s ease;
+      }
+      #creature-loading.ready {
+        opacity: 0;
+      }
+      #creature-loading::before {
+        content: "";
+        width: 176px;
+        height: 176px;
+        border-radius: 50%;
+        background: radial-gradient(circle, var(--text-muted) 0%, transparent 62%);
+        opacity: 0.14;
+        animation: creature-breath 2.4s ease-in-out infinite;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        #creature-loading::before {
+          animation: none;
+        }
+      }
+      @keyframes creature-breath {
+        0%,
+        100% {
+          transform: scale(0.92);
+          opacity: 0.1;
+        }
+        50% {
+          transform: scale(1.06);
+          opacity: 0.18;
+        }
+      }
+
       /* First-visit welcome overlay — sits between creature and chat input */
       #welcome-overlay {
         position: fixed;
@@ -7960,6 +8005,9 @@
   </head>
   <body>
     <canvas id="motebit-canvas"></canvas>
+    <!-- Calm placeholder shown until the creature's first WebGL frame paints;
+         faded out by main.ts via renderer.onFirstFrame. -->
+    <div id="creature-loading" aria-hidden="true"></div>
     <div id="toast-container"></div>
 
     <!-- Identity-divergence banner — shown when bootstrap detects that

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -478,6 +478,23 @@ async function autoInitWebLLM(model: string = DEFAULT_WEBLLM_MODEL): Promise<voi
 async function bootstrap(): Promise<void> {
   await app.init(canvas!, document.documentElement.dataset.theme === "dark" ? "dark" : "light");
 
+  // Fade the calm loading placeholder the instant the creature's first WebGL
+  // frame paints — the honest "creature is visible" moment (init() builds the
+  // scene but paints nothing; the first render() pays the shader-compile cost).
+  // A safety timeout guarantees the placeholder never hangs if WebGL fails.
+  const creatureLoading = document.getElementById("creature-loading");
+  if (creatureLoading) {
+    let revealed = false;
+    const reveal = (): void => {
+      if (revealed) return;
+      revealed = true;
+      creatureLoading.classList.add("ready");
+      window.setTimeout(() => creatureLoading.remove(), 1000);
+    };
+    app.getRenderer().onFirstFrame(reveal);
+    window.setTimeout(reveal, 12000);
+  }
+
   // Initialize IDB storage, migration, and runtime
   await app.bootstrap();
 

--- a/packages/render-engine/src/__tests__/adapter.test.ts
+++ b/packages/render-engine/src/__tests__/adapter.test.ts
@@ -386,6 +386,25 @@ describe("ThreeJSAdapter (headless)", () => {
     adapter.render(defaultFrame({ delta_time: 0, time: 0 }));
   });
 
+  it("onFirstFrame does not fire until a real frame paints (headless never renders one)", async () => {
+    await adapter.init(null);
+    let fired = 0;
+    adapter.onFirstFrame(() => fired++);
+    // Headless render() short-circuits before painting (no WebGL context), so
+    // the signal must NOT fire — a loading placeholder would never wrongly clear.
+    adapter.render(defaultFrame());
+    adapter.render(defaultFrame());
+    expect(fired).toBe(0);
+  });
+
+  it("onFirstFrame registration is idempotent and safe to call repeatedly", async () => {
+    await adapter.init(null);
+    expect(() => {
+      adapter.onFirstFrame(() => {});
+      adapter.onFirstFrame(() => {});
+    }).not.toThrow();
+  });
+
   it("getCreatureGroup returns null headless (no creature refs)", async () => {
     await adapter.init(null);
     expect(adapter.getCreatureGroup()).toBeNull();

--- a/packages/render-engine/src/adapter.ts
+++ b/packages/render-engine/src/adapter.ts
@@ -83,6 +83,12 @@ export class ThreeJSAdapter implements RenderAdapter {
   private initialized = false;
   private creatureRefs: CreatureRefs | null = null;
   private creatureState: CreatureState = createCreatureState();
+  /** Fired once, after the creature's FIRST frame actually paints — the signal a
+   *  surface uses to fade out its loading placeholder. `render()` is what pays
+   *  the WebGL shader-compile cost, so this is the honest "creature is visible"
+   *  moment, not `init()` (which builds the scene but paints nothing). */
+  private firstFrameFired = false;
+  private firstFrameCallback: (() => void) | null = null;
 
   private renderer: THREE.WebGLRenderer | null = null;
   private scene: THREE.Scene | null = null;
@@ -168,7 +174,33 @@ export class ThreeJSAdapter implements RenderAdapter {
     this.scene.add(rim);
 
     this.initialized = true;
+
+    // Pre-warm the GPU: compile the creature + slab shaders NOW, off the first
+    // render frame, so the first paint doesn't stall on shader compilation (the
+    // dominant cost of a cold WebGL first frame). Fire-and-forget — it runs in
+    // parallel with the surface's async bootstrap; the render loop simply hits
+    // warm shaders once it starts. Guarded because older Three or a headless
+    // stub may lack compileAsync.
+    if (typeof this.renderer.compileAsync === "function") {
+      void this.renderer.compileAsync(this.scene, this.camera).catch(() => {
+        // Pre-warm is an optimization, never a correctness dependency — a
+        // compile hiccup just means the first frame compiles lazily as before.
+      });
+    }
     return Promise.resolve();
+  }
+
+  /**
+   * Register a one-shot callback fired when the creature's first frame paints.
+   * If the first frame has already rendered, the callback runs synchronously —
+   * a late subscriber never misses the signal.
+   */
+  onFirstFrame(callback: () => void): void {
+    if (this.firstFrameFired) {
+      callback();
+      return;
+    }
+    this.firstFrameCallback = callback;
   }
 
   render(frame: RenderFrame): void {
@@ -179,6 +211,16 @@ export class ThreeJSAdapter implements RenderAdapter {
 
     if (this.controls) this.controls.update();
     this.renderer.render(this.scene, this.camera);
+
+    // The creature is now on screen — fire the one-shot first-frame signal so a
+    // surface can fade out its loading placeholder. AFTER render(), not before:
+    // this line runs once the pixels exist.
+    if (!this.firstFrameFired) {
+      this.firstFrameFired = true;
+      const cb = this.firstFrameCallback;
+      this.firstFrameCallback = null;
+      cb?.();
+    }
 
     // Spatial canvas: update artifact animations and sync CSS overlay
     if (this.artifactManager) {


### PR DESCRIPTION
Answering "why does motebit.com load slowly" — **profiled first, then fixed** (per the ask).

## The profile flipped the hypothesis

Lighthouse against the **live site** says the page **shell is fast** — FCP **0.6s**, LCP **0.6s**, TTI **0.7s**, TBT **10ms**, **perf score 100**, and the cache-policy audit *passes* (so the `max-age=0` header I first suspected is real but cheap in practice, not the cause). curl'd asset timing confirms ~760 KiB brotli, reasonably chunked (transformers/ONNX is lazy, three.js is the only heavy eager dep).

So where's the ~5s a user sees? The **one thing web-vitals don't measure**: the **WebGL creature inside the `<canvas>`**. LCP tracks DOM/image elements, not canvas contents — Lighthouse "finished" at 0.6s while the creature (Three.js init + PMREM environment + **first-frame shader compilation** + GPU work) was still rendering. And `init()` *builds* the scene but paints nothing; the first frame — and its shader compile — only lands when the render loop starts **inside** `bootstrap()`. Meanwhile the canvas shows a blank clear color with **no affordance** — the blank-then-pop the screenshots caught. **No load-logic bug**; the gap is perceived perf + first-frame jank.

## The fix

- **`render-engine` (ThreeJSAdapter):** `compileAsync(scene, camera)` at the end of `init()` **pre-warms** the creature/slab shaders off the first frame (guarded + fire-and-forget). Plus a one-shot **`onFirstFrame(cb)`** signal fired *after* the first real `render()` paints — the honest "creature is visible" moment.
- **`index.html`:** a calm **`#creature-loading`** placeholder — a soft breathing pulse where the creature will appear, theme-aware, `prefers-reduced-motion` respected. No spinner (calm software).
- **`main.ts`:** fade + remove the placeholder on `onFirstFrame`, with a 12s safety fallback so a WebGL failure never leaves it hanging.

## Result

The blank-tan window becomes a calm, intentional loading state, and the first frame no longer stalls on cold shader compilation. render-engine **106 tests** (+2); web builds; **132 gates** pass; pre-push gauntlet passed. Both packages private — no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)