### PR TITLE
feat(runtime): mint the routing-decision transcript at the WorkerSelector seam (transcript Inc 3)

### DIFF
--- a/packages/runtime/src/__tests__/execute-granted-delegation.test.ts
+++ b/packages/runtime/src/__tests__/execute-granted-delegation.test.ts
@@ -22,7 +22,9 @@ import {
   signDelegation,
   signStandingDelegation,
   signDelegationRevocation,
+  verifyRoutingTranscript,
 } from "@motebit/crypto";
+import { recomputeRoutingDecision } from "@motebit/semiring";
 import { RiskLevel, AgentTrustLevel } from "@motebit/protocol";
 import type {
   DelegationToken,
@@ -499,6 +501,121 @@ describe("executeGrantedDelegation — deterministic granted spend, fail-closed"
     expect(buildP2pPayment).toHaveBeenCalled();
     expect(buildP2pPayment.mock.calls[0]![0].workerAddress).toBe(ALICE_ADDR);
     vi.unstubAllGlobals();
+  });
+
+  it("a ranked paid hire MINTS a signed routing-decision transcript that verifies on both rungs", async () => {
+    // Inc 3 of docs/doctrine/routing-decision-transcript.md: the producer at
+    // the WorkerSelector seam. Same deterministic two-candidate hire as above,
+    // with the delegator's signing keys wired — the runtime must freeze the
+    // basis from the REAL ranking pass, sign it, and retain it. Both rungs are
+    // then checked: integrity (verifyRoutingTranscript) and faithfulness
+    // (recomputeRoutingDecision) — the accept-on-proof loop closed end to end.
+    const ALICE_ADDR = "AliceWorkerAddr2222222222222222222222222222";
+    const operator = await generateKeypair();
+    const clerk = await generateKeypair();
+    const grant = await makeGrant(operator, clerk);
+    const token = await mintTick(grant, operator);
+
+    const storage = createInMemoryStorage();
+    await (
+      storage.agentTrustStore as { setAgentTrust: (r: AgentTrustRecord) => Promise<void> }
+    ).setAgentTrust({
+      motebit_id: "clerk-001",
+      remote_motebit_id: "alice-worker",
+      trust_level: AgentTrustLevel.Trusted,
+      first_seen_at: NOW - 100 * HOUR,
+      last_seen_at: NOW,
+      interaction_count: 20,
+      successful_tasks: 20,
+      failed_tasks: 0,
+    });
+
+    const { wallet, buildP2pPayment } = mockWallet(async (r) => ({
+      tx_hash: "tx",
+      chain: "solana",
+      network: "solana:x",
+      to_address: r.workerAddress,
+      amount_micro: r.amountMicro,
+      fee_to_address: r.treasuryAddress,
+      fee_amount_micro: r.feeAmountMicro,
+    }));
+
+    const runtime = new MotebitRuntime(
+      {
+        motebitId: "clerk-001",
+        tickRateHz: 0,
+        policy: { requireApprovalAbove: RiskLevel.R1_DRAFT, denyAbove: RiskLevel.R4_MONEY },
+        solanaWallet: wallet,
+        signingKeys: { privateKey: clerk.privateKey, publicKey: clerk.publicKey },
+      },
+      { ...createAdapters(), storage },
+    );
+    runtime.enableInteractiveDelegation({
+      syncUrl: "https://mock-relay.test",
+      authToken: async () => "test-token",
+      relayPublicKey: PINNED_HEX,
+      buildP2pPayment,
+      acknowledgeNoHistoryRisk: true,
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.includes("/api/v1/agents/discover"))
+          return jsonResponse({
+            agents: [
+              {
+                motebit_id: "bob-worker",
+                settlement_address: WORKER_ADDR,
+                settlement_modes: "p2p",
+                pricing: [{ capability: "research", unit_cost: 1.5 }],
+              },
+              {
+                motebit_id: "alice-worker",
+                settlement_address: ALICE_ADDR,
+                settlement_modes: "p2p",
+                pricing: [{ capability: "research", unit_cost: 1.5 }],
+              },
+            ],
+          });
+        if (url.includes("/p2p-eligibility")) return jsonResponse({ allowed: true });
+        if (url.includes("/listing"))
+          return jsonResponse({ pricing: [{ capability: "research", unit_cost: 1.5 }] });
+        if (url.endsWith("/task")) return jsonResponse({ task_id: "t1" }, 201);
+        if (url.includes("/task/"))
+          return jsonResponse({ task: { status: "completed" }, receipt: fakeReceipt() });
+        return new Response("not found", { status: 404 });
+      }),
+    );
+
+    await runtime.executeGrantedDelegation({
+      capability: "research",
+      prompt: "survey the topic",
+      delegation: { token, grant },
+      dryRun: false,
+    });
+    vi.unstubAllGlobals();
+
+    const transcripts = runtime.getRecentRoutingTranscripts();
+    expect(transcripts).toHaveLength(1);
+    const t = transcripts[0]!;
+    expect(t.winner_motebit_id).toBe("alice-worker");
+    expect(t.capability).toBe("research");
+    expect(t.delegator_motebit_id).toBe("clerk-001");
+    expect(t.seed).toBe(token.signature); // seed provenance = the signed tick
+    expect(t.candidates).toHaveLength(2);
+    // Rung 1 — integrity: the delegator committed to this decision record.
+    expect(await verifyRoutingTranscript(t)).toEqual({ valid: true });
+    // Rung 2 — faithfulness: the recorded winner follows from the frozen inputs.
+    expect(recomputeRoutingDecision(t)).toEqual({
+      consistent: true,
+      recomputed_winner: "alice-worker",
+    });
+    // Tamper — the record is not editable after the fact.
+    expect(await verifyRoutingTranscript({ ...t, explored: !t.explored })).toEqual({
+      valid: false,
+      reason: "signature_invalid",
+    });
   });
 
   it("unpinned LOW-STAKES ⇒ exploration engaged at full strength (the newcomer on-ramp is live)", async () => {

--- a/packages/runtime/src/motebit-runtime.ts
+++ b/packages/runtime/src/motebit-runtime.ts
@@ -255,7 +255,7 @@ import { SecretRedactingProvider } from "./secret-redacting-provider.js";
 import { CredentialManager } from "./credential-manager.js";
 import { readLatestHardwareAttestationClaim } from "./hardware-attestation-projection.js";
 import { readLatencyStats } from "./latency-stats-projection.js";
-import { scoreAttestation, selectWorker as selectWorkerByTrust } from "@motebit/semiring";
+import { scoreAttestation, rankWorkersWithBasis } from "@motebit/semiring";
 import { PlanExecutionManager } from "./plan-execution.js";
 import { createGoalsEmitter, type GoalsEmitter, type GoalLifecycleStatus } from "./goals.js";
 import { createMemoryFormationQueue, type MemoryFormationQueue } from "./memory-formation-queue.js";
@@ -300,8 +300,11 @@ import {
   consolidationReceiptDigest,
   consolidationContentDigest,
   signContentArtifact,
+  signRoutingTranscript,
+  bytesToHex as cryptoBytesToHex,
   type ContentArtifactManifest,
 } from "@motebit/crypto";
+import type { RoutingDecisionTranscript } from "@motebit/protocol";
 import type { ConsolidationMutationCommitment } from "@motebit/sdk";
 // `GOAL_RESULT_ARTIFACT` is re-exported via `@motebit/sdk` per the sdk
 // CLAUDE.md re-export rule — every protocol type accessible through sdk.
@@ -567,6 +570,13 @@ export class MotebitRuntime {
   private latencyStatsStore: LatencyStatsStoreAdapter | null;
   private agentGraph: AgentGraphManager;
   private _signingKeys: { privateKey: Uint8Array; publicKey: Uint8Array } | null;
+  /**
+   * Bounded buffer of recently minted routing-decision transcripts
+   * (docs/doctrine/routing-decision-transcript.md — minted always, retained
+   * locally, egressed on dispute or owner choice, never broadcast). The
+   * `getRecentApprovalDecisions()` buffer-and-getter shape.
+   */
+  private _recentRoutingTranscripts: RoutingDecisionTranscript[] = [];
   /**
    * Sovereign Solana wallet rail. Null when the runtime has no signing keys
    * or the caller did not configure a Solana rail. When present, exposes
@@ -3996,6 +4006,19 @@ export class MotebitRuntime {
   }
 
   /**
+   * Recently minted routing-decision transcripts, newest last — the signed
+   * record of why each ranked paid hire won
+   * (docs/doctrine/routing-decision-transcript.md). Session-scoped and
+   * bounded, like `getRecentApprovalDecisions()`: disclosure is
+   * dispute-scoped or owner-initiated, never broadcast, and the buffer
+   * REVEALS, never authorizes. Durable cross-restart archival is a deferred,
+   * consumer-shaped concern.
+   */
+  getRecentRoutingTranscripts(): ReadonlyArray<RoutingDecisionTranscript> {
+    return this._recentRoutingTranscripts;
+  }
+
+  /**
    * Per-session pixel-passthrough consent. Composed into the loop's
    * `projectForAi` pixel gate alongside provider mode and effective
    * sensitivity. Default is `denied` — fail-closed for fresh sessions.
@@ -4948,12 +4971,15 @@ export class MotebitRuntime {
               // inflate its `read_url` estimate. The pairwise trust level (the
               // relationship) still speaks through the prior.
               const capability = params.capability;
-              const exploitTop = selectWorkerByTrust(this.motebitId, rankable, { capability });
-              const winner = selectWorkerByTrust(this.motebitId, rankable, {
+              // The produced-basis emitter runs the REAL ranking and freezes
+              // exactly what it consumed — winner, explored flag, and the
+              // transcript basis in one pass
+              // (docs/doctrine/routing-decision-transcript.md Inc 3).
+              const { winner, basis } = rankWorkersWithBasis(this.motebitId, rankable, {
                 capability,
                 explore: { seed: exploreSeed, strength },
               });
-              if (winner != null) {
+              if (winner != null && basis != null) {
                 // Surface the "why" — the sub-hop routing decision, including
                 // whether exploration overrode the exploit-favorite (the honest
                 // "why the newcomer got tried" signal).
@@ -4962,10 +4988,49 @@ export class MotebitRuntime {
                   capability,
                   candidates: rankable.length,
                   strength: Number(strength.toFixed(3)),
-                  explored: exploitTop != null && winner.motebit_id !== exploitTop.motebit_id,
+                  explored: basis.explored,
                   quality: Number(winner.route.trust.toFixed(3)),
                   bonded: rankable.find((r) => r.motebit_id === winner.motebit_id)?.bonded === true,
                 });
+                // Mint the signed routing-decision transcript from the frozen
+                // basis (produced-basis: minted by the code path that made the
+                // decision, never reconstructed). Reveals, never authorizes —
+                // minting failure never fails the hire; the transcript is
+                // evidence, not authority.
+                if (this._signingKeys != null) {
+                  try {
+                    const transcript = await signRoutingTranscript(
+                      {
+                        spec: "motebit/routing-transcript@1.0",
+                        delegator_motebit_id: this.motebitId,
+                        delegator_public_key: cryptoBytesToHex(this._signingKeys.publicKey),
+                        issued_at: Date.now(),
+                        ...basis,
+                      },
+                      this._signingKeys.privateKey,
+                    );
+                    this._recentRoutingTranscripts.push(transcript);
+                    if (this._recentRoutingTranscripts.length > 50) {
+                      this._recentRoutingTranscripts.shift();
+                    }
+                    this._logger.warn("routing.transcript_minted", {
+                      winner: transcript.winner_motebit_id,
+                      capability: transcript.capability,
+                      candidates: transcript.candidates.length,
+                      explored: transcript.explored,
+                      // The signature is the transcript's collision-resistant
+                      // handle (it covers the JCS-canonical bytes) — the
+                      // binding key a consumer joins on. Wire-level digest
+                      // binding into the delegation record lands with Inc 4's
+                      // consumer (the conformance probe), consumer-forced.
+                      transcript_sig: transcript.signature.slice(0, 16),
+                    });
+                  } catch (err) {
+                    this._logger.warn("routing.transcript_mint_failed", {
+                      error: err instanceof Error ? err.message : String(err),
+                    });
+                  }
+                }
               }
               return winner?.motebit_id ?? null;
             };


### PR DESCRIPTION
Inc 3 of [`routing-decision-transcript.md`](https://github.com/motebit/motebit/blob/main/docs/doctrine/routing-decision-transcript.md) — the producer. Every ranked paid hire now leaves a signed, recomputable record of why the winner won.

## What ships

- The runtime's `WorkerSelector` closure swaps its double `selectWorkerByTrust` call for the produced-basis emitter `rankWorkersWithBasis` (#348): one real ranking pass yields the winner, the explored flag, and the frozen decision basis — the transcript's numbers come from the code path that made the decision, never a reconstruction.
- The basis is signed with the delegator's identity (`signRoutingTranscript`), retained in a bounded session buffer behind `getRecentRoutingTranscripts()` (the `getRecentApprovalDecisions` shape — dispute-scoped disclosure, never broadcast), and surfaced via `routing.transcript_minted` with the signature prefix as the join handle.
- **Minting failure never fails the hire** — the transcript reveals, never authorizes.

## Proof

End-to-end regression through the REAL `executeGrantedDelegation` path: a ranked two-candidate paid hire mints exactly one transcript whose `seed` is the signed tick token, that verifies on **both rungs** — `verifyRoutingTranscript` (integrity) and `recomputeRoutingDecision` (faithfulness) — and that rejects post-hoc edits (`signature_invalid`). Full runtime suite 1221 green; full pre-push gate suite green.

## Deferred to Inc 4 (consumer-forced)

Wire-level digest binding into the delegation record, shaped by its first consumer — the conformance probe asserting a verified transcript on its own delegation — plus the emission drift gate (ranked-hire-without-transcript = red build). Same sequencing as `ApprovalDecision` archival.

🤖 Generated with [Claude Code](https://claude.com/claude-code)