### PR TITLE
fix(molecule-runner): wire delegator signing keys — the transcript producer was silently dormant in deployed molecules

### DIFF
--- a/packages/molecule-runner/src/index.ts
+++ b/packages/molecule-runner/src/index.ts
@@ -530,6 +530,12 @@ export function defaultCreateMoneyRuntime(
       policy: { ...policyOverrides, denyAbove: RiskLevel.R4_MONEY },
       solanaWallet: wallet,
       grantSpendStore: grantSpendStore as never,
+      // The molecule's identity keys double as the delegator signing keys so
+      // the runtime can mint routing-decision transcripts for its ranked paid
+      // hires (docs/doctrine/routing-decision-transcript.md Inc 3 — without
+      // these the producer is silently dormant and every deployed molecule
+      // WARNs "no transcripts" in conformance).
+      signingKeys: { privateKey: identity.privateKey, publicKey: identity.publicKey },
     },
     { storage, renderer: new NullRenderer(), tools },
   );

--- a/scripts/check-routing-transcript-emission.ts
+++ b/scripts/check-routing-transcript-emission.ts
@@ -43,6 +43,11 @@ const CHAIN: Array<{ file: string; needle: string; link: string }> = [
     link: "producer signs the frozen basis",
   },
   {
+    file: "packages/molecule-runner/src/index.ts",
+    needle: "signingKeys: { privateKey: identity.privateKey",
+    link: "money molecules wire delegator signing keys (else the producer is silently dormant in every deployed molecule)",
+  },
+  {
     file: "packages/runtime/src/relay-delegation.ts",
     needle: "routingTranscript?:",
     link: "GrantedDelegationResult carries the egress field",
@@ -85,5 +90,5 @@ if (broken.length > 0) {
 }
 
 console.log(
-  `✓ check-routing-transcript-emission: all ${CHAIN.length} links of the transcript chain (producer → result egress → receipt embed → both-rung proof) are present.`,
+  `✓ check-routing-transcript-emission: all ${CHAIN.length} links of the transcript chain (producer → signing keys → result egress → receipt embed → both-rung proof) are present.`,
 );


### PR DESCRIPTION
The first live conformance exercise of the transcript arc (run 29891164104, immediately after the #350 staging redeploy) returned WARN "no transcripts" on two ranked-eligible paid hops. Root cause: `defaultCreateMoneyRuntime` never passed `signingKeys` to the runtime, so `_signingKeys` was null in every deployed molecule and the Inc 3 producer skipped minting — exactly as its reveals-never-authorizes contract dictates (a mint failure must never fail the hire), but dormant fleet-wide.

Fix: the molecule identity keys double as the delegator signing keys.

Hardening: `check-routing-transcript-emission` gains a seventh chain link (molecule-runner wires `signingKeys`) so this dormancy class fails CI structurally instead of surfacing as a conformance WARN someone has to notice. 39 molecule-runner tests green; gate suite green at push.

After merge: redeploy `motebit-research-stg` and re-dispatch the staging probe — expected WARN→PASS on "routing transcripts verify (both rungs)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)