### PR TITLE
fix(runtime): thread the minted transcript onto the delegation result — the lost egress link

### DIFF
--- a/packages/runtime/src/__tests__/execute-granted-delegation.test.ts
+++ b/packages/runtime/src/__tests__/execute-granted-delegation.test.ts
@@ -588,13 +588,20 @@ describe("executeGrantedDelegation — deterministic granted spend, fail-closed"
       }),
     );
 
-    await runtime.executeGrantedDelegation({
+    const execResult = await runtime.executeGrantedDelegation({
       capability: "research",
       prompt: "survey the topic",
       delegation: { token, grant },
       dryRun: false,
     });
     vi.unstubAllGlobals();
+
+    // Inc 4 egress: the RESULT carries the transcript (what a molecule
+    // self-attests from) — not just the session buffer.
+    expect(execResult.ok).toBe(true);
+    if (execResult.ok && !execResult.dryRun) {
+      expect(execResult.routingTranscript?.winner_motebit_id).toBe("alice-worker");
+    }
 
     const transcripts = runtime.getRecentRoutingTranscripts();
     expect(transcripts).toHaveLength(1);

--- a/packages/runtime/src/motebit-runtime.ts
+++ b/packages/runtime/src/motebit-runtime.ts
@@ -4946,6 +4946,10 @@ export class MotebitRuntime {
       // never a hidden `Math.random`. Strength scales DOWN with the hop's stakes:
       // explore freely on micro-priced hops, pure-exploit on dollar-scale ones.
       const exploreSeed = params.delegation.token.signature;
+      // The transcript minted for THIS call's ranked selection — threaded onto
+      // the result so a molecule can self-attest it into its own receipt
+      // (Inc 4 egress; the sub_settlements shape).
+      let mintedTranscript: RoutingDecisionTranscript | null = null;
       const selectWorker: WorkerSelector | undefined =
         params.targetWorkerId != null
           ? undefined
@@ -5013,6 +5017,7 @@ export class MotebitRuntime {
                     if (this._recentRoutingTranscripts.length > 50) {
                       this._recentRoutingTranscripts.shift();
                     }
+                    mintedTranscript = transcript;
                     this._logger.warn("routing.transcript_minted", {
                       winner: transcript.winner_motebit_id,
                       capability: transcript.capability,
@@ -5144,6 +5149,9 @@ export class MotebitRuntime {
         dryRun: false,
         receipt: result.receipt,
         ...(result.settlement ? { settlement: result.settlement } : {}),
+        ...(mintedTranscript != null
+          ? { routingTranscript: mintedTranscript as RoutingDecisionTranscript }
+          : {}),
       };
     } finally {
       // Standing authority dies with the call — never leaks to a later turn.

--- a/scripts/check-routing-transcript-emission.ts
+++ b/scripts/check-routing-transcript-emission.ts
@@ -43,6 +43,11 @@ const CHAIN: Array<{ file: string; needle: string; link: string }> = [
     link: "producer signs the frozen basis",
   },
   {
+    file: "packages/runtime/src/motebit-runtime.ts",
+    needle: "mintedTranscript = transcript",
+    link: "producer threads the minted transcript onto the delegation result (the buffer alone is not egress)",
+  },
+  {
     file: "packages/molecule-runner/src/index.ts",
     needle: "signingKeys: { privateKey: identity.privateKey",
     link: "money molecules wire delegator signing keys (else the producer is silently dormant in every deployed molecule)",


### PR DESCRIPTION
The first live both-rungs exercise (probe run 29892533454 against research-stg v17) showed the producer MINTING (`routing.transcript_minted` in the service logs, inside the probe window) while the receipt payload stayed empty. Root cause: the three `mintedTranscript` threading edits (declaration, closure assignment, result spread) were lost in the Inc 4 branch churn and never reached main — while the result-type field and every other chain link DID land, so the emission gate stayed green, and the regression test asserted the session buffer but not the result field, so it stayed green too.

Two structural locks added with the restore:

- the end-to-end regression now asserts `execResult.routingTranscript` — the seam a molecule actually consumes, not just the buffer;
- `check-routing-transcript-emission` gains an eighth chain link (`mintedTranscript = transcript` — the buffer alone is not egress).

After merge: redeploy `motebit-research-stg`, re-dispatch the staging probe — expected WARN→PASS on "routing transcripts verify (both rungs)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)