### PR TITLE
feat(relay): effective-config harness — the systemic fix for the shadow-the-constant class

### DIFF
--- a/scripts/check-deploy-parity.ts
+++ b/scripts/check-deploy-parity.ts
@@ -101,10 +101,16 @@ function parseEnvExample(path: string): Set<string> {
 /**
  * Return all env var names read in a service's source.
  *
- * Recognizes three shapes:
+ * Recognizes four shapes:
  *   - process.env.FOO
  *   - process.env["FOO"]
  *   - parseBoolEnv("FOO", ...) / parseIntEnv / parseFloatEnv (services/relay/src/env.ts helpers)
+ *   - env.FOO / env["FOO"] — the INJECTED env source in a pure config builder
+ *     (relay-config.ts `buildRelayConfigFromEnv(env, …)`). The builder reads
+ *     the env through a parameter (default process.env) so effective config is
+ *     unit-testable; the reads are real, just one indirection removed from
+ *     `process.env`. SCREAMING_SNAKE-constrained so `env.foo`/`obj.envX` don't
+ *     match.
  *
  * If a service introduces a new env-reading helper, extend the regex — the
  * gate's correctness depends on knowing every shape. Better to false-positive
@@ -114,6 +120,7 @@ function envVarsReadInSource(serviceDir: string): Set<string> {
   const names = new Set<string>();
   const directEnv = /process\.env(?:\.([A-Z][A-Z0-9_]*)|\[["']([A-Z][A-Z0-9_]*)["']\])/g;
   const helperEnv = /\bparse(?:Bool|Int|Float)Env\s*\(\s*["']([A-Z][A-Z0-9_]*)["']/g;
+  const injectedEnv = /\benv(?:\.([A-Z][A-Z0-9_]*)|\[["']([A-Z][A-Z0-9_]*)["']\])/g;
 
   function walk(dir: string): void {
     let entries: string[];
@@ -138,6 +145,10 @@ function envVarsReadInSource(serviceDir: string): Set<string> {
         helperEnv.lastIndex = 0;
         while ((m = helperEnv.exec(src)) !== null) {
           names.add(m[1]);
+        }
+        injectedEnv.lastIndex = 0;
+        while ((m = injectedEnv.exec(src)) !== null) {
+          names.add(m[1] ?? m[2]);
         }
       }
     }

--- a/scripts/check-gates-effective.ts
+++ b/scripts/check-gates-effective.ts
@@ -148,12 +148,12 @@ const PROBES: ReadonlyArray<Probe> = [
   {
     script: "check-security-default-wiring",
     proves:
-      "flags server.ts re-shadowing the federation discover-signature default with a hard-coded literal instead of the canonical DEFAULT_REQUIRE_DISCOVER_SIGNATURE constant (the #346 sunset-inert-in-prod regression)",
+      "flags the relay config builder re-shadowing the federation discover-signature default with a hard-coded literal instead of the canonical DEFAULT_REQUIRE_DISCOVER_SIGNATURE constant (the #346 sunset-inert-in-prod regression)",
     perturb: () =>
-      mutateFile("services/relay/src/server.ts", (src) =>
+      mutateFile("services/relay/src/relay-config.ts", (src) =>
         src.replace(
-          'MOTEBIT_FEDERATION_REQUIRE_DISCOVER_SIGNATURE",\n          DEFAULT_REQUIRE_DISCOVER_SIGNATURE,',
-          'MOTEBIT_FEDERATION_REQUIRE_DISCOVER_SIGNATURE",\n          false,',
+          "DEFAULT_REQUIRE_DISCOVER_SIGNATURE,\n            env,",
+          "false,\n            env,",
         ),
       ),
   },

--- a/scripts/check-security-default-wiring.ts
+++ b/scripts/check-security-default-wiring.ts
@@ -39,11 +39,19 @@ interface Rule {
   boundary: string;
 }
 
+// The env → config wiring now lives in the pure builder
+// (relay-config.ts), driven by the SECURITY_BOUNDARY_DEFAULTS registry there.
+// This gate is the fast static tripwire; the effective-config unit test
+// (relay-config.test.ts) is the strong semantic enforcement (it boots the
+// real builder and asserts the computed value). Both bind to the same
+// registry — the test imports it directly, this gate mirrors the one
+// constant-backed boundary as a source-text assertion so a shadowing literal
+// fails at `pnpm check` speed without a build.
 const REGISTRY: Rule[] = [
   {
     envVar: "MOTEBIT_FEDERATION_REQUIRE_DISCOVER_SIGNATURE",
     constant: "DEFAULT_REQUIRE_DISCOVER_SIGNATURE",
-    configFile: "services/relay/src/server.ts",
+    configFile: "services/relay/src/relay-config.ts",
     boundary: "federation per-hop discover signing (the #188 sunset; cross-org trust boundary)",
   },
 ];

--- a/services/relay/src/__tests__/relay-config.test.ts
+++ b/services/relay/src/__tests__/relay-config.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Effective-configuration tests — the strong enforcement layer of the
+ * security-default harness.
+ *
+ * These drive the REAL production config builder (`buildRelayConfigFromEnv`,
+ * the exact function `server.ts` calls) under crafted env maps and assert the
+ * EFFECTIVE value the deployed process would compute — the layer that was
+ * missing when #346 shipped the discover-signature sunset inert (the sunset
+ * test asserted the constant; nothing asserted the built config). Every
+ * registered `SECURITY_BOUNDARY_DEFAULTS` boundary is covered by construction:
+ * add a boundary to the registry and it is automatically asserted here.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  buildRelayConfigFromEnv,
+  SECURITY_BOUNDARY_DEFAULTS,
+  MINIMAL_VALID_RELAY_ENV,
+  probeSecurityBoundaries,
+} from "../relay-config.js";
+import type { EnvSource } from "../env.js";
+import { DEFAULT_REQUIRE_DISCOVER_SIGNATURE } from "../federation.js";
+import { createTestRelay } from "./test-helpers.js";
+import type { SyncRelay } from "../index.js";
+
+const DEPS = { getShuttingDown: () => false } as const;
+
+/**
+ * A baseline env in which every federation-scoped boundary is REACHABLE
+ * (federation enabled) but no security env var is set — so the effective
+ * config must fall to the strict default for every boundary. This is the
+ * exact shape a production relay boots with when an operator has not
+ * explicitly opted out of any boundary.
+ */
+function federationEnabledEnvWithNoSecurityOverrides(): EnvSource {
+  return {
+    ...MINIMAL_VALID_RELAY_ENV,
+    MOTEBIT_FEDERATION_ENDPOINT_URL: "https://relay.example",
+  };
+}
+
+describe("buildRelayConfigFromEnv — effective security-boundary defaults", () => {
+  it("every registered boundary falls to its strict value when its env var is unset (the #346 regression)", () => {
+    const cfg = buildRelayConfigFromEnv(federationEnabledEnvWithNoSecurityOverrides(), DEPS);
+    for (const b of SECURITY_BOUNDARY_DEFAULTS) {
+      const effective = b.effectiveValue(cfg);
+      expect(
+        effective,
+        `${b.boundary} (${b.envVar}) must be present in the built config`,
+      ).toBeTypeOf("boolean");
+      expect(
+        effective,
+        `${b.boundary} (${b.envVar}) must be ${b.strictWhenUnset} when unset — a shadowing literal or dropped wiring here is a production fail-open`,
+      ).toBe(b.strictWhenUnset);
+    }
+  });
+
+  it("the discover-signature default tracks the canonical sunset constant, not a literal", () => {
+    const cfg = buildRelayConfigFromEnv(federationEnabledEnvWithNoSecurityOverrides(), DEPS);
+    // If the sunset constant is ever flipped back, this effective value moves
+    // with it — proving single-source-of-truth (a test on the constant is a
+    // test on production).
+    expect(cfg.federation?.requireDiscoverSignature).toBe(DEFAULT_REQUIRE_DISCOVER_SIGNATURE);
+    expect(cfg.federation?.requireDiscoverSignature).toBe(true);
+  });
+
+  it("an explicit opt-out env var overrides the strict default (config-restorable)", () => {
+    const env = {
+      ...federationEnabledEnvWithNoSecurityOverrides(),
+      MOTEBIT_FEDERATION_REQUIRE_DISCOVER_SIGNATURE: "false",
+      MOTEBIT_ENABLE_DEVICE_AUTH: "false",
+      MOTEBIT_FEDERATION_AUTO_ACCEPT: "true",
+    };
+    const cfg = buildRelayConfigFromEnv(env, DEPS);
+    expect(cfg.federation?.requireDiscoverSignature).toBe(false);
+    expect(cfg.enableDeviceAuth).toBe(false);
+    expect(cfg.federation?.autoAcceptPeers).toBe(true);
+  });
+
+  it("throws when the required x402 pay-to address is absent (pure config validation)", () => {
+    expect(() => buildRelayConfigFromEnv({}, DEPS)).toThrow(/X402_PAY_TO_ADDRESS is required/);
+  });
+
+  it("federation-scoped boundaries read undefined when federation is disabled (not-applicable, not fail-open)", () => {
+    const cfg = buildRelayConfigFromEnv(MINIMAL_VALID_RELAY_ENV, DEPS);
+    expect(cfg.federation).toBeUndefined();
+    // The registry accessor returns undefined — the effective-config test above
+    // uses a federation-enabled env precisely so these are reachable-and-strict.
+    const discoverSig = SECURITY_BOUNDARY_DEFAULTS.find(
+      (b) => b.envVar === "MOTEBIT_FEDERATION_REQUIRE_DISCOVER_SIGNATURE",
+    );
+    expect(discoverSig?.effectiveValue(cfg)).toBeUndefined();
+  });
+
+  it("passes the runtime deps through untouched (shutdown getter, test vote policy)", () => {
+    const getShuttingDown = (): boolean => true;
+    const cfg = buildRelayConfigFromEnv(MINIMAL_VALID_RELAY_ENV, {
+      getShuttingDown,
+      testVotePolicy: "upheld",
+    });
+    expect(cfg.getShuttingDown).toBe(getShuttingDown);
+    expect(cfg.testVotePolicy).toBe("upheld");
+  });
+});
+
+describe("probeSecurityBoundaries — deployed-behavior layer", () => {
+  it("asserts strict when the running relay returns the strict status", async () => {
+    const fetchImpl = (async () => new Response(null, { status: 403 })) as unknown as typeof fetch;
+    const results = await probeSecurityBoundaries("https://relay.example", {
+      federationEnabled: true,
+      fetchImpl,
+    });
+    const discover = results.find(
+      (r) => r.envVar === "MOTEBIT_FEDERATION_REQUIRE_DISCOVER_SIGNATURE",
+    );
+    expect(discover?.strict).toBe(true);
+    expect(discover?.skipped).toBe(false);
+  });
+
+  it("catches a fail-open relay (strict endpoint returning 200)", async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ agents: [] }), { status: 200 })) as unknown as typeof fetch;
+    const results = await probeSecurityBoundaries("https://relay.example", {
+      federationEnabled: true,
+      fetchImpl,
+    });
+    const discover = results.find(
+      (r) => r.envVar === "MOTEBIT_FEDERATION_REQUIRE_DISCOVER_SIGNATURE",
+    );
+    expect(discover?.strict).toBe(false); // 200 ≠ expected 403 → not strict → the #346 live symptom
+  });
+
+  it("skips federation-scoped probes when federation is disabled (unreachable, not failed)", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("should not be called");
+    }) as unknown as typeof fetch;
+    const results = await probeSecurityBoundaries("https://relay.example", {
+      federationEnabled: false,
+      fetchImpl,
+    });
+    const discover = results.find(
+      (r) => r.envVar === "MOTEBIT_FEDERATION_REQUIRE_DISCOVER_SIGNATURE",
+    );
+    expect(discover?.skipped).toBe(true);
+  });
+});
+
+describe("probeSecurityBoundaries against a REAL booted relay (the capstone: helper × artifact agree)", () => {
+  let relay: SyncRelay | undefined;
+  afterEach(async () => {
+    await relay?.close();
+    relay = undefined;
+  });
+
+  it("a federation-enabled relay built with the strict default rejects the probe → strict", async () => {
+    // Boot an actual relay (the same createSyncRelay the production builder
+    // feeds) with federation enabled and the discover-signature default at its
+    // strict value — then run the SAME probe helper used against prod, routed
+    // to the booted app. This closes the deployed-behavior layer against a
+    // real artifact, not a mock: the harness's three layers (static gate,
+    // effective-config unit, deployed probe) all agree on one registry.
+    relay = await createTestRelay({
+      enableDeviceAuth: false,
+      federation: { endpointUrl: "http://relay.test:3000", displayName: "Probe" },
+    });
+    const app = relay.app;
+    const routed = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : (input as Request).url;
+      const path = url.replace(/^https?:\/\/[^/]+/, "");
+      return app.request(path, init);
+    }) as unknown as typeof fetch;
+
+    const results = await probeSecurityBoundaries("http://relay.test", {
+      federationEnabled: true,
+      fetchImpl: routed,
+    });
+    const discover = results.find(
+      (r) => r.envVar === "MOTEBIT_FEDERATION_REQUIRE_DISCOVER_SIGNATURE",
+    );
+    expect(
+      discover,
+      "discover-signature probe must run against a federation-enabled relay",
+    ).toBeDefined();
+    expect(discover!.skipped).toBe(false);
+    expect(discover!.strict, discover!.detail).toBe(true);
+  });
+
+  it("the SAME relay under an explicit tolerant opt-out fails the probe → not strict (proves the probe discriminates)", async () => {
+    relay = await createTestRelay({
+      enableDeviceAuth: false,
+      federation: {
+        endpointUrl: "http://relay.test:3000",
+        displayName: "Probe",
+        requireDiscoverSignature: false,
+      },
+    });
+    const app = relay.app;
+    const routed = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : (input as Request).url;
+      const path = url.replace(/^https?:\/\/[^/]+/, "");
+      return app.request(path, init);
+    }) as unknown as typeof fetch;
+
+    const results = await probeSecurityBoundaries("http://relay.test", {
+      federationEnabled: true,
+      fetchImpl: routed,
+    });
+    const discover = results.find(
+      (r) => r.envVar === "MOTEBIT_FEDERATION_REQUIRE_DISCOVER_SIGNATURE",
+    );
+    // Tolerant relay accepts the unsigned probe (not 403) → the probe correctly
+    // reports not-strict. This is the exact live symptom #346 had in prod.
+    expect(discover!.strict).toBe(false);
+  });
+});

--- a/services/relay/src/env.ts
+++ b/services/relay/src/env.ts
@@ -9,7 +9,17 @@
  *
  * These helpers centralize the parsing rules so every boolean env var
  * behaves the same way, and the default is explicit in the call site.
+ *
+ * The `env` source is INJECTABLE (default `process.env`) so the config
+ * builder (`relay-config.ts`) can compute EFFECTIVE configuration under an
+ * arbitrary env map — the seam that makes "boot the real config, assert what
+ * the deployed process actually computes" testable (the effective-config
+ * harness closing the #346/#357/#358 shadow-the-constant class). Existing
+ * call sites pass two args and read `process.env` unchanged.
  */
+
+/** The minimal shape of an environment source — `process.env` satisfies it. */
+export type EnvSource = Record<string, string | undefined>;
 
 /**
  * Parse a boolean environment variable with an explicit default.
@@ -25,8 +35,12 @@
  *   const deviceAuth = parseBoolEnv("MOTEBIT_ENABLE_DEVICE_AUTH", true);
  *   const freeze     = parseBoolEnv("MOTEBIT_EMERGENCY_FREEZE", false);
  */
-export function parseBoolEnv(name: string, defaultValue: boolean): boolean {
-  const raw = process.env[name];
+export function parseBoolEnv(
+  name: string,
+  defaultValue: boolean,
+  env: EnvSource = process.env,
+): boolean {
+  const raw = env[name];
   if (raw == null) return defaultValue;
   const normalized = raw.trim().toLowerCase();
   if (normalized === "true" || normalized === "1" || normalized === "yes" || normalized === "on") {
@@ -42,8 +56,12 @@ export function parseBoolEnv(name: string, defaultValue: boolean): boolean {
  * Parse an integer environment variable with a default. Rejects NaN and
  * non-finite values, returning the default instead.
  */
-export function parseIntEnv(name: string, defaultValue: number): number {
-  const raw = process.env[name];
+export function parseIntEnv(
+  name: string,
+  defaultValue: number,
+  env: EnvSource = process.env,
+): number {
+  const raw = env[name];
   if (raw == null) return defaultValue;
   const parsed = parseInt(raw, 10);
   return Number.isFinite(parsed) ? parsed : defaultValue;
@@ -53,8 +71,12 @@ export function parseIntEnv(name: string, defaultValue: number): number {
  * Parse a float environment variable with a default. Rejects NaN and
  * non-finite values.
  */
-export function parseFloatEnv(name: string, defaultValue: number): number {
-  const raw = process.env[name];
+export function parseFloatEnv(
+  name: string,
+  defaultValue: number,
+  env: EnvSource = process.env,
+): number {
+  const raw = env[name];
   if (raw == null) return defaultValue;
   const parsed = parseFloat(raw);
   return Number.isFinite(parsed) ? parsed : defaultValue;

--- a/services/relay/src/index.ts
+++ b/services/relay/src/index.ts
@@ -251,8 +251,13 @@ export interface SyncRelayConfig {
     revocationHorizonIntervalMs?: number;
     /**
      * Require a valid per-hop sender signature on inbound `/federation/v1/discover`
-     * (relay-federation@1.3 §4.1). Default: false (tolerant-reader rollout window).
-     * Mirrors `FederationConfig.requireDiscoverSignature` — passed straight through.
+     * (relay-federation@1.4 §4.1.1). Default: TRUE since the #188 sunset —
+     * `DEFAULT_REQUIRE_DISCOVER_SIGNATURE` (federation.ts) — an unsigned inbound
+     * discover rejects (403). The production boot wires this from that canonical
+     * constant via `buildRelayConfigFromEnv` (relay-config.ts); an operator
+     * peering with a pre-1.3 relay sets `MOTEBIT_FEDERATION_REQUIRE_DISCOVER_SIGNATURE=false`
+     * explicitly (config-restorable opt-out). Passed straight through to
+     * `FederationConfig.requireDiscoverSignature`.
      */
     requireDiscoverSignature?: boolean;
   };

--- a/services/relay/src/relay-config.ts
+++ b/services/relay/src/relay-config.ts
@@ -1,0 +1,309 @@
+/**
+ * Effective relay configuration — the pure env → config seam.
+ *
+ * WHY THIS EXISTS. Three production incidents in one week
+ * (#346 the discover-signature sunset shipped inert because `server.ts`
+ * hard-coded the tolerant default and shadowed the canonical constant;
+ * #357 signing keys never reached deployed molecules; #358 a produced
+ * transcript was lost before egress) share ONE root: a security control is
+ * implemented and unit-tested at the source layer while the DEPLOYMENT
+ * WIRING neutralizes it, and the test asserts the source layer, so CI is
+ * green while the shipped binary is fail-open. Nothing exercised the
+ * EFFECTIVE configuration the deployed process actually computes.
+ *
+ * The fix is single-source-of-truth + testability of the real thing:
+ *
+ *   1. `buildRelayConfigFromEnv(env, deps)` — a PURE function that turns an
+ *      injected env map into the exact `SyncRelayConfig` the production boot
+ *      passes to `createSyncRelay`. `server.ts` calls it with `process.env`;
+ *      tests call it with arbitrary env maps and assert the computed result.
+ *      This is what makes "boot the real config, assert what the deployed
+ *      process computes" a unit test — a test on the constant becomes a test
+ *      on production.
+ *
+ *   2. `SECURITY_BOUNDARY_DEFAULTS` — the enumerable registry of every
+ *      config field that IS a security boundary, each carrying its canonical
+ *      safe-when-unset value, an accessor that reads its EFFECTIVE value from
+ *      a built config, and (where observable) a black-box probe descriptor.
+ *      One registry, three enforcement layers bind to it: the static gate
+ *      (`check-security-default-wiring`), the effective-config unit test
+ *      (`relay-config.test.ts`), and the deployed black-box probe
+ *      (`probeSecurityBoundaries`). A new boundary is one registry entry,
+ *      auto-covered at all three layers.
+ *
+ * The parse helpers (`env.ts`) take an injectable `env` (default
+ * `process.env`) so this builder is pure over its input.
+ */
+
+import type { SyncRelayConfig, X402Config, ShutdownStateGetter } from "./index.js";
+import { parseBoolEnv, parseIntEnv, parseFloatEnv, type EnvSource } from "./env.js";
+import { DEFAULT_REQUIRE_DISCOVER_SIGNATURE } from "./federation.js";
+
+/**
+ * Runtime-only config pieces the pure env builder cannot produce — closures
+ * and already-validated values the boot entry computes with side effects
+ * (shutdown state, the staging-only vote policy). Injected explicitly so the
+ * env → config portion stays pure and testable.
+ */
+export interface RelayConfigRuntimeDeps {
+  getShuttingDown: ShutdownStateGetter;
+  testVotePolicy?: "upheld" | "overturned" | "split";
+}
+
+/**
+ * Build the production relay config from an env source. PURE: no I/O, no
+ * `process.env` read (all env access flows through the injected `env`), no
+ * port binding. `server.ts` is the only production caller; the effective-
+ * config test drives it with crafted env maps.
+ *
+ * Throws `X402ConfigError`-shaped `Error` when the required
+ * `X402_PAY_TO_ADDRESS` is absent — the one config-validation invariant that
+ * belongs in the pure builder (every task settlement flows through x402).
+ */
+export function buildRelayConfigFromEnv(
+  env: EnvSource,
+  deps: RelayConfigRuntimeDeps,
+): SyncRelayConfig {
+  if (env.X402_PAY_TO_ADDRESS == null || env.X402_PAY_TO_ADDRESS === "") {
+    throw new Error("X402_PAY_TO_ADDRESS is required. Set it to the platform USDC wallet address.");
+  }
+  const x402: X402Config = {
+    payToAddress: env.X402_PAY_TO_ADDRESS,
+    network: env.X402_NETWORK ?? "eip155:84532",
+    facilitatorUrl: env.X402_FACILITATOR_URL,
+    testnet: env.X402_TESTNET !== "false",
+  };
+
+  return {
+    dbPath: env.MOTEBIT_DB_PATH,
+    apiToken: env.MOTEBIT_API_TOKEN,
+    corsOrigin: env.MOTEBIT_CORS_ORIGIN,
+    // Opt-out boolean (device auth): safe default ON — an operator disables it
+    // explicitly. A shadowing literal here would silently drop device-token
+    // verification, so it is a registered security boundary.
+    enableDeviceAuth: parseBoolEnv("MOTEBIT_ENABLE_DEVICE_AUTH", true, env),
+    emergencyFreeze: parseBoolEnv("MOTEBIT_EMERGENCY_FREEZE", false, env),
+    getShuttingDown: deps.getShuttingDown,
+    x402,
+    relayKeyPassphrase: env.MOTEBIT_RELAY_KEY_PASSPHRASE,
+    platformFeeRate: parseFloatEnv("MOTEBIT_PLATFORM_FEE_RATE", 0.05, env),
+    federation: env.MOTEBIT_FEDERATION_ENDPOINT_URL
+      ? {
+          endpointUrl: env.MOTEBIT_FEDERATION_ENDPOINT_URL,
+          displayName: env.MOTEBIT_FEDERATION_DISPLAY_NAME,
+          enabled: parseBoolEnv("MOTEBIT_FEDERATION_ENABLED", true, env),
+          maxPeers: env.MOTEBIT_FEDERATION_MAX_PEERS
+            ? parseIntEnv("MOTEBIT_FEDERATION_MAX_PEERS", 50, env)
+            : undefined,
+          // Anti-sybil safe default: do NOT auto-accept peering proposals.
+          autoAcceptPeers: parseBoolEnv("MOTEBIT_FEDERATION_AUTO_ACCEPT", false, env),
+          // Strict per-hop discover signing. The default is the canonical
+          // constant (flipped strict by the #188 sunset), never a literal —
+          // that shadowing is exactly what made #346 inert in production.
+          requireDiscoverSignature: parseBoolEnv(
+            "MOTEBIT_FEDERATION_REQUIRE_DISCOVER_SIGNATURE",
+            DEFAULT_REQUIRE_DISCOVER_SIGNATURE,
+            env,
+          ),
+          allowedPeers: env.MOTEBIT_FEDERATION_ALLOWED_PEERS
+            ? env.MOTEBIT_FEDERATION_ALLOWED_PEERS.split(",").map((s) => s.trim())
+            : undefined,
+          blockedPeers: env.MOTEBIT_FEDERATION_BLOCKED_PEERS
+            ? env.MOTEBIT_FEDERATION_BLOCKED_PEERS.split(",").map((s) => s.trim())
+            : undefined,
+        }
+      : undefined,
+    stripe:
+      env.STRIPE_SECRET_KEY && env.STRIPE_WEBHOOK_SECRET
+        ? {
+            secretKey: env.STRIPE_SECRET_KEY,
+            webhookSecret: env.STRIPE_WEBHOOK_SECRET,
+            currency: env.STRIPE_CURRENCY,
+          }
+        : undefined,
+    bridge: env.BRIDGE_API_KEY
+      ? {
+          apiKey: env.BRIDGE_API_KEY,
+          customerId: env.BRIDGE_CUSTOMER_ID,
+          sourcePaymentRail: env.BRIDGE_SOURCE_RAIL,
+          sourceCurrency: env.BRIDGE_SOURCE_CURRENCY,
+          baseUrl: env.BRIDGE_API_BASE_URL,
+          webhookPublicKey: env.BRIDGE_WEBHOOK_PUBLIC_KEY,
+        }
+      : undefined,
+    testVotePolicy: deps.testVotePolicy,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Security-boundary registry — the single source of truth the static gate,
+// the effective-config test, and the black-box probe all bind to.
+// ---------------------------------------------------------------------------
+
+/**
+ * A black-box probe descriptor: how to assert, against a RUNNING relay, that
+ * a boundary is in its strict posture — the deployed-behavior layer that
+ * catches what neither source-scan nor unit-config can (a build/wiring/env
+ * divergence between the tested config and the shipped artifact).
+ */
+export interface SecurityBoundaryProbe {
+  method: "GET" | "POST";
+  path: string;
+  /** JSON body for POST probes. */
+  body?: unknown;
+  /** HTTP status the endpoint MUST return when the boundary is strict. */
+  expectStatusWhenStrict: number;
+  /**
+   * When the boundary lives under `federation`, the probe only means anything
+   * on a federation-enabled relay. `true` ⇒ skip the probe when federation is
+   * disabled (the boundary is unreachable, not fail-open).
+   */
+  requiresFederation?: boolean;
+}
+
+/** A config field that is a security boundary — enumerable, three-layer-enforced. */
+export interface SecurityBoundaryDefault {
+  /** Human-readable boundary name (for messages). */
+  boundary: string;
+  /** The env var that overrides the default. */
+  envVar: string;
+  /**
+   * The canonical name of the constant that supplies the default, when the
+   * default is a named constant rather than an inline literal. The static
+   * gate asserts `server.ts`/the builder references THIS symbol (not a
+   * shadowing literal). `null` when the safe default is an inline literal the
+   * builder owns directly (e.g. auto-accept `false`, device-auth `true`).
+   */
+  canonicalConstant: string | null;
+  /** The safe value the effective config MUST carry when the env var is unset. */
+  strictWhenUnset: boolean;
+  /**
+   * Read the EFFECTIVE value of this boundary from a built config. `undefined`
+   * means the boundary is not present in this config shape (e.g. federation
+   * disabled) — the test treats that as not-applicable, never a pass.
+   */
+  effectiveValue: (cfg: SyncRelayConfig) => boolean | undefined;
+  /** Optional deployed-behavior probe. */
+  probe?: SecurityBoundaryProbe;
+}
+
+export const SECURITY_BOUNDARY_DEFAULTS: readonly SecurityBoundaryDefault[] = [
+  {
+    boundary: "federation per-hop discover signing (cross-org trust boundary; #188 sunset)",
+    envVar: "MOTEBIT_FEDERATION_REQUIRE_DISCOVER_SIGNATURE",
+    canonicalConstant: "DEFAULT_REQUIRE_DISCOVER_SIGNATURE",
+    strictWhenUnset: true,
+    effectiveValue: (cfg) => cfg.federation?.requireDiscoverSignature,
+    probe: {
+      method: "POST",
+      path: "/federation/v1/discover",
+      body: {
+        query: { capability: "web_search" },
+        hop_count: 0,
+        max_hops: 1,
+        visited: [],
+        query_id: "security-probe-unsigned",
+        origin_relay: "security-probe",
+      },
+      expectStatusWhenStrict: 403,
+      requiresFederation: true,
+    },
+  },
+  {
+    boundary: "per-device token authentication",
+    envVar: "MOTEBIT_ENABLE_DEVICE_AUTH",
+    canonicalConstant: null,
+    strictWhenUnset: true,
+    effectiveValue: (cfg) => cfg.enableDeviceAuth,
+  },
+  {
+    boundary: "federation auto-accept peering (anti-sybil: never auto-admit peers)",
+    envVar: "MOTEBIT_FEDERATION_AUTO_ACCEPT",
+    canonicalConstant: null,
+    // Safe default is FALSE — the boundary is "strict" when auto-accept is off.
+    strictWhenUnset: false,
+    effectiveValue: (cfg) => cfg.federation?.autoAcceptPeers,
+  },
+];
+
+/**
+ * The minimal env a valid relay config requires (x402 pay-to). Exposed so the
+ * effective-config test builds a realistic baseline before permuting the
+ * security env vars around it.
+ */
+export const MINIMAL_VALID_RELAY_ENV: EnvSource = {
+  X402_PAY_TO_ADDRESS: "0x0000000000000000000000000000000000000000",
+};
+
+/**
+ * Probe a RUNNING relay's security boundaries (deployed-behavior layer).
+ * Returns one result per applicable boundary. `federationEnabled` gates the
+ * federation-scoped probes (an unreachable boundary is skipped, not failed).
+ * Pure over an injected `fetchImpl` so it is drivable in tests and against
+ * prod alike.
+ */
+export async function probeSecurityBoundaries(
+  baseUrl: string,
+  opts: {
+    federationEnabled: boolean;
+    fetchImpl?: typeof fetch;
+  },
+): Promise<
+  Array<{
+    boundary: string;
+    envVar: string;
+    skipped: boolean;
+    strict: boolean;
+    detail: string;
+  }>
+> {
+  const doFetch = opts.fetchImpl ?? fetch;
+  const results: Array<{
+    boundary: string;
+    envVar: string;
+    skipped: boolean;
+    strict: boolean;
+    detail: string;
+  }> = [];
+  for (const b of SECURITY_BOUNDARY_DEFAULTS) {
+    if (b.probe == null) continue;
+    if (b.probe.requiresFederation && !opts.federationEnabled) {
+      results.push({
+        boundary: b.boundary,
+        envVar: b.envVar,
+        skipped: true,
+        strict: false,
+        detail: "federation disabled — boundary unreachable, probe skipped",
+      });
+      continue;
+    }
+    const url = `${baseUrl.replace(/\/$/, "")}${b.probe.path}`;
+    let status: number;
+    try {
+      const resp = await doFetch(url, {
+        method: b.probe.method,
+        headers: { "Content-Type": "application/json" },
+        ...(b.probe.body != null ? { body: JSON.stringify(b.probe.body) } : {}),
+      });
+      status = resp.status;
+    } catch (err) {
+      results.push({
+        boundary: b.boundary,
+        envVar: b.envVar,
+        skipped: false,
+        strict: false,
+        detail: `probe request failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      continue;
+    }
+    const strict = status === b.probe.expectStatusWhenStrict;
+    results.push({
+      boundary: b.boundary,
+      envVar: b.envVar,
+      skipped: false,
+      strict,
+      detail: `${b.probe.method} ${b.probe.path} → ${status} (strict expects ${b.probe.expectStatusWhenStrict})`,
+    });
+  }
+  return results;
+}

--- a/services/relay/src/server.ts
+++ b/services/relay/src/server.ts
@@ -21,10 +21,9 @@
 import { serve } from "@hono/node-server";
 import type { Hono } from "hono";
 import { createSyncRelay } from "./index.js";
-import type { X402Config } from "./index.js";
 import { createLogger } from "./logger.js";
-import { parseBoolEnv, parseIntEnv, parseFloatEnv } from "./env.js";
-import { DEFAULT_REQUIRE_DISCOVER_SIGNATURE } from "./federation.js";
+import { parseBoolEnv } from "./env.js";
+import { buildRelayConfigFromEnv } from "./relay-config.js";
 
 if (process.env.NODE_ENV === "production" && !process.env.MOTEBIT_DB_PATH) {
   createLogger({ service: "relay" }).error("relay.fatal", {
@@ -32,16 +31,6 @@ if (process.env.NODE_ENV === "production" && !process.env.MOTEBIT_DB_PATH) {
   });
   process.exit(1);
 }
-// x402 payment layer: required — every task settlement flows through x402
-if (!process.env.X402_PAY_TO_ADDRESS) {
-  throw new Error("X402_PAY_TO_ADDRESS is required. Set it to the platform USDC wallet address.");
-}
-const x402Env: X402Config = {
-  payToAddress: process.env.X402_PAY_TO_ADDRESS,
-  network: process.env.X402_NETWORK ?? "eip155:84532",
-  facilitatorUrl: process.env.X402_FACILITATOR_URL,
-  testnet: process.env.X402_TESTNET !== "false",
-};
 
 // --- Shutdown state (shared with health check via config) ---
 let shuttingDown = false;
@@ -82,78 +71,18 @@ if (testVotePolicyRaw !== undefined) {
   }
 }
 
-const relay = await createSyncRelay({
-  dbPath: process.env.MOTEBIT_DB_PATH,
-  apiToken: process.env.MOTEBIT_API_TOKEN,
-  corsOrigin: process.env.MOTEBIT_CORS_ORIGIN,
-  // Opt-out booleans: default on, explicit "false" to disable.
-  enableDeviceAuth: parseBoolEnv("MOTEBIT_ENABLE_DEVICE_AUTH", true),
-  // Opt-in boolean: default off, explicit "true" to enable.
-  emergencyFreeze: parseBoolEnv("MOTEBIT_EMERGENCY_FREEZE", false),
-  getShuttingDown: () => shuttingDown,
-  x402: x402Env,
-  // Relay identity encryption passphrase. Read from env once, here, into
-  // the config object — no more direct process.env access downstream.
-  relayKeyPassphrase: process.env.MOTEBIT_RELAY_KEY_PASSPHRASE,
-  platformFeeRate: parseFloatEnv("MOTEBIT_PLATFORM_FEE_RATE", 0.05),
-  federation: process.env.MOTEBIT_FEDERATION_ENDPOINT_URL
-    ? {
-        endpointUrl: process.env.MOTEBIT_FEDERATION_ENDPOINT_URL,
-        displayName: process.env.MOTEBIT_FEDERATION_DISPLAY_NAME,
-        enabled: parseBoolEnv("MOTEBIT_FEDERATION_ENABLED", true),
-        maxPeers: process.env.MOTEBIT_FEDERATION_MAX_PEERS
-          ? parseIntEnv("MOTEBIT_FEDERATION_MAX_PEERS", 50)
-          : undefined,
-        autoAcceptPeers: parseBoolEnv("MOTEBIT_FEDERATION_AUTO_ACCEPT", false),
-        // Strict per-hop discover signing. The DEFAULT lives in ONE place —
-        // `DEFAULT_REQUIRE_DISCOVER_SIGNATURE` (federation.ts) — which the
-        // #188 sunset flipped to `true` for relay-federation@1.4. Using the
-        // constant as the env fallback (never a hard-coded literal) is what
-        // makes the sunset actually govern the shipped relay: a literal here
-        // shadowed the constant, so #346 was a no-op in production (the
-        // `?? DEFAULT` in federation.ts is dead when the config carries a
-        // concrete boolean). An operator peering with a pre-1.3 relay that
-        // still sends unsigned discovers sets the env var to `false`
-        // explicitly — an owned, config-restorable opt-out (spec §4.1.1).
-        requireDiscoverSignature: parseBoolEnv(
-          "MOTEBIT_FEDERATION_REQUIRE_DISCOVER_SIGNATURE",
-          DEFAULT_REQUIRE_DISCOVER_SIGNATURE,
-        ),
-        allowedPeers: process.env.MOTEBIT_FEDERATION_ALLOWED_PEERS
-          ? process.env.MOTEBIT_FEDERATION_ALLOWED_PEERS.split(",").map((s) => s.trim())
-          : undefined,
-        blockedPeers: process.env.MOTEBIT_FEDERATION_BLOCKED_PEERS
-          ? process.env.MOTEBIT_FEDERATION_BLOCKED_PEERS.split(",").map((s) => s.trim())
-          : undefined,
-      }
-    : undefined,
-  stripe:
-    process.env.STRIPE_SECRET_KEY && process.env.STRIPE_WEBHOOK_SECRET
-      ? {
-          secretKey: process.env.STRIPE_SECRET_KEY,
-          webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
-          currency: process.env.STRIPE_CURRENCY,
-        }
-      : undefined,
-  // BRIDGE_API_KEY alone enables the Path-3 user-initiated off-ramp
-  // (BridgeOfframpAdapter — user is the KYC'd customer, customer ID is
-  // per-request). BRIDGE_CUSTOMER_ID additionally registers the
-  // BridgeSettlementRail for own-account treasury operations (motebit
-  // operator's Bridge customer ID; required only by the future
-  // convertOwnAccount treasury method). The two surfaces have distinct
-  // scopes; they shouldn't share a gating predicate.
-  bridge: process.env.BRIDGE_API_KEY
-    ? {
-        apiKey: process.env.BRIDGE_API_KEY,
-        customerId: process.env.BRIDGE_CUSTOMER_ID,
-        sourcePaymentRail: process.env.BRIDGE_SOURCE_RAIL,
-        sourceCurrency: process.env.BRIDGE_SOURCE_CURRENCY,
-        baseUrl: process.env.BRIDGE_API_BASE_URL,
-        webhookPublicKey: process.env.BRIDGE_WEBHOOK_PUBLIC_KEY,
-      }
-    : undefined,
-  testVotePolicy,
-});
+// The entire env → config computation lives in the pure
+// `buildRelayConfigFromEnv` (relay-config.ts) so the EFFECTIVE configuration
+// the deployed process computes is unit-testable under arbitrary env maps —
+// the seam that closes the #346/#357/#358 shadow-the-constant class (a test
+// on the constant is now a test on production). The boot entry supplies only
+// the runtime closures the pure builder cannot produce.
+const relay = await createSyncRelay(
+  buildRelayConfigFromEnv(process.env, {
+    getShuttingDown: () => shuttingDown,
+    testVotePolicy,
+  }),
+);
 const app: Hono = relay.app;
 
 const port = Number(process.env.PORT ?? 3000);


### PR DESCRIPTION
The systemic remediation for the three composition failures in one week (#346 sunset inert, #357 dormant keys, #358 lost threading). They share one root: a security control is implemented and unit-tested at the source layer while the **deployment wiring** neutralizes it, and the test asserts the source layer — CI green, shipped binary fail-open. Nothing exercised the **effective configuration** the deployed process computes. A per-incident static gate only tripwires one syntactic form of the class (external critique, correct).

## One registry, three enforcement layers

- **`buildRelayConfigFromEnv(env, deps)`** (`relay-config.ts`) — the pure env→config builder `server.ts` now calls. All env access flows through an injected env (the `env.ts` parse helpers gained an injectable source, default `process.env`), so the config the deployed process computes is unit-testable under arbitrary env maps — **a test on the constant becomes a test on production.** `server.ts` drops ~70 lines of inline construction to one builder call + runtime closures.
- **`SECURITY_BOUNDARY_DEFAULTS`** — the enumerable registry of every config field that IS a security boundary (discover-signature strict, device-auth on, federation auto-accept off), each with its safe-when-unset value, an effective-value accessor, and an optional black-box probe descriptor. A new boundary is one entry, auto-covered at all three layers.
- **Three layers bind to it:** (1) static gate `check-security-default-wiring` (repointed to the builder, fast tripwire); (2) the effective-config unit test — boots the real builder, asserts computed values, **proven to catch the #346 regression** (perturbing the constant to a literal fails the test with the exact fail-open symptom); (3) `probeSecurityBoundaries` deployed-behavior probe, **capstone-tested against a REAL booted relay** (strict relay → probe strict; tolerant relay → probe not-strict) and reusable against prod.

Also fixes a stale claim-vs-code doc (`SyncRelayConfig.requireDiscoverSignature` still said "Default: false, tolerant") and teaches `check-deploy-parity` the injected-env read pattern.

Relay 1454 tests green; 147/147 gates proven effective; extraction behavior-preserving (federation suite 79 green). This is the "test the artifact / effective config, not the module" layer the external audit flagged as our weakest — now covered, and the reusable probe is the seed of the deployed black-box testing the paid audit will exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)