### PR TITLE
fix(relay): close bond-signal forgery — federation laundering, zero-capital mint, malformed-hop override

### DIFF
--- a/services/relay/src/__tests__/discover-marketplace.test.ts
+++ b/services/relay/src/__tests__/discover-marketplace.test.ts
@@ -11,7 +11,7 @@
  * another's. Anonymous discover (no caller) returns identity + capabilities +
  * pricing only — public marketplace data, private trust kept private.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { SyncRelay } from "../index.js";
 import { generateKeypair, bytesToHex } from "@motebit/encryption";
 import { AUTH_HEADER, createTestRelay } from "./test-helpers.js";
@@ -20,6 +20,7 @@ import {
   enrichWithHardwareAttestation,
   enrichWithLatencyStats,
   enrichWithBondStatus,
+  sanitizePeerAgent,
 } from "../agents.js";
 
 interface DiscoveredAgent {
@@ -592,9 +593,12 @@ describe("GET /api/v1/agents/discover — marketplace enrichment", () => {
       motebit_id: string;
       backing_state?: "pending" | "backed" | "underbacked";
       expires_at?: number;
+      /** Committed amount in micro-USDC. Default 5_000_000 (above the signal floor). */
+      bond_amount_micro?: number;
     },
   ): void {
     const now = Date.now();
+    const amount = opts.bond_amount_micro ?? 5_000_000;
     db.prepare(
       `INSERT INTO relay_bond_commitments
         (bond_id, motebit_id, bonded_address, bonded_public_key, bond_amount_micro,
@@ -606,7 +610,7 @@ describe("GET /api/v1/agents/discover — marketplace enrichment", () => {
       opts.motebit_id,
       "BondAddr1111111111111111111111111111111111",
       "aa".repeat(32),
-      5_000_000,
+      amount,
       "usdc",
       "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
       now,
@@ -615,7 +619,7 @@ describe("GET /api/v1/agents/discover — marketplace enrichment", () => {
       "sig",
       "{}",
       opts.backing_state ?? "pending",
-      opts.backing_state === "backed" ? 5_000_000 : null,
+      opts.backing_state === "backed" ? amount : null,
       opts.backing_state != null && opts.backing_state !== "pending" ? now : null,
       now,
     );
@@ -663,14 +667,175 @@ describe("GET /api/v1/agents/discover — marketplace enrichment", () => {
     }
   });
 
-  it("enrichWithBondStatus preserves peer-provided bonded on federated agents", () => {
-    // Same federation-passthrough rule as the HA + latency enrichers: the
-    // home relay's bond table is authoritative for agents that bonded there.
+  it("enrichWithBondStatus STRIPS peer-provided bonded — a federated peer cannot mint the signal (laundering fix)", () => {
+    // A bond is an onchain fact only THIS relay's RPC verifier may assert; a
+    // peer forwarding an agent cannot vouch that it is bonded (rule 6). An
+    // inbound `bonded: true` on an agent with no local backed bond row must be
+    // stripped, never re-published. Regression for the HIGH federation-
+    // laundering finding — this test previously asserted the vulnerable
+    // "preserves peer-provided bonded" behavior.
     const enriched = enrichWithBondStatus(
       [{ motebit_id: "fed-bonded-agent", capabilities: ["x"], bonded: true } as EnricherInput],
       relay.moteDb.db,
     );
-    expect(enriched[0]!.bonded).toBe(true);
+    expect(enriched[0]!.bonded).toBeUndefined();
+  });
+
+  it("enrichWithBondStatus attaches NOTHING for a sub-floor (near-zero) bond — zero-capital sybil signal is closed", async () => {
+    const kp = await generateKeypair();
+    await registerAgent(relay, "dust-bond-agent", bytesToHex(kp.publicKey));
+    insertBond(relay.moteDb.db, {
+      bond_id: "bond-dust",
+      motebit_id: "dust-bond-agent",
+      backing_state: "backed",
+      bond_amount_micro: 1, // a signed, address-bound, backed — but 0.000001 USDC
+    });
+    const res = await relay.app.request("/api/v1/agents/discover");
+    const { agents } = (await res.json()) as { agents: DiscoveredAgent[] };
+    const target = agents.find((a) => a.motebit_id === "dust-bond-agent");
+    expect(target).toBeDefined();
+    expect(target!.bonded).toBeUndefined();
+  });
+
+  it("sanitizePeerAgent strips relay-attested fields on a valid record; DROPS a forged low hop_distance", () => {
+    // A valid multi-hop record: bonded stripped, the rest passes through.
+    const cleaned = sanitizePeerAgent({
+      motebit_id: "peer-agent",
+      bonded: true,
+      hop_distance: 2,
+      settlement_address: "PeerOwnAddr",
+    });
+    expect(cleaned).not.toBeNull();
+    expect(cleaned!.bonded).toBeUndefined();
+    expect(cleaned!.hop_distance).toBe(2);
+    expect(cleaned!.settlement_address).toBe("PeerOwnAddr");
+
+    // A forged hop_distance -1 (bid to override a local hop-0 record) is DROPPED,
+    // never normalized to a winning 1.
+    expect(sanitizePeerAgent({ motebit_id: "victim", bonded: true, hop_distance: -1 })).toBeNull();
+  });
+
+  it("sanitizePeerAgent DROPS (never normalizes) any protocol-invalid hop_distance — the remote-vs-remote fix", () => {
+    // Honest values in [1, MAX] pass through unchanged.
+    expect(sanitizePeerAgent({ motebit_id: "x", hop_distance: 1 })!.hop_distance).toBe(1);
+    expect(sanitizePeerAgent({ motebit_id: "x", hop_distance: 3 })!.hop_distance).toBe(3);
+    // Everything else is dropped — NOT normalized to an advantageous 1, which
+    // would let a forgery outrank an honest distance-2/3 record.
+    expect(sanitizePeerAgent({ motebit_id: "x" })).toBeNull(); // missing
+    expect(sanitizePeerAgent({ motebit_id: "x", hop_distance: 0 })).toBeNull();
+    expect(sanitizePeerAgent({ motebit_id: "x", hop_distance: -1 })).toBeNull();
+    expect(sanitizePeerAgent({ motebit_id: "x", hop_distance: 1.9 })).toBeNull(); // float
+    expect(sanitizePeerAgent({ motebit_id: "x", hop_distance: "1" })).toBeNull(); // string
+    expect(sanitizePeerAgent({ motebit_id: "x", hop_distance: 999 })).toBeNull(); // out of range
+  });
+
+  it("END-TO-END: a malicious peer cannot override a local record's routing or launder its bond (collision attack)", async () => {
+    // The real security invariant (not just "the sanitizer removed a field"): a
+    // federated peer that forges a LOCAL agent's motebit_id — with bonded:true,
+    // a forged low hop_distance, and an ATTACKER settlement_address — cannot win
+    // the lowest-hop-wins merge, cannot redirect the agent's settlement, and
+    // cannot mint its bond signal. Exercises the full discover handler + merge,
+    // not the sanitizer in isolation.
+    const kp = await generateKeypair();
+    await registerAgent(relay, "collision-target", bytesToHex(kp.publicKey));
+
+    // An active peer so the handler fans out.
+    relay.moteDb.db
+      .prepare(
+        "INSERT INTO relay_peers (peer_relay_id, public_key, endpoint_url, state) VALUES (?, ?, ?, 'active')",
+      )
+      .run("evil-peer", "bb".repeat(32), "http://evil-peer.test");
+
+    // The malicious peer returns a forged record colliding with the local id.
+    const forged = {
+      motebit_id: "collision-target",
+      bonded: true,
+      hop_distance: -1,
+      settlement_address: "AttackerAddr9999999999999999999999999999999",
+      source_relay: "evil-peer",
+      capabilities: ["web_search"],
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) =>
+        url.includes("/federation/v1/discover")
+          ? new Response(JSON.stringify({ agents: [forged] }), { status: 200 })
+          : new Response("not found", { status: 404 }),
+      ),
+    );
+    try {
+      const res = await relay.app.request("/api/v1/agents/discover");
+      const { agents } = (await res.json()) as {
+        agents: Array<Record<string, unknown> & { motebit_id: string }>;
+      };
+      const target = agents.find((a) => a.motebit_id === "collision-target");
+      expect(target).toBeDefined();
+      // Bond signal NOT laundered.
+      expect(target!.bonded).toBeUndefined();
+      // Local record won the merge (hop_distance 0), attacker's forged record
+      // (hop_distance -1) was dropped as protocol-invalid.
+      expect(target!.hop_distance).toBe(0);
+      // Settlement routing NOT redirected to the attacker.
+      expect(target!.settlement_address).not.toBe("AttackerAddr9999999999999999999999999999999");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("END-TO-END remote-vs-remote: a malicious peer's malformed-hop forgery cannot outrank an honest peer's record", async () => {
+    // The residual attack the earlier local-collision test could NOT prove: two
+    // peers serving the SAME non-local identity. The honest peer reports it at a
+    // valid distance 2 with its real settlement address; the malicious peer
+    // reports the same id with a forged hop_distance (protocol-invalid) and an
+    // attacker settlement address. The malformed record must be DROPPED so it
+    // cannot win the lowest-hop-wins merge and redirect settlement.
+    for (const [id, url] of [
+      ["honest-peer", "http://honest-peer.test"],
+      ["evil-peer", "http://evil-peer.test"],
+    ] as const) {
+      relay.moteDb.db
+        .prepare(
+          "INSERT INTO relay_peers (peer_relay_id, public_key, endpoint_url, state) VALUES (?, ?, ?, 'active')",
+        )
+        .run(id, "cc".repeat(32), url);
+    }
+    const honestRecord = {
+      motebit_id: "remote-identity",
+      hop_distance: 2,
+      settlement_address: "HonestRemoteAddr1111111111111111111111111111",
+      source_relay: "honest-peer",
+      capabilities: ["web_search"],
+    };
+    const forgedRecord = {
+      motebit_id: "remote-identity",
+      hop_distance: 0, // protocol-invalid → dropped (would else normalize to a winning 1)
+      settlement_address: "AttackerAddr9999999999999999999999999999999",
+      source_relay: "evil-peer",
+      capabilities: ["web_search"],
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.startsWith("http://honest-peer.test"))
+          return new Response(JSON.stringify({ agents: [honestRecord] }), { status: 200 });
+        if (url.startsWith("http://evil-peer.test"))
+          return new Response(JSON.stringify({ agents: [forgedRecord] }), { status: 200 });
+        return new Response("not found", { status: 404 });
+      }),
+    );
+    try {
+      const res = await relay.app.request("/api/v1/agents/discover");
+      const { agents } = (await res.json()) as {
+        agents: Array<Record<string, unknown> & { motebit_id: string }>;
+      };
+      const target = agents.find((a) => a.motebit_id === "remote-identity");
+      expect(target).toBeDefined();
+      // The honest record won; the attacker's malformed forgery was dropped.
+      expect(target!.settlement_address).toBe("HonestRemoteAddr1111111111111111111111111111");
+      expect(target!.settlement_address).not.toBe("AttackerAddr9999999999999999999999999999999");
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("enrichWithBondStatus attaches nothing for agents with no bond row", () => {

--- a/services/relay/src/agents.ts
+++ b/services/relay/src/agents.ts
@@ -16,6 +16,66 @@ import type { RelayIdentity } from "./federation.js";
 import { insertRevocationEvent, signDiscoverBody } from "./federation.js";
 import type { TaskRouter } from "./task-routing.js";
 import { evaluateSettlementEligibility } from "./task-routing.js";
+import { REFERENCE_MIN_BONDED_SIGNAL_MICRO } from "./bond-store.js";
+
+/**
+ * Fields the ORIGIN relay computes itself and MUST NOT accept from a federated
+ * peer — a peer that forwards agents cannot mint these signals about them
+ * (rule 6: the relay re-publishes only what it independently verifies). `bonded`
+ * is RPC-verified locally by `enrichWithBondStatus`; `hardware_attestation`
+ * and `latency_stats` have their own passthrough discipline (a peer's local
+ * view of ITS agents is authoritative for those), so only `bonded` is stripped.
+ */
+const RELAY_ATTESTED_PEER_FIELDS = ["bonded"] as const;
+
+/**
+ * Upper sanity bound on a peer-asserted `hop_distance`. The mesh caps
+ * traversal at `max_hops = 3`, so an honest `hop_count + 1` never exceeds 4;
+ * 8 is generous headroom. A value outside `[1, MAX]` is protocol-invalid.
+ */
+const MAX_PEER_HOP_DISTANCE = 8;
+
+/**
+ * Sanitize an agent record received from a federated peer before it enters the
+ * merge, or DROP it (`null`) if protocol-invalid. (1) Strip relay-attested
+ * fields the peer cannot vouch for (the federation-laundering fix).
+ * (2) Validate `hop_distance` is a safe integer in `[1, MAX_PEER_HOP_DISTANCE]`
+ * — a genuine peer returns `hop_count + 1` in that range (federation.ts), so an
+ * honest value passes through unchanged. A missing / non-integer / out-of-range
+ * / non-number value is protocol-invalid and the record is DROPPED, NOT
+ * normalized: normalizing a forgery to the minimum distance (1) would let it
+ * outrank an honest distant record (distance 2/3) in the lowest-hop-wins merge
+ * and thereby redirect that identity's settlement_address (the remote-vs-remote
+ * manipulation). Dropping is fail-closed and cannot beat any honest record.
+ *
+ * KNOWN LIMITATION — NOT closed by this function, flagged for the specialist
+ * review as potentially EXISTENTIAL, not ordinary hardening: a malicious DIRECT
+ * peer can assert a VALID-but-lying low hop_distance (claim `1`) for a NON-local
+ * identity that an honest peer serves further away, winning the merge with a
+ * forged settlement_address. hop_distance is peer-asserted and unverifiable;
+ * the real fix is binding settlement_address cryptographically to the agent's
+ * succession key / signed manifest so a relay TRANSPORTS the address but never
+ * CREATES its authority by returning JSON. This function closes the LOCAL
+ * collision (local always wins) and the MALFORMED-hop vector; the crypto-
+ * binding of settlement authority is deferred (docs/security/external-audit-scope.md).
+ * (Also deferred: portable remote-bond EVIDENCE a receiver re-verifies — the
+ * wire carries no bond evidence today, so dropping the boolean is
+ * conservative-correct, not a regression.)
+ */
+export function sanitizePeerAgent(agent: Record<string, unknown>): Record<string, unknown> | null {
+  const raw = agent.hop_distance;
+  if (!(
+    typeof raw === "number" &&
+    Number.isSafeInteger(raw) &&
+    raw >= 1 &&
+    raw <= MAX_PEER_HOP_DISTANCE
+  )) {
+    return null; // protocol-invalid hop_distance — drop, never normalize
+  }
+  const clean: Record<string, unknown> = { ...agent };
+  for (const f of RELAY_ATTESTED_PEER_FIELDS) delete clean[f];
+  return clean;
+}
 import {
   hexPublicKeyToDidKey,
   verifyKeySuccession,
@@ -274,14 +334,24 @@ export function enrichWithBondStatus<T extends Record<string, unknown> & { moteb
          FROM relay_bond_commitments
         WHERE motebit_id IN (${placeholders})
           AND expires_at > ?
-          AND backing_state = 'backed'`,
+          AND backing_state = 'backed'
+          AND bond_amount_micro >= ?`,
     )
-    .all(...agents.map((a) => a.motebit_id), nowMs) as Array<{ motebit_id: string }>;
-  if (rows.length === 0) return agents;
+    .all(...agents.map((a) => a.motebit_id), nowMs, REFERENCE_MIN_BONDED_SIGNAL_MICRO) as Array<{
+    motebit_id: string;
+  }>;
   const backed = new Set(rows.map((r) => r.motebit_id));
+  // AUTHORITATIVE: the relay asserts `bonded` ONLY from its OWN RPC-verified,
+  // above-floor, non-expired bond rows — never a value carried IN. A federated
+  // peer cannot mint this signal by attaching `bonded: true` to an agent it
+  // forwards (rule 6: the relay re-publishes only what it independently
+  // verifies). So we STRIP any inbound `bonded` on every agent and set it true
+  // only for locally-backed ids — closing the federation-laundering path even
+  // when this relay has zero backed candidates (the old early-return leaked a
+  // laundered value in that case).
   return agents.map((a) => {
-    if (a.bonded != null) return a; // peer-provided bond status wins for federated agents
-    return backed.has(a.motebit_id) ? { ...a, bonded: true } : a;
+    const { bonded: _inbound, ...rest } = a as T & { bonded?: unknown };
+    return (backed.has(a.motebit_id) ? { ...rest, bonded: true } : rest) as T;
   });
 }
 
@@ -1459,7 +1529,9 @@ export function registerAgentRoutes(deps: AgentsDeps): void {
         });
         if (!resp.ok) return [];
         const data = (await resp.json()) as { agents: Array<Record<string, unknown>> };
-        return data.agents ?? [];
+        return (data.agents ?? [])
+          .map(sanitizePeerAgent)
+          .filter((a): a is Record<string, unknown> => a !== null);
       } catch {
         return [];
       }

--- a/services/relay/src/bond-store.ts
+++ b/services/relay/src/bond-store.ts
@@ -33,6 +33,20 @@ const logger = createLogger({ service: "relay", module: "bond-store" });
  */
 export const BOND_BACKING_STALENESS_MS = 60_000;
 
+/**
+ * Reference minimum bond amount (micro-USDC) for the PUBLIC discover `bonded`
+ * signal. A bond below this floor is a real, signed, address-bound commitment
+ * but too small to carry the anti-sybil weight the signal implies — without a
+ * floor, a self-registered $0 bond mints `bonded: true` at zero capital, and a
+ * sybil swarm does so per-identity for free (the exact property the bond is
+ * meant to bound). `REFERENCE_` because the credible-commitment threshold is a
+ * mechanism-design choice an operator tunes, not interop law; $1.00 makes an
+ * N-identity swarm cost ~$N rather than nothing. This gates ONLY the discover
+ * signal — the money-eligibility gate keeps its own stricter coverage math
+ * (`bondCoversTicket`, ≥10× ticket + in-flight).
+ */
+export const REFERENCE_MIN_BONDED_SIGNAL_MICRO = 1_000_000;
+
 /** Verifier-cache state for a bond's onchain backing. */
 export type BondBackingState = "pending" | "backed" | "underbacked";
 


### PR DESCRIPTION
Fixes the one HIGH-severity verified-real finding from the outward adversarial pass (a malicious peer forges the public `bonded` trust signal), plus its siblings — hardened over two rounds of external (ChatGPT) review that each found a real residual.

## What this closes
- **Federation bond laundering (HIGH).** `enrichWithBondStatus` is now authoritative — it strips any inbound `bonded` and asserts it only from this relay's own RPC-verified, above-floor, non-expired bond rows (rule 6). Plus ingress `sanitizePeerAgent` on every federated agent.
- **Zero-capital mint (MED).** `REFERENCE_MIN_BONDED_SIGNAL_MICRO` ($1, tunable — mechanism-design, not interop law) gates the discover signal; money-eligibility keeps its own stricter coverage math.
- **Local-collision override (HIGH).** A peer forging a LOCAL agent's id to redirect its settlement cannot win the lowest-hop-wins merge (local is distance 0).
- **Malformed-hop ranking manipulation (MED).** `sanitizePeerAgent` now **drops** (never normalizes) any `hop_distance` that isn't a safe integer in `[1, 8]` — normalizing a forgery to the winning minimum (1) was itself exploitable remote-vs-remote (caught in review round 2).

## Proof
Inverted the test that asserted the vulnerable "preserves peer bonded" behavior; added zero-value, hop-clamp, **two end-to-end handler tests** (local-collision and remote-vs-remote: honest peer @2 vs malicious malformed → honest wins, attacker settlement dropped). Relay 1459 green, lint + bond gates clean.

## Deliberately NOT closed — flagged for the specialist review (in code + `docs/security/external-audit-scope.md`)
- **Settlement authority (potentially existential).** A malicious DIRECT peer asserting a VALID-but-lying low `hop_distance` for a NON-local identity an honest peer serves further away can still win with a forged `settlement_address`. `hop_distance` is peer-asserted and unverifiable; the root fix is binding `settlement_address` cryptographically to the agent's succession key so a relay TRANSPORTS but never CREATES payment authority.
- **Bond mechanism soundness / freshness / portable remote-bond evidence** — the economic-robustness layer.

**Claim scope:** this closes forged-boolean laundering, zero-value signaling, and the two hop-override vectors. It is **not** a claim that bond-based sybil resistance is solved, nor that federated bond semantics or settlement authority are complete — those are the layer-3/4 questions for the scoped specialist engagement.

No auto-merge — this is security-sensitive and the settlement-authority limitation deserves a human read before it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)