### PR TITLE
fix(relay): strip peer-forged hardware_attestation + latency_stats — the sibling gap #361 left open

### DIFF
--- a/services/relay/src/__tests__/discover-marketplace.test.ts
+++ b/services/relay/src/__tests__/discover-marketplace.test.ts
@@ -471,21 +471,30 @@ describe("GET /api/v1/agents/discover — marketplace enrichment", () => {
     expect(enriched[0]!.hardware_attestation?.platform).toBe("software");
   });
 
-  it("enrichWithHardwareAttestation preserves peer-provided HA on federated agents", () => {
-    // Federation merge passes through HA from the upstream peer relay. The
-    // local enricher must not overwrite it when we have no local credential —
-    // the peer's HA store is more authoritative for cross-relay agents.
+  it("enrichWithHardwareAttestation overlays ONLY the relay's own projection, never a peer's forged HA (bond-signal sibling)", () => {
+    // Sibling-boundary fix (follow-up to the `bonded` laundering close): a
+    // federated peer's `hardware_attestation` is not independently verifiable
+    // here — it is laundering by the same threat model as a forged `bonded`.
+    // The relay overlays only its OWN local credential projection; the peer's
+    // claim is discarded (and stripped upstream on ingress by
+    // sanitizePeerAgent). Pre-fix, the peer's forged android_keystore/score-100
+    // won — this asserts the secure behavior and fails against that code.
+    insertTrustCredential(relay.moteDb.db, {
+      credential_id: "ha-fed-cred",
+      subject_motebit_id: "federated-agent",
+      platform: "secure_enclave",
+    });
     const enriched = enrichWithHardwareAttestation(
       [
         {
           motebit_id: "federated-agent",
           capabilities: ["x"],
-          hardware_attestation: { platform: "android_keystore", score: 1 },
+          hardware_attestation: { platform: "android_keystore", score: 100 },
         } as EnricherInput,
       ],
       relay.moteDb.db,
     );
-    expect(enriched[0]!.hardware_attestation?.platform).toBe("android_keystore");
+    expect(enriched[0]!.hardware_attestation?.platform).toBe("secure_enclave");
   });
 
   // ── enrichWithLatencyStats: per-row observed-latency readout data ──
@@ -543,10 +552,13 @@ describe("GET /api/v1/agents/discover — marketplace enrichment", () => {
     expect(enriched[0]!.latency_stats).toBeUndefined();
   });
 
-  it("enrichWithLatencyStats preserves peer-provided latency on federated agents", () => {
-    // Same federation-passthrough rule as the HA enricher: the peer's
-    // latency view is more authoritative for agents we've never directly
-    // routed to. The local enricher must not overwrite it.
+  it("enrichWithLatencyStats overlays ONLY the relay's own measurement, never a peer's forged latency (bond-signal sibling)", () => {
+    // Sibling-boundary fix: a federated peer's `latency_stats` is not
+    // independently verifiable here — laundering by the same threat model as a
+    // forged `bonded`. The relay attaches only its OWN measured latency; the
+    // peer's claim is discarded (and stripped upstream by sanitizePeerAgent).
+    // Pre-fix, the peer's forged 50ms won over the relay's real 9999ms
+    // measurement — this asserts the secure behavior and fails against that.
     insertLatencySample(relay.moteDb.db, {
       motebit_id: "submitter-x",
       remote_motebit_id: "fed-lat-agent",
@@ -562,8 +574,7 @@ describe("GET /api/v1/agents/discover — marketplace enrichment", () => {
       ],
       relay.moteDb.db,
     );
-    expect(enriched[0]!.latency_stats?.avg_ms).toBe(50);
-    expect(enriched[0]!.latency_stats?.sample_count).toBe(10);
+    expect(enriched[0]!.latency_stats?.avg_ms).toBe(9999);
   });
 
   it("/api/v1/agents/discover surfaces latency_stats on agents with samples", async () => {
@@ -697,16 +708,23 @@ describe("GET /api/v1/agents/discover — marketplace enrichment", () => {
     expect(target!.bonded).toBeUndefined();
   });
 
-  it("sanitizePeerAgent strips relay-attested fields on a valid record; DROPS a forged low hop_distance", () => {
-    // A valid multi-hop record: bonded stripped, the rest passes through.
+  it("sanitizePeerAgent strips ALL relay-attested fields on a valid record; DROPS a forged low hop_distance", () => {
+    // A valid multi-hop record: every relay-attested signal a peer cannot
+    // mint (bonded + its siblings hardware_attestation + latency_stats) is
+    // stripped on ingress; the rest passes through.
     const cleaned = sanitizePeerAgent({
       motebit_id: "peer-agent",
       bonded: true,
+      hardware_attestation: { platform: "secure_enclave", key_exported: false, score: 100 },
+      latency_stats: { avg_ms: 1, p95_ms: 1, sample_count: 999 },
       hop_distance: 2,
       settlement_address: "PeerOwnAddr",
     });
     expect(cleaned).not.toBeNull();
     expect(cleaned!.bonded).toBeUndefined();
+    // Sibling-boundary fix: a peer cannot mint these about a remote agent.
+    expect(cleaned!.hardware_attestation).toBeUndefined();
+    expect(cleaned!.latency_stats).toBeUndefined();
     expect(cleaned!.hop_distance).toBe(2);
     expect(cleaned!.settlement_address).toBe("PeerOwnAddr");
 

--- a/services/relay/src/agents.ts
+++ b/services/relay/src/agents.ts
@@ -21,12 +21,19 @@ import { REFERENCE_MIN_BONDED_SIGNAL_MICRO } from "./bond-store.js";
 /**
  * Fields the ORIGIN relay computes itself and MUST NOT accept from a federated
  * peer — a peer that forwards agents cannot mint these signals about them
- * (rule 6: the relay re-publishes only what it independently verifies). `bonded`
- * is RPC-verified locally by `enrichWithBondStatus`; `hardware_attestation`
- * and `latency_stats` have their own passthrough discipline (a peer's local
- * view of ITS agents is authoritative for those), so only `bonded` is stripped.
+ * (rule 6: the relay re-publishes only what it independently verifies). All
+ * three are relay-computed against LOCAL stores and re-attached by their
+ * enrichers: `bonded` from the RPC-verified bond rows (`enrichWithBondStatus`),
+ * `hardware_attestation` from the local credential store
+ * (`enrichWithHardwareAttestation`), `latency_stats` from `relay_latency_stats`
+ * (`enrichWithLatencyStats`). A peer's claim about a remote agent's hardware
+ * attestation or latency is not independently verifiable here and so is
+ * laundering by the same threat model as a forged `bonded` — sibling-boundary
+ * rule: the fix that stripped `bonded` applies identically to its siblings.
+ * A remote agent the relay has no local projection for simply carries no
+ * attested value (never the peer's word for it).
  */
-const RELAY_ATTESTED_PEER_FIELDS = ["bonded"] as const;
+const RELAY_ATTESTED_PEER_FIELDS = ["bonded", "hardware_attestation", "latency_stats"] as const;
 
 /**
  * Upper sanity bound on a peer-asserted `hop_distance`. The mesh caps
@@ -212,7 +219,9 @@ export function enrichWithHardwareAttestation<
   if (projectedByAgent.size === 0) return agents;
 
   return agents.map((a) => {
-    if (a.hardware_attestation != null) return a; // peer-provided HA wins for federated agents
+    // No peer-provided passthrough: a federated peer's `hardware_attestation`
+    // is stripped on ingress (RELAY_ATTESTED_PEER_FIELDS) and only the relay's
+    // OWN local projection is attached — the same discipline as `bonded`.
     const projection = projectedByAgent.get(a.motebit_id);
     if (projection == null) return a;
     return { ...a, hardware_attestation: projection };
@@ -289,7 +298,9 @@ export function enrichWithLatencyStats<T extends Record<string, unknown> & { mot
   if (projectedByAgent.size === 0) return agents;
 
   return agents.map((a) => {
-    if (a.latency_stats != null) return a; // peer-provided latency wins for federated agents
+    // No peer-provided passthrough: a federated peer's `latency_stats` is
+    // stripped on ingress and only the relay's OWN measured projection is
+    // attached — the same discipline as `bonded` and `hardware_attestation`.
     const projection = projectedByAgent.get(a.motebit_id);
     if (projection == null) return a;
     return { ...a, latency_stats: projection };


### PR DESCRIPTION
Follow-up to #361 (bond-signal forgery). An independent adversarial review of #361 confirmed its four fixes are correct **and** found an undisclosed, same-class sibling gap it left open — which this closes.

## The gap
#361 closed `bonded` federation-laundering (`enrichWithBondStatus` authoritative + `sanitizePeerAgent` strips inbound `bonded`). But the **identical** vulnerable pattern was still live on its siblings:
- `enrichWithHardwareAttestation` and `enrichWithLatencyStats` each kept `if (a.X != null) return a; // peer-provided X wins`.
- `RELAY_ATTESTED_PEER_FIELDS` stripped only `bonded`.

So a federated peer could forge `hardware_attestation` (e.g. `{platform:"secure_enclave", key_exported:false, score:100}` — a fake "Secure Enclave verified" badge) or `latency_stats` on any agent it forwards, and those survived straight to the public `/api/v1/agents/discover` response and the Agents-panel trust badges — **laundering by the identical threat model #361 fixed**, mis-rationalized in a comment as safe passthrough. That violates the repo's **Sibling boundary rule** (fix one boundary, audit all siblings in the same pass).

## The fix — exactly symmetric to the bonded close
- Add `hardware_attestation` + `latency_stats` to `RELAY_ATTESTED_PEER_FIELDS` (stripped on ingress from every federated agent).
- Remove the peer-provided passthrough early-returns in both enrichers → the relay overlays only its **own local projection** (a remote agent it has no local data on carries no attested value — never the peer's word for it).
- Correct the comment that framed the passthrough as authoritative.

A relay re-publishes only signals it independently verifies (rule 6); a peer's claim about a *remote* agent's hardware attestation or measured latency isn't verifiable here.

## Tests
- Inverted the two "preserves peer-provided" tests to assert the relay's own local projection wins over a peer's forged value — **each fails against the pre-fix code** (real regression guards).
- Extended the `sanitizePeerAgent` test to assert both new fields are stripped on ingress.
- Full relay suite **1474 green**; all **135 drift gates green**.

## Severity + tracked residuals
Not a live theft vector today (the runtime's own rankers recompute HA/latency from local stores), but the public discover API + trust badges re-publish the forged values as authoritative — same class as the HIGH #361 fixed.

Still open (tracked, defense-in-depth, currently safe): the federation intermediate handler (`/federation/v1/discover`) forwards sub-peer agents without `sanitizePeerAgent` / bond-stripping (the origin still sanitizes even multi-hop). And the valid-but-lying `hop_distance` → settlement redirect (disclosed by #361; root fix is crypto-binding `settlement_address` to the succession key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)