### PR TITLE
chore(deps): cbor2 1 → 2 in attestation verifiers

### DIFF
--- a/.changeset/cbor2-v2-attestation.md
+++ b/.changeset/cbor2-v2-attestation.md
@@ -1,0 +1,10 @@
+---
+"@motebit/crypto-appattest": patch
+"@motebit/crypto-webauthn": patch
+---
+
+Bump `cbor2` 1 → 2 in the attestation verifiers. API-compatible for our decode
+surface (COSE/CBOR attestation objects); build + full fixture-based tests pass
+unchanged. `@peculiar/x509` held at v1 deliberately — its v2 adds a
+tsyringe/`reflect-metadata` global-polyfill requirement that warrants its own
+scoped change on this security-sensitive path.

--- a/packages/crypto-appattest/package.json
+++ b/packages/crypto-appattest/package.json
@@ -65,7 +65,7 @@
     "@motebit/protocol": "workspace:*",
     "@motebit/crypto": "workspace:*",
     "@peculiar/x509": "^1.12.0",
-    "cbor2": "^1.9.0"
+    "cbor2": "^2.3.0"
   },
   "devDependencies": {
     "@peculiar/webcrypto": "^1.7.1",

--- a/packages/crypto-webauthn/package.json
+++ b/packages/crypto-webauthn/package.json
@@ -64,7 +64,7 @@
     "@motebit/protocol": "workspace:*",
     "@motebit/crypto": "workspace:*",
     "@peculiar/x509": "^1.12.0",
-    "cbor2": "^1.9.0"
+    "cbor2": "^2.3.0"
   },
   "devDependencies": {
     "@noble/curves": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1243,8 +1243,8 @@ importers:
         specifier: ^1.12.0
         version: 1.14.3
       cbor2:
-        specifier: ^1.9.0
-        version: 1.12.0
+        specifier: ^2.3.0
+        version: 2.3.0
     devDependencies:
       '@peculiar/webcrypto':
         specifier: ^1.7.1
@@ -1302,8 +1302,8 @@ importers:
         specifier: ^1.12.0
         version: 1.14.3
       cbor2:
-        specifier: ^1.9.0
-        version: 1.12.0
+        specifier: ^2.3.0
+        version: 2.3.0
     devDependencies:
       '@noble/curves':
         specifier: ^2.2.0
@@ -3453,6 +3453,10 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
+  '@cto.af/wtf8@0.0.5':
+    resolution: {integrity: sha512-LfUFi+Vv4eDzj+XAtR89e3wwjXA/NZjUSwU5NhwbBrLecxPaBYFy3exCuc1j+D4UZeOVdqlsl8G7LmOt18V0tg==}
+    engines: {node: '>=20'}
+
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
@@ -4613,9 +4617,6 @@ packages:
 
   '@peculiar/asn1-rsa@2.6.1':
     resolution: {integrity: sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==}
-
-  '@peculiar/asn1-schema@2.6.0':
-    resolution: {integrity: sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==}
 
   '@peculiar/asn1-schema@2.7.0':
     resolution: {integrity: sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==}
@@ -7218,9 +7219,9 @@ packages:
   caniuse-lite@1.0.30001803:
     resolution: {integrity: sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==}
 
-  cbor2@1.12.0:
-    resolution: {integrity: sha512-3Cco8XQhi27DogSp9Ri6LYNZLi/TBY/JVnDe+mj06NkBjW/ZYOtekaEU4wZ4xcRMNrFkDv8KNtOAqHyDfz3lYg==}
-    engines: {node: '>=18.7'}
+  cbor2@2.3.0:
+    resolution: {integrity: sha512-76WB3hq8BoaGkMkBVJ27fW5LJU+qqDLEpgRNCG/SYKhODWXpVPOTD4UcUto3IEzYLA52nsvbhb0wabhHDn3qXg==}
+    engines: {node: '>=20'}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -12934,6 +12935,8 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
+  '@cto.af/wtf8@0.0.5': {}
+
   '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@emnapi/core@1.10.0':
@@ -14072,7 +14075,7 @@ snapshots:
 
   '@peculiar/asn1-cms@2.6.1':
     dependencies:
-      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-schema': 2.7.0
       '@peculiar/asn1-x509': 2.6.1
       '@peculiar/asn1-x509-attr': 2.6.1
       asn1js: 3.0.10
@@ -14080,14 +14083,14 @@ snapshots:
 
   '@peculiar/asn1-csr@2.6.1':
     dependencies:
-      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-schema': 2.7.0
       '@peculiar/asn1-x509': 2.6.1
       asn1js: 3.0.10
       tslib: 2.8.1
 
   '@peculiar/asn1-ecc@2.6.1':
     dependencies:
-      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-schema': 2.7.0
       '@peculiar/asn1-x509': 2.6.1
       asn1js: 3.0.10
       tslib: 2.8.1
@@ -14113,7 +14116,7 @@ snapshots:
       '@peculiar/asn1-cms': 2.6.1
       '@peculiar/asn1-pfx': 2.6.1
       '@peculiar/asn1-pkcs8': 2.6.1
-      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-schema': 2.7.0
       '@peculiar/asn1-x509': 2.6.1
       '@peculiar/asn1-x509-attr': 2.6.1
       asn1js: 3.0.10
@@ -14121,15 +14124,9 @@ snapshots:
 
   '@peculiar/asn1-rsa@2.6.1':
     dependencies:
-      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-schema': 2.7.0
       '@peculiar/asn1-x509': 2.6.1
       asn1js: 3.0.10
-      tslib: 2.8.1
-
-  '@peculiar/asn1-schema@2.6.0':
-    dependencies:
-      asn1js: 3.0.10
-      pvtsutils: 1.3.6
       tslib: 2.8.1
 
   '@peculiar/asn1-schema@2.7.0':
@@ -14147,7 +14144,7 @@ snapshots:
 
   '@peculiar/asn1-x509@2.6.1':
     dependencies:
-      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-schema': 2.7.0
       asn1js: 3.0.10
       pvtsutils: 1.3.6
       tslib: 2.8.1
@@ -14175,7 +14172,7 @@ snapshots:
       '@peculiar/asn1-ecc': 2.6.1
       '@peculiar/asn1-pkcs9': 2.6.1
       '@peculiar/asn1-rsa': 2.6.1
-      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-schema': 2.7.0
       '@peculiar/asn1-x509': 2.6.1
       pvtsutils: 1.3.6
       reflect-metadata: 0.2.2
@@ -17013,7 +17010,9 @@ snapshots:
 
   caniuse-lite@1.0.30001803: {}
 
-  cbor2@1.12.0: {}
+  cbor2@2.3.0:
+    dependencies:
+      '@cto.af/wtf8': 0.0.5
 
   ccount@2.0.1: {}
 


### PR DESCRIPTION
Bumps `cbor2` 1 → 2 in `@motebit/crypto-appattest` and `@motebit/crypto-webauthn` (the COSE/CBOR attestation-object decoders). Part of clearing the #310 production-major stack.

## Scope
- **cbor2 v2**: API-compatible for our decode surface. Build + full fixture-based tests pass unchanged across both packages (6/6 turbo tasks).
- **`@peculiar/x509` held at v1 deliberately.** Its v2 introduces a `tsyringe`/`reflect-metadata` global-polyfill requirement (import-time DI). On these *security-sensitive attestation* verifiers that's a real integration decision — whether the library entry forces a global polyfill on every consumer — so it gets its own scoped change, not a bundled bump.

## Verification
- Local pre-push: build, audit (critical), all gates, affected `test:coverage` — 87/87 tasks green.
- Patch changeset for both published packages (dep-only bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)