### PR TITLE
chore(deps): stripe SDK 17 → 22 (+ fixes 2 latent basil money-path bugs)

### DIFF
--- a/.changeset/stripe-v22.md
+++ b/.changeset/stripe-v22.md
@@ -1,0 +1,10 @@
+---
+"motebit": patch
+---
+
+Bump `stripe` SDK 17 → 22. The runtime API version stays pinned at
+`2025-03-31.basil` (unchanged); the bump aligns the SDK's TypeScript types with
+that pinned version, which surfaced two field-location fixes on the relay money
+path (see PR for the latent-bug detail): `invoice.subscription` →
+`invoice.parent.subscription_details.subscription`, and subscription
+`current_period_end` → `items.data[0].current_period_end`.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -73,7 +73,7 @@
     "better-sqlite3": "^12.11.1",
     "hono": "^4.12.28",
     "sql.js": "^1.14.1",
-    "stripe": "^17.0.0",
+    "stripe": "^22.0.0",
     "viem": "^2.54.6",
     "vscode-jsonrpc": "^9.0.0",
     "vscode-languageserver": "^10.0.0",

--- a/packages/settlement-rails/package.json
+++ b/packages/settlement-rails/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.20.0",
-    "stripe": "^17.0.0",
+    "stripe": "^22.0.0",
     "typescript": "^5.6.0",
     "vitest": "^4.1.10"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,8 +154,8 @@ importers:
         specifier: ^1.14.1
         version: 1.14.1
       stripe:
-        specifier: ^17.0.0
-        version: 17.7.0
+        specifier: ^22.0.0
+        version: 22.3.2(@types/node@22.20.0)
       viem:
         specifier: ^2.54.6
         version: 2.54.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
@@ -1996,8 +1996,8 @@ importers:
         specifier: ^22.20.0
         version: 22.20.0
       stripe:
-        specifier: ^17.0.0
-        version: 17.7.0
+        specifier: ^22.0.0
+        version: 22.3.2(@types/node@22.20.0)
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -2641,8 +2641,8 @@ importers:
         specifier: '>=4.12.4 <5.0.0'
         version: 4.12.28
       stripe:
-        specifier: ^17.0.0
-        version: 17.7.0
+        specifier: ^22.0.0
+        version: 22.3.2(@types/node@22.20.0)
     devDependencies:
       '@motebit/ai-core':
         specifier: workspace:*
@@ -11188,9 +11188,14 @@ packages:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
-  stripe@17.7.0:
-    resolution: {integrity: sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==}
-    engines: {node: '>=12.*'}
+  stripe@22.3.2:
+    resolution: {integrity: sha512-O13QOvgEIQvDlTy6Ubb5kB980wpbhmoZNsgCXKILjCMZS67f+bW+6w99k3gnSi/N1lkryoj1WYdpGT5Wc5edjg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   structured-headers@0.4.1:
     resolution: {integrity: sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg==}
@@ -21996,10 +22001,9 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
-  stripe@17.7.0:
-    dependencies:
+  stripe@22.3.2(@types/node@22.20.0):
+    optionalDependencies:
       '@types/node': 22.20.0
-      qs: 6.15.0
 
   structured-headers@0.4.1: {}
 

--- a/services/relay/package.json
+++ b/services/relay/package.json
@@ -50,7 +50,7 @@
     "@x402/hono": "^2.17.0",
     "better-sqlite3": "^12.11.1",
     "hono": "^4.12.28",
-    "stripe": "^17.0.0"
+    "stripe": "^22.0.0"
   },
   "devDependencies": {
     "@motebit/ai-core": "workspace:*",

--- a/services/relay/src/__tests__/stripe-webhook-adapter.test.ts
+++ b/services/relay/src/__tests__/stripe-webhook-adapter.test.ts
@@ -200,7 +200,8 @@ describe("StripeSubscriptionEventAdapter", () => {
         data: {
           object: {
             id: "in_test_001",
-            subscription: "sub_active_123",
+            // Stripe 2025-03-31.basil: subscription moved under parent.
+            parent: { subscription_details: { subscription: "sub_active_123" } },
           },
         },
       });
@@ -218,7 +219,7 @@ describe("StripeSubscriptionEventAdapter", () => {
         data: {
           object: {
             id: "in_test_002",
-            subscription: { id: "sub_nested_456" },
+            parent: { subscription_details: { subscription: { id: "sub_nested_456" } } },
           },
         },
       });
@@ -236,7 +237,7 @@ describe("StripeSubscriptionEventAdapter", () => {
         data: {
           object: {
             id: "in_oneoff_001",
-            subscription: null,
+            parent: null,
           },
         },
       });
@@ -250,7 +251,7 @@ describe("StripeSubscriptionEventAdapter", () => {
         data: {
           object: {
             id: null,
-            subscription: "sub_123",
+            parent: { subscription_details: { subscription: "sub_123" } },
           },
         },
       });

--- a/services/relay/src/subscriptions.ts
+++ b/services/relay/src/subscriptions.ts
@@ -616,7 +616,10 @@ export function registerProxyTokenRoutes(
         cancel_at_period_end: true,
       });
 
-      const periodEndSec = updated.current_period_end;
+      // Stripe's 2025-03-31.basil API moved current_period_end off the
+      // Subscription object onto each subscription item. Relay plans are
+      // single-item, so the item's period end is the subscription's.
+      const periodEndSec = updated.items.data[0]?.current_period_end;
       const periodEnd = typeof periodEndSec === "number" ? periodEndSec * 1000 : null;
       db.prepare(
         "UPDATE relay_subscriptions SET status = 'cancelling', current_period_end = ?, updated_at = ? WHERE motebit_id = ?",

--- a/services/relay/src/webhooks/stripe-webhook-adapter.ts
+++ b/services/relay/src/webhooks/stripe-webhook-adapter.ts
@@ -190,10 +190,10 @@ export class StripeSubscriptionEventAdapter implements SubscriptionEventAdapter 
 
       case "invoice.paid": {
         const invoice = event.data.object;
-        const subscriptionId =
-          typeof invoice.subscription === "string"
-            ? invoice.subscription
-            : (invoice.subscription?.id ?? null);
+        // Stripe's 2025-03-31.basil API removed invoice.subscription; the
+        // originating subscription now lives under parent.subscription_details.
+        const parentSub = invoice.parent?.subscription_details?.subscription ?? null;
+        const subscriptionId = typeof parentSub === "string" ? parentSub : (parentSub?.id ?? null);
         if (!subscriptionId) {
           return { kind: "ignored", type: event.type };
         }


### PR DESCRIPTION
Bumps `stripe` SDK 17 → 22 across its 3 consumers (`@motebit/settlement-rails`, `@motebit/relay`, `motebit` CLI). **The runtime API version is unchanged** — it stays pinned at `2025-03-31.basil`. The SDK bump aligns Stripe's *TypeScript types* with that already-pinned version, and doing so surfaced **two latent money-path bugs** that the stale SDK-17 types had been masking.

## ⚠️ The latent bugs this bump exposes and fixes

Under SDK 17 the code pinned the runtime to `2025-03-31.basil` (`new Stripe(key, { apiVersion: "2025-03-31.basil" as Stripe.LatestApiVersion })`), but SDK 17's *types* were generated for an older, pre-basil API version. Basil had already moved two fields, so at **runtime** the code was reading `undefined` — while the compiler saw the old fields and stayed quiet. The cast (`as Stripe.LatestApiVersion`) is what let the version/type mismatch persist silently.

1. **`invoice.paid` webhooks were silently dropped.** Basil removed `invoice.subscription`; the id moved to `invoice.parent.subscription_details.subscription`. The adapter read `invoice.subscription` → `undefined` → **every real renewal webhook mapped to `{ kind: "ignored" }`.** The unit tests passed only because they mocked the *pre-basil* shape the live API never sends. Fixed the read; corrected the test mocks to the basil shape.
2. **Subscription cancel wrote a null period-end.** Basil moved `current_period_end` off `Subscription` onto each item. `updated.current_period_end` → `undefined` → cancel always persisted `current_period_end = null` (so `active_until` was lost). Now reads `updated.items.data[0].current_period_end` (relay plans are single-item).

## Scope / decisions
- **Runtime apiVersion pin unchanged** (`2025-03-31.basil`). SDK 22's own `LatestApiVersion` is `2026-06-24.dahlia`; I deliberately did **not** move the pin — that's a separate runtime decision. Both field moves exist in basil *and* dahlia, so the fixes are correct either way.
- The only two Stripe-object reads that changed are the two above. `checkout.session.subscription`/`.customer` are unchanged in basil (verified — typecheck clean).

## Coverage boundary (honest note)
The `invoice.paid` fix is unit-proven (the adapter has a Stripe-mock test). The **cancel-path fix is type-verified but not unit-tested** — `subscription-lifecycle.test.ts` deliberately covers "non-Stripe paths only" and has no Stripe mock harness. I did not stand one up for a single branch inside this dep-bump PR. **Recommended follow-up:** extract the period-end read into a pure helper (like the adapter's `mapEvent`) and unit-test it, or add a Stripe-mock cancel test.

## Verification
- Typecheck clean across all 3 consumers.
- Full suites green under stripe 22: **relay 128** (+1 known skip), **settlement-rails 4**, **cli 30**.
- Patch changeset for `motebit` (only published consumer); relay + settlement-rails are private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)