### PR TITLE
test(relay): unit-test the basil period-end read (closes #394 cancel-path gap)

### DIFF
--- a/services/relay/src/__tests__/subscription-period-end.test.ts
+++ b/services/relay/src/__tests__/subscription-period-end.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for subscriptionPeriodEndMs — the pure extractor for a Stripe
+ * subscription's current period end under the 2025-03-31.basil shape.
+ *
+ * This proves the basil field-location contract (current_period_end lives on
+ * items, not the Subscription object) that the /cancel route depends on. The
+ * route handler itself only has non-Stripe-path coverage (no Stripe mock
+ * harness in subscription-lifecycle.test.ts), so the field access is proven
+ * here instead. See the latent-bug fix in the stripe 17→22 bump (#394): under
+ * the pre-basil read, cancel always persisted a null period end.
+ */
+import { describe, it, expect } from "vitest";
+import type Stripe from "stripe";
+
+import { subscriptionPeriodEndMs } from "../subscriptions.js";
+
+/** Minimal basil-shaped Subscription with a single item's period end. */
+function subWithItemPeriodEnd(sec: number | undefined): Stripe.Subscription {
+  return {
+    items: { data: sec === undefined ? [] : [{ current_period_end: sec }] },
+  } as unknown as Stripe.Subscription;
+}
+
+describe("subscriptionPeriodEndMs", () => {
+  it("reads current_period_end from the first item and converts s → ms", () => {
+    // 2026-07-01T00:00:00Z in epoch seconds.
+    const sec = Math.floor(Date.UTC(2026, 6, 1) / 1000);
+    expect(subscriptionPeriodEndMs(subWithItemPeriodEnd(sec))).toBe(sec * 1000);
+  });
+
+  it("returns null when the subscription has no items (nothing to read)", () => {
+    expect(subscriptionPeriodEndMs(subWithItemPeriodEnd(undefined))).toBeNull();
+  });
+
+  it("returns null when the item's current_period_end is not a number", () => {
+    const sub = {
+      items: { data: [{ current_period_end: undefined }] },
+    } as unknown as Stripe.Subscription;
+    expect(subscriptionPeriodEndMs(sub)).toBeNull();
+  });
+
+  it("regression: the pre-basil top-level field is NOT consulted", () => {
+    // A subscription carrying the OLD top-level current_period_end but an empty
+    // items array must read as null — proving we do not fall back to the
+    // removed field (the exact shape that masked the latent cancel bug).
+    const sub = {
+      current_period_end: 1_800_000_000,
+      items: { data: [] },
+    } as unknown as Stripe.Subscription;
+    expect(subscriptionPeriodEndMs(sub)).toBeNull();
+  });
+});

--- a/services/relay/src/subscriptions.ts
+++ b/services/relay/src/subscriptions.ts
@@ -57,6 +57,22 @@ function getStripe(): Stripe {
   return new Stripe(key, { apiVersion: "2025-03-31.basil" as Stripe.LatestApiVersion });
 }
 
+/**
+ * Extract a subscription's current period end, in milliseconds, from Stripe's
+ * `2025-03-31.basil` shape. Basil removed `current_period_end` from the
+ * Subscription object and moved it onto each subscription item; relay plans are
+ * single-item, so the first item's period end is the subscription's. Returns
+ * `null` when absent or non-numeric.
+ *
+ * Exported so the basil field-location contract is unit-tested directly — the
+ * cancel route that consumes it has no Stripe mock harness (it only exercises
+ * non-Stripe paths), so this pure helper is where the field access is proven.
+ */
+export function subscriptionPeriodEndMs(sub: Stripe.Subscription): number | null {
+  const sec = sub.items.data[0]?.current_period_end;
+  return typeof sec === "number" ? sec * 1000 : null;
+}
+
 // ── Subscription table ──────────────────────────────────────────────────
 
 /** Track subscription status (minimal — Stripe is source of truth). */
@@ -616,11 +632,7 @@ export function registerProxyTokenRoutes(
         cancel_at_period_end: true,
       });
 
-      // Stripe's 2025-03-31.basil API moved current_period_end off the
-      // Subscription object onto each subscription item. Relay plans are
-      // single-item, so the item's period end is the subscription's.
-      const periodEndSec = updated.items.data[0]?.current_period_end;
-      const periodEnd = typeof periodEndSec === "number" ? periodEndSec * 1000 : null;
+      const periodEnd = subscriptionPeriodEndMs(updated);
       db.prepare(
         "UPDATE relay_subscriptions SET status = 'cancelling', current_period_end = ?, updated_at = ? WHERE motebit_id = ?",
       ).run(periodEnd, Date.now(), motebitId);


### PR DESCRIPTION
Follow-up to #394 (stripe 17→22). That PR fixed the subscription-cancel path to read `current_period_end` from Stripe's basil item shape (`items.data[0]`), but flagged that the branch had no unit coverage — `subscription-lifecycle.test.ts` deliberately exercises only non-Stripe paths (no Stripe mock harness).

## Change
- Extract the field read into a pure exported helper `subscriptionPeriodEndMs(sub)`.
- The cancel route now calls it (behavior identical).
- New `subscription-period-end.test.ts` proves the basil contract directly: reads from the item, s→ms conversion, null on missing/non-numeric, and a **regression guard** that the removed pre-basil top-level `current_period_end` is never consulted (the exact shape that masked the latent bug).

## Verification
- Relay typecheck clean; 58 relay subscription/stripe tests pass (54 + 4 new).
- No changeset — `@motebit/relay` is private; pure refactor + test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)