### PR TITLE
fix(browser-sandbox): Playwright base image v1.59.1 → v1.61.1 (prod crash-loop, cloud browser down)

### DIFF
--- a/services/browser-sandbox/Dockerfile
+++ b/services/browser-sandbox/Dockerfile
@@ -11,7 +11,7 @@
 # Playwright image is the right metabolic absorption.
 
 # --- Build: install deps + compile TypeScript with full pnpm workspace ---
-FROM mcr.microsoft.com/playwright:v1.59.1-jammy AS build
+FROM mcr.microsoft.com/playwright:v1.61.1-jammy AS build
 WORKDIR /app
 
 # pnpm via corepack (Node 22+ ships corepack; Playwright base has Node 20).
@@ -40,7 +40,7 @@ RUN pnpm --filter @motebit/browser-sandbox... build
 RUN pnpm --filter @motebit/browser-sandbox deploy --prod /app/deployed
 
 # --- Runtime: Playwright base + the deployed bundle ---
-FROM mcr.microsoft.com/playwright:v1.59.1-jammy AS runtime
+FROM mcr.microsoft.com/playwright:v1.61.1-jammy AS runtime
 WORKDIR /app
 
 # Drop privileges — Playwright's base image runs as root by default,


### PR DESCRIPTION
**Production incident — fixed and deployed.** The cloud browser was down (motebits reported "no cloud browser available"). Root-caused from the symptom through fly logs:

```
browser-sandbox: boot failed: browserType.launch: Executable doesn't exist at
  /ms-playwright/chromium_headless_shell-1228/.../chrome-headless-shell
current: mcr.microsoft.com/playwright:v1.59.1-jammy · required: v1.61.1-jammy
Main child exited normally with code: 1 → machine reached max restart count of 10
```

`playwright-core` bumped to **1.61.1** (npm), but the Dockerfile base image stayed pinned at **v1.59.1-jammy** — which bundles a different chromium build than 1.61.1 expects, so the browser binary was missing, the app crash-looped on boot, and fly stopped the machine. A dependency bump whose deployment artifact didn't follow.

**Fix:** match the base image to the npm package (both build + runtime stages).

**Already deployed + verified live** (`fly deploy --remote-only`): the sandbox now boots `launching chromium (headless)` → `listening on :3500 — max sessions=4`, and answers HTTP (404 on `/` = server up) instead of timing out. This PR is the record; main should match prod.

**Follow-ups (not in this PR):**
- Gatable drift: a parity check between the Dockerfile playwright tag and the resolved `playwright-core` version — same class as `check-doctrine-cited-constants`.
- `min_machines_running=1` in fly.toml isn't keeping a machine warm (it auto-stopped), so first use pays a ~25s cold start; worth reconciling if that latency matters.
- Security (separate): `VITE_BROWSER_SANDBOX_TOKEN` is set in Vercel prod, exposing the bearer in the client bundle — deleting it also flips prod onto the intended relay-grant path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)