### PR TITLE
fix(browser-sandbox): keep the machine warm (auto_stop=false) — kill the ~25s cold-start

### DIFF
--- a/services/browser-sandbox/fly.toml
+++ b/services/browser-sandbox/fly.toml
@@ -17,15 +17,23 @@ kill_timeout = 10
 [http_service]
   internal_port = 3500
   force_https = true
-  # Keep one machine always running. Cold-start on this service is
+  # Keep the machine always running — cold-start on this service is
   # ~25s (Chromium boot + Playwright init + Node runtime), which
   # blocks the user's first `/computer` invocation in a session for
   # a quarter-minute. Fly.io shared-CPU 1GB ≈ $2/mo for always-on,
-  # cheap insurance against the UX cliff. Auto-start stays on so a
-  # second concurrent session still wakes a second machine on
-  # demand; auto-stop stays on so machines beyond the floor spin
-  # down when idle.
-  auto_stop_machines = "stop"
+  # cheap insurance against the UX cliff.
+  #
+  # We use auto_stop = false rather than min_machines_running = 1
+  # deliberately: min_machines_running prevents fly from stopping
+  # BELOW the floor, but it does NOT proactively START a stopped
+  # machine to REACH the floor — so a machine left stopped after a
+  # deploy (or a crash-loop, as happened 2026-07-25 when the
+  # Playwright image drifted) stays cold until the next request
+  # eats the full ~25s. This is a single-tenant sandbox (concurrency
+  # ≈ 1), so "never stop the one machine" is exactly "keep it warm,"
+  # with no scale-down worth preserving. auto_start stays on so a
+  # rare second concurrent session can still wake another machine.
+  auto_stop_machines = false
   auto_start_machines = true
   min_machines_running = 1
 


### PR DESCRIPTION
Follow-up to #403 (the Playwright outage fix). The sandbox was configured with `min_machines_running = 1` to keep a machine warm, but that setting prevents fly from stopping *below* the floor — it does **not** proactively *start* a stopped machine to *reach* it. So a machine left stopped after a deploy or crash-loop stayed cold until the next request paid the full ~25s Chromium+Playwright+Node boot (observed live 2026-07-25).

**Fix:** `auto_stop_machines = false`. Single-tenant sandbox (concurrency ≈ 1), so never-stopping the one machine *is* keeping it warm — no scale-down worth preserving.

**Deployed + verified live:** health responds in **0.34s** (was 25-28s cold), machine stays `started` with checks passing. ≈ $2/mo for always-on — cheap against the first-invocation UX cliff.

Part of today's browser-sandbox restore: #403 fixed the crash-loop (Playwright image drift), the `VITE_BROWSER_SANDBOX_TOKEN` bearer was removed from Vercel prod (client now uses the relay-grant path, verified end-to-end), and this kills the cold-start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)