### PR TITLE
fix(relay): transparency anchor certifies the SERVED declaration, not a phantom

### DIFF
--- a/services/relay/src/__tests__/transparency.test.ts
+++ b/services/relay/src/__tests__/transparency.test.ts
@@ -23,6 +23,7 @@ import {
 import {
   anchorTransparencyDeclaration,
   buildSignedDeclaration,
+  getSignedDeclaration,
   renderMarkdown,
   DECLARATION_CONTENT,
 } from "../transparency.js";
@@ -141,6 +142,68 @@ describe("anchorTransparencyDeclaration — Stage 2 onchain anchor", () => {
     // verifier reads transparency.json, sees declaration.hash, and
     // looks for memo `motebit:transparency:v1:{declaration.hash}` on chain.
     expect(captured).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("getSignedDeclaration — served hash IS anchored hash (composition guarantee)", () => {
+  // The defect this defends against: the serve path
+  // (registerTransparencyRoutes) and the onchain anchor path (index.ts
+  // boot) each built the declaration via a SEPARATE buildSignedDeclaration
+  // call. Because declared_at (a Date.now() default) is inside the hashed
+  // payload, the two builds produced different hashes — so the relay
+  // anchored a hash the endpoint never served, and the TOFU cross-check
+  // the anchor exists for (fetch declaration → hash → find matching Solana
+  // memo) could never succeed. The fix: one shared singleton, keyed by
+  // identity.
+
+  it("declared_at is hash-affecting — so two independent builds WOULD diverge", async () => {
+    // This is the hazard the shared accessor removes. If two builds pick
+    // different timestamps (they will — different Date.now() at serve vs
+    // anchor), their hashes differ. Demonstrated deterministically with
+    // explicit distinct timestamps.
+    const a = await buildSignedDeclaration(relayIdentity, 1000);
+    const b = await buildSignedDeclaration(relayIdentity, 2000);
+    expect(a.hash).not.toBe(b.hash);
+  });
+
+  it("serve path and anchor path draw the SAME declaration bytes", async () => {
+    // Model the two real call sites: both consume getSignedDeclaration.
+    const served = await getSignedDeclaration(relayIdentity);
+
+    let anchoredHash: string | undefined;
+    await anchorTransparencyDeclaration(await getSignedDeclaration(relayIdentity), {
+      submitTransparencyAnchor: async (hash) => {
+        anchoredHash = hash;
+        return { txHash: "tx" };
+      },
+    });
+
+    // The whole point: what a verifier fetches (served.hash) is exactly
+    // what lands on chain (anchoredHash). Same declared_at, same hash.
+    expect(anchoredHash).toBe(served.hash);
+    expect(served.declared_at).toBe((await getSignedDeclaration(relayIdentity)).declared_at);
+  });
+
+  it("returns a stable singleton per identity (idempotent)", async () => {
+    const first = await getSignedDeclaration(relayIdentity);
+    const second = await getSignedDeclaration(relayIdentity);
+    expect(first).toBe(second); // same object reference
+    expect(first.hash).toBe(second.hash);
+  });
+
+  it("isolates distinct relay identities (WeakMap keying)", async () => {
+    const keypair = await generateKeypair();
+    const otherIdentity: RelayIdentity = {
+      relayMotebitId: `relay-${crypto.randomUUID()}`,
+      publicKey: keypair.publicKey,
+      privateKey: keypair.privateKey,
+      publicKeyHex: bytesToHex(keypair.publicKey),
+      did: `did:key:z${bytesToHex(keypair.publicKey).slice(0, 16)}`,
+    };
+    const mine = await getSignedDeclaration(relayIdentity);
+    const theirs = await getSignedDeclaration(otherIdentity);
+    expect(theirs.relay_public_key).not.toBe(mine.relay_public_key);
+    expect(theirs.hash).not.toBe(mine.hash);
   });
 });
 

--- a/services/relay/src/index.ts
+++ b/services/relay/src/index.ts
@@ -1533,9 +1533,13 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
     // §8 savant-gap closure.
     void (async () => {
       try {
-        const { buildSignedDeclaration, anchorTransparencyDeclaration } =
+        const { getSignedDeclaration, anchorTransparencyDeclaration } =
           await import("./transparency.js");
-        const declaration = await buildSignedDeclaration(relayIdentity);
+        // Shared singleton — the SAME declaration bytes the serve path
+        // caches, so the anchored hash IS the served hash (declared_at is
+        // in the hash; a separate build here would anchor a phantom the
+        // endpoint never serves). See getSignedDeclaration.
+        const declaration = await getSignedDeclaration(relayIdentity);
         const result = await anchorTransparencyDeclaration(declaration, memoSubmitter);
         logger.info("transparency.anchored", {
           hash: declaration.hash,

--- a/services/relay/src/transparency.ts
+++ b/services/relay/src/transparency.ts
@@ -375,6 +375,32 @@ export async function buildSignedDeclaration(
 }
 
 /**
+ * Process-wide singleton signed declaration, keyed by relay identity.
+ *
+ * `declared_at` is inside the hashed+signed payload (see
+ * `buildSignedDeclaration`), so two independent `buildSignedDeclaration`
+ * calls produce two different `Date.now()` timestamps → two different
+ * hashes. The serve path (`registerTransparencyRoutes`) and the onchain
+ * anchor path (`index.ts` boot) MUST therefore consume the SAME built
+ * instance — otherwise the anchor certifies a hash the endpoint never
+ * serves, and the TOFU cross-check the anchor exists to provide (fetch
+ * declaration → hash → find matching Solana memo) can never succeed.
+ * This accessor is the single shared source: build once, serve AND anchor
+ * the same bytes. Keyed by identity object so tests with distinct
+ * identities stay isolated.
+ */
+const declarationCache = new WeakMap<RelayIdentity, Promise<SignedDeclaration>>();
+
+export function getSignedDeclaration(relayIdentity: RelayIdentity): Promise<SignedDeclaration> {
+  let declaration = declarationCache.get(relayIdentity);
+  if (declaration === undefined) {
+    declaration = buildSignedDeclaration(relayIdentity);
+    declarationCache.set(relayIdentity, declaration);
+  }
+  return declaration;
+}
+
+/**
  * Anchor a signed transparency declaration to Solana via the Memo
  * program. Closes the trust-on-first-use (TOFU) gap on the first fetch
  * of `/.well-known/motebit-transparency.json` — a verifier who knows
@@ -540,8 +566,10 @@ export interface TransparencyRouteDeps {
 export async function registerTransparencyRoutes(deps: TransparencyRouteDeps): Promise<void> {
   const { app, relayIdentity } = deps;
 
-  // Build once at startup. The declaration content is static between deploys.
-  const declaration = await buildSignedDeclaration(relayIdentity);
+  // Build once at startup, via the shared singleton so the onchain anchor
+  // path (index.ts) serves and anchors the SAME bytes (same declared_at,
+  // same hash). See getSignedDeclaration.
+  const declaration = await getSignedDeclaration(relayIdentity);
 
   // Public endpoint — unauthenticated, served as canonical JSON for
   // verifier compatibility (no Express middleware-style key reordering).


### PR DESCRIPTION
## The defect (found by a live prod money-path smoke-test)

The relay's operator-transparency onchain anchor certifies a declaration the relay **never serves**.

- **Serve path** (`transparency.ts` `registerTransparencyRoutes`) builds the declaration once at startup → `declared_at = T1` → served hash `H1`, cached and served at `/.well-known/motebit-transparency.json`.
- **Anchor path** (`index.ts` boot IIFE) made a *separate* `buildSignedDeclaration` call → `declared_at = T2` → anchored hash `H2` onchain.

`declared_at` is inside the hashed+signed payload, so `T1 ≠ T2` ⇒ `H1 ≠ H2`, **always, by construction.**

The anchor exists for exactly one purpose (its own comment; `transparency.ts:513`): a verifier fetches the declaration, hashes it, and finds the matching Solana memo at the relay's pinned address — closing the trust-on-first-use gap. **That cross-check could never succeed.**

Confirmed live against `relay.motebit.com`:
```
served hash   : 68b7c518…  (declared_at today)
onchain memos : latest 3a7eb366…  — no memo matches the served hash
signer key    : 11c266f2…  ✓ (relay identity / treasury)
```

This is a **self-attesting-system** claim that fails when a stranger tests it, and a textbook **composition-preserves-enforcement** flaw: two individually-correct components (serve signs fine; anchor submits fine) whose guarantee — *served hash == anchored hash* — lived only in their composition, shared by neither.

## The fix (tight)

`getSignedDeclaration(relayIdentity)` — a WeakMap-memoized singleton that **both** the serve path and the anchor path consume. Build once, serve AND anchor the same bytes → served hash *is* anchored hash. Keyed by identity object so tests stay isolated.

Regression test (`transparency.test.ts`) models the two real call sites and asserts `served.hash === anchoredHash`, plus:
- `declared_at`-is-hash-affecting (pins the hazard the accessor removes),
- stable singleton per identity,
- WeakMap identity isolation.

## Verified
- `transparency` tests: 22/22 (4 new)
- full relay suite: 1489 passed, 2 known-skips
- typecheck + lint clean
- all 136 hard drift gates pass

## Follow-up (separate PR, per scope)
The one-shot boot anchor is fire-and-forget with no retry and **not** under `superviseInterval` (unlike the ~15 loops rule 18 supervises) — a transient RPC failure leaves the live declaration unanchored, invisibly. That explains why the latest onchain transparency memo is ~38h old despite a ~14h-ago restart. Supervision fix filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)