### PR TITLE
fix(relay): supervise the transparency anchor — retry-until-landed, visible on /admin/health

### DIFF
--- a/scripts/check-gates-effective.ts
+++ b/scripts/check-gates-effective.ts
@@ -2078,17 +2078,19 @@ export async function probeFetch(): Promise<unknown> {
   {
     script: "check-transparency-onchain-anchored",
     proves:
-      "flags a relay startup that constructs a `SolanaMemoSubmitter` without calling `anchorTransparencyDeclaration`. Drift class: the TOFU/savant gap — the producer-signed declaration goes unanchored, leaving a network-layer trust hole the verifier cannot close from the consumer side.",
+      "flags a relay startup that constructs a `SolanaMemoSubmitter` without wiring the transparency anchor (`startTransparencyAnchorLoop` or `anchorTransparencyDeclaration`). Drift class: the TOFU/savant gap — the producer-signed declaration goes unanchored, leaving a network-layer trust hole the verifier cannot close from the consumer side.",
     perturb: () =>
-      // Mutate services/relay/src/index.ts to remove the
-      // anchorTransparencyDeclaration call while keeping
-      // createSolanaMemoSubmitter intact. The gate must reject the
-      // file because the submitter is wired but the anchor is not.
+      // Mutate services/relay/src/index.ts to remove the transparency
+      // anchor wiring while keeping createSolanaMemoSubmitter intact. The
+      // gate must reject the file because the submitter is wired but the
+      // anchor is not. index.ts wires the anchor via the supervised
+      // startTransparencyAnchorLoop call — strip that (and any direct
+      // anchor call) so both needles are absent.
       mutateFile(`services/relay/src/index.ts`, (src) => {
-        // Strip the entire anchor-block we added; the gate sees
-        // createSolanaMemoSubmitter still present, anchorTransparencyDeclaration
-        // absent.
-        return src.replace(/anchorTransparencyDeclaration/g, "probe_anchor_removed");
+        return src.replace(
+          /startTransparencyAnchorLoop|anchorTransparencyDeclaration/g,
+          "probe_anchor_removed",
+        );
       }),
   },
   {

--- a/scripts/check-transparency-onchain-anchored.ts
+++ b/scripts/check-transparency-onchain-anchored.ts
@@ -18,12 +18,15 @@
  *
  * This gate makes the producer side load-bearing: in the relay startup
  * file, every code path that constructs a `SolanaMemoSubmitter` MUST
- * also wire `anchorTransparencyDeclaration` so the declaration's hash
- * is committed onchain. Forgetting the second call leaves the savant
- * gap open silently.
+ * also wire the transparency anchor so the declaration's hash is
+ * committed onchain — either the supervised `startTransparencyAnchorLoop`
+ * (the canonical shape: retry-until-landed + visible on /admin/health) or
+ * a direct `anchorTransparencyDeclaration` call. Forgetting the wiring
+ * leaves the savant gap open silently.
  *
  * Forbidden: a relay startup that creates `createSolanaMemoSubmitter`
- * without a corresponding `anchorTransparencyDeclaration` call.
+ * without wiring the transparency anchor (`startTransparencyAnchorLoop`
+ * or `anchorTransparencyDeclaration`).
  *
  * Scope: `services/relay/src/index.ts` only. The gate is narrow on
  * purpose — Solana submitters constructed elsewhere (tests, scripts)
@@ -43,7 +46,9 @@ const REPO_ROOT = resolve(new URL(".", import.meta.url).pathname, "..");
 const SCAN_FILES = ["services/relay/src/index.ts"];
 
 const SUBMITTER_PATTERN = /\bcreateSolanaMemoSubmitter\s*\(/g;
-const ANCHOR_PATTERN = /\banchorTransparencyDeclaration\s*\(/g;
+// The anchor is wired either through the supervised loop (canonical) or a
+// direct anchor call — both commit the declaration hash onchain.
+const ANCHOR_PATTERN = /\b(startTransparencyAnchorLoop|anchorTransparencyDeclaration)\s*\(/g;
 
 interface Finding {
   file: string;
@@ -84,7 +89,7 @@ function main(): void {
     if (anchorMatches.length === 0) {
       findings.push({
         file: rel,
-        reason: `creates createSolanaMemoSubmitter (${submitterMatches.length} call(s)) but does NOT call anchorTransparencyDeclaration anywhere in the file — the transparency declaration goes unanchored, leaving the TOFU/savant gap open`,
+        reason: `creates createSolanaMemoSubmitter (${submitterMatches.length} call(s)) but does NOT wire the transparency anchor (startTransparencyAnchorLoop or anchorTransparencyDeclaration) anywhere in the file — the transparency declaration goes unanchored, leaving the TOFU/savant gap open`,
       });
     }
   }
@@ -107,22 +112,27 @@ function main(): void {
   }
   console.log(
     `\n  Fix: after createSolanaMemoSubmitter constructs the submitter,\n` +
-      `       call anchorTransparencyDeclaration with the same submitter so\n` +
-      `       the declaration's hash is committed onchain:\n` +
+      `       start the supervised transparency anchor loop with the same\n` +
+      `       submitter so the declaration's hash is committed onchain:\n` +
       `\n` +
-      `         const { buildSignedDeclaration, anchorTransparencyDeclaration } =\n` +
+      `         const { startTransparencyAnchorLoop } =\n` +
       `           await import("./transparency.js");\n` +
-      `         const declaration = await buildSignedDeclaration(relayIdentity);\n` +
-      `         await anchorTransparencyDeclaration(declaration, memoSubmitter);\n` +
+      `         transparencyAnchorInterval = startTransparencyAnchorLoop(\n` +
+      `           relayIdentity,\n` +
+      `           memoSubmitter,\n` +
+      `           () => getEmergencyFreeze(),\n` +
+      `           loopSupervisor,\n` +
+      `         );\n` +
       `\n` +
       `       Closes the trust-on-first-use savant gap: a verifier with the\n` +
       `       relay's pinned anchor address can cross-check the declaration\n` +
       `       hash against the onchain memo without trusting HTTPS/DNS for\n` +
-      `       the first contact. Fire-and-forget at the relay; anchor failure\n` +
+      `       the first contact. The loop retries until it lands and surfaces\n` +
+      `       a persistent failure on GET /api/v1/admin/health; anchor failure\n` +
       `       must NOT block startup.\n` +
       `\n` +
       `       Doctrine: docs/doctrine/operator-transparency.md § Stage 2,\n` +
-      `       docs/doctrine/nist-alignment.md §8.\n`,
+      `       docs/doctrine/nist-alignment.md §8, services/relay/CLAUDE.md rule 18.\n`,
   );
   process.exit(1);
 }

--- a/services/relay/src/__tests__/transparency.test.ts
+++ b/services/relay/src/__tests__/transparency.test.ts
@@ -22,10 +22,12 @@ import {
 } from "@motebit/encryption";
 import {
   anchorTransparencyDeclaration,
+  attemptTransparencyAnchor,
   buildSignedDeclaration,
   getSignedDeclaration,
   renderMarkdown,
   DECLARATION_CONTENT,
+  type TransparencyAnchorState,
 } from "../transparency.js";
 import type { RelayIdentity } from "../federation.js";
 
@@ -204,6 +206,67 @@ describe("getSignedDeclaration — served hash IS anchored hash (composition gua
     const theirs = await getSignedDeclaration(otherIdentity);
     expect(theirs.relay_public_key).not.toBe(mine.relay_public_key);
     expect(theirs.hash).not.toBe(mine.hash);
+  });
+});
+
+describe("attemptTransparencyAnchor — supervised-loop core (idempotent + retry-safe)", () => {
+  // The prior boot anchor was a fire-and-forget one-shot: a transient RPC
+  // failure left the live declaration PERMANENTLY unanchored, invisibly. The
+  // supervised loop retries until it lands; this is its per-tick core.
+
+  it("anchors once and reports the SERVED hash", async () => {
+    const served = await getSignedDeclaration(relayIdentity);
+    const state: TransparencyAnchorState = { anchored: false };
+    let submitted: string | undefined;
+
+    const landed = await attemptTransparencyAnchor(state, relayIdentity, {
+      submitTransparencyAnchor: async (hash) => {
+        submitted = hash;
+        return { txHash: "tx-1" };
+      },
+    });
+
+    expect(landed).not.toBeNull();
+    expect(landed!.hash).toBe(served.hash); // what lands IS what is served
+    expect(landed!.txHash).toBe("tx-1");
+    expect(submitted).toBe(served.hash);
+    expect(state.anchored).toBe(true);
+  });
+
+  it("is a no-op once anchored (does not re-pay to re-anchor an idempotent hash)", async () => {
+    const state: TransparencyAnchorState = { anchored: true };
+    let calls = 0;
+    const landed = await attemptTransparencyAnchor(state, relayIdentity, {
+      submitTransparencyAnchor: async () => {
+        calls += 1;
+        return { txHash: "tx" };
+      },
+    });
+    expect(landed).toBeNull();
+    expect(calls).toBe(0); // submitter never touched
+  });
+
+  it("retry-safe: a failed submit leaves anchored=false, and the next attempt lands", async () => {
+    const state: TransparencyAnchorState = { anchored: false };
+
+    // Tick 1: submitter throws (transient RPC failure). Rethrows so the
+    // supervised loop records the error; state stays unanchored.
+    await expect(
+      attemptTransparencyAnchor(state, relayIdentity, {
+        submitTransparencyAnchor: async () => {
+          throw new Error("solana rpc down");
+        },
+      }),
+    ).rejects.toThrow("solana rpc down");
+    expect(state.anchored).toBe(false);
+
+    // Tick 2: RPC recovers → the anchor lands. The exact permanence bug the
+    // old fire-and-forget one-shot could not recover from.
+    const landed = await attemptTransparencyAnchor(state, relayIdentity, {
+      submitTransparencyAnchor: async () => ({ txHash: "tx-2" }),
+    });
+    expect(landed).not.toBeNull();
+    expect(state.anchored).toBe(true);
   });
 });
 

--- a/services/relay/src/index.ts
+++ b/services/relay/src/index.ts
@@ -1106,6 +1106,7 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
   // forward-declared bindings are initialized by then.
   let solanaTreasuryAddress: string | undefined;
   let solanaTreasuryReconciliationInterval: ReturnType<typeof setInterval> | undefined;
+  let transparencyAnchorInterval: ReturnType<typeof setInterval> | undefined;
 
   // Admin: treasury reconciliation overview (recent records + aggregated stats).
   // Response shape is per-chain: `chains[]` carries one entry per active or
@@ -1521,37 +1522,26 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
       streams: ["settlement", "credential", "revocation", "transparency"],
     });
 
-    // --- Transparency declaration onchain anchoring ---
+    // --- Transparency declaration onchain anchoring (supervised) ---
     // Closes the TOFU gap on /.well-known/motebit-transparency.json: a
     // verifier with the pinned relay anchor address can cross-check the
     // declaration's hash against a Solana memo without trusting the
-    // HTTPS/DNS channel that delivered the declaration. Fire-and-forget
-    // — anchor failure does not block startup or invalidate the signed
-    // (unanchored) declaration; an unanchored verifier still gets TOFU.
-    // Doctrine: docs/doctrine/operator-transparency.md § Stage 2 onchain
-    // anchor (lifted forward 2026-05-11); docs/doctrine/nist-alignment.md
-    // §8 savant-gap closure.
-    void (async () => {
-      try {
-        const { getSignedDeclaration, anchorTransparencyDeclaration } =
-          await import("./transparency.js");
-        // Shared singleton — the SAME declaration bytes the serve path
-        // caches, so the anchored hash IS the served hash (declared_at is
-        // in the hash; a separate build here would anchor a phantom the
-        // endpoint never serves). See getSignedDeclaration.
-        const declaration = await getSignedDeclaration(relayIdentity);
-        const result = await anchorTransparencyDeclaration(declaration, memoSubmitter);
-        logger.info("transparency.anchored", {
-          hash: declaration.hash,
-          tx_hash: result.txHash,
-          anchor_address: memoSubmitter.address,
-        });
-      } catch (err) {
-        logger.warn("transparency.anchor_failed", {
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    })();
+    // HTTPS/DNS channel that delivered the declaration. Supervised +
+    // retry-until-landed (rule 18): the prior fire-and-forget one-shot left
+    // the live declaration PERMANENTLY unanchored on any transient RPC
+    // failure, invisibly. Now a persistent failure surfaces as
+    // `transparency-anchor` erroring on GET /api/v1/admin/health, and the
+    // loop retries until it lands (then idempotent no-op). The anchor uses
+    // the shared getSignedDeclaration singleton so what lands IS what the
+    // endpoint serves. Doctrine: docs/doctrine/operator-transparency.md
+    // § Stage 2 onchain anchor; docs/doctrine/nist-alignment.md §8.
+    const { startTransparencyAnchorLoop } = await import("./transparency.js");
+    transparencyAnchorInterval = startTransparencyAnchorLoop(
+      relayIdentity,
+      memoSubmitter,
+      () => getEmergencyFreeze(),
+      loopSupervisor,
+    );
   }
 
   // --- Settlement anchor batching (relay-federation-v1.md §7.6) ---
@@ -1871,6 +1861,7 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
     if (p2pVerifierInterval) clearInterval(p2pVerifierInterval);
     if (bondVerifierInterval) clearInterval(bondVerifierInterval);
     if (solanaTreasuryReconciliationInterval) clearInterval(solanaTreasuryReconciliationInterval);
+    if (transparencyAnchorInterval) clearInterval(transparencyAnchorInterval);
     clearInterval(sweepInterval);
     clearInterval(batchWithdrawalInterval);
     clearInterval(orchestrationWorkerInterval);

--- a/services/relay/src/transparency.ts
+++ b/services/relay/src/transparency.ts
@@ -31,6 +31,10 @@ import { canonicalJson, sign, bytesToHex, sha256 } from "@motebit/encryption";
 import type { SignedTransparencyDeclaration } from "@motebit/protocol";
 import { TRANSPARENCY_SPEC_ID, TRANSPARENCY_SUITE } from "@motebit/protocol";
 import type { RelayIdentity } from "./federation.js";
+import { createLogger } from "./logger.js";
+import { superviseInterval, type LoopSupervisor } from "./loop-supervisor.js";
+
+const logger = createLogger({ service: "relay", module: "transparency" });
 
 // ---------------------------------------------------------------------------
 // Source of truth — every field here must match observable retention behavior
@@ -422,6 +426,87 @@ export async function anchorTransparencyDeclaration(
   submitter: { submitTransparencyAnchor: (hashHex: string) => Promise<{ txHash: string }> },
 ): Promise<{ txHash: string }> {
   return submitter.submitTransparencyAnchor(declaration.hash);
+}
+
+/** Default retry cadence for the transparency anchor loop (1 minute). */
+export const TRANSPARENCY_ANCHOR_RETRY_MS = 60_000;
+
+/** Mutable landed-flag threaded through the anchor loop's ticks. */
+export interface TransparencyAnchorState {
+  anchored: boolean;
+}
+
+/**
+ * One anchor attempt, idempotent-guarded. Returns the anchored hash + txHash
+ * on the attempt that lands, `null` once already anchored (a cheap no-op —
+ * re-anchoring an unchanged, idempotent hash only wastes SOL). Throws on
+ * submitter failure WITHOUT setting `anchored`, so the supervised loop records
+ * the error and retries on the next tick rather than giving up permanently.
+ *
+ * Consumes the SAME shared singleton the serve path caches
+ * (`getSignedDeclaration`), so what lands on chain is exactly what the endpoint
+ * serves — the invariant `getSignedDeclaration` exists to hold.
+ */
+export async function attemptTransparencyAnchor(
+  state: TransparencyAnchorState,
+  relayIdentity: RelayIdentity,
+  submitter: { submitTransparencyAnchor: (hashHex: string) => Promise<{ txHash: string }> },
+): Promise<{ txHash: string; hash: string } | null> {
+  if (state.anchored) return null;
+  const declaration = await getSignedDeclaration(relayIdentity);
+  const result = await anchorTransparencyDeclaration(declaration, submitter);
+  state.anchored = true;
+  return { txHash: result.txHash, hash: declaration.hash };
+}
+
+/**
+ * Start the supervised transparency-anchor loop.
+ *
+ * Replaces the prior fire-and-forget boot IIFE, which had TWO invisible
+ * failure modes: a transient RPC failure at boot left the live declaration
+ * PERMANENTLY unanchored (no retry), and the failure never reached the
+ * `GET /api/v1/admin/health` `loops` surface (off-supervisor). Both are the
+ * rule-18 class — money/trust-adjacent boot work must be supervised, not
+ * `void asyncWork()`.
+ *
+ * The loop attempts the anchor each tick until it lands, then idempotent-guards
+ * to a cheap no-op `ok` tick (it stays registered so the supervisor keeps
+ * reporting `ok`; clearing it on success would let the freshness window flip it
+ * to a false `stale` and poison `anyUnhealthy()`). A persistent failure shows
+ * as `transparency-anchor` `erroring`. First attempt fires after `intervalMs`
+ * (superviseInterval's cadence) — a negligible delay for an additive,
+ * TOFU-backed trust anchor.
+ *
+ * Doctrine: `services/relay/CLAUDE.md` rule 18;
+ * `docs/doctrine/operator-transparency.md` § Stage 2 onchain anchor.
+ */
+export function startTransparencyAnchorLoop(
+  relayIdentity: RelayIdentity,
+  submitter: {
+    submitTransparencyAnchor: (hashHex: string) => Promise<{ txHash: string }>;
+    address: string;
+  },
+  isFrozen: () => boolean,
+  supervisor?: LoopSupervisor,
+  intervalMs: number = TRANSPARENCY_ANCHOR_RETRY_MS,
+): ReturnType<typeof setInterval> {
+  const state: TransparencyAnchorState = { anchored: false };
+  return superviseInterval(
+    supervisor,
+    "transparency-anchor",
+    intervalMs,
+    async () => {
+      const landed = await attemptTransparencyAnchor(state, relayIdentity, submitter);
+      if (landed) {
+        logger.info("transparency.anchored", {
+          hash: landed.hash,
+          tx_hash: landed.txHash,
+          anchor_address: submitter.address,
+        });
+      }
+    },
+    { isFrozen },
+  );
 }
 
 /**


### PR DESCRIPTION
## Follow-up to #405 — the secondary find, confirmed live

#405 fixed *what* the anchor certifies (served hash == anchored hash). This fixes *whether it lands at all*.

The boot transparency anchor was a **fire-and-forget one-shot** with two invisible failure modes (the `services/relay/CLAUDE.md` rule-18 class):
- a transient RPC failure at boot left the live declaration **permanently unanchored** (no retry), and
- the failure never reached the `GET /api/v1/admin/health` `loops` surface.

**Observed live:** immediately after deploying #405, the fresh boot's served hash (`9eb301b5…`) **never landed onchain** — the exact silent one-shot failure. The treasury has SOL for the fee (~179 memo txs), so it's the no-retry gap, not depletion.

## Fix

`startTransparencyAnchorLoop` — a **supervised** (`superviseInterval`) loop that attempts the anchor each tick until it lands, then idempotent-guards to a cheap no-op `ok` tick. It stays registered (clearing on success would let the freshness window flip it to a false `stale` and poison `anyUnhealthy()`); a persistent failure surfaces as `transparency-anchor` **erroring** on `/admin/health`.

The tick core `attemptTransparencyAnchor` is:
- **idempotent** — no-op once landed; does not re-pay to re-anchor an unchanged hash,
- **retry-safe** — a failed submit leaves `anchored=false` and rethrows, so the supervisor records the error and the next tick retries.

It consumes the same `getSignedDeclaration` singleton, so #405's served==anchored invariant is preserved. Registered for shutdown cleanup alongside the sibling conditional loops.

## Tests + gate
- `attemptTransparencyAnchor`: anchors-once-reports-served-hash / no-op-once-anchored / retry-safe-after-failure (no timers).
- `check-transparency-onchain-anchored` + its `check-gates-effective` probe updated to accept `startTransparencyAnchorLoop` as the canonical anchor wiring (supervised superset of a bare `anchorTransparencyDeclaration` call).

## Verified
- relay: 1492 tests, 2 known-skips
- **136 hard gates**, **149/149 gate-effectiveness** all green
- typecheck + lint clean

## Operational note (not in this PR)
The relay's Solana treasury (`2CKrwjT5…`, the memo fee-payer) is at ~0.000895 SOL (~179 memo txs). When it hits zero all onchain anchoring stops — silently today, *visibly on /admin/health* once this ships. Worth a top-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)