### PR TITLE
feat(relay): fee-payer solvency guard — alert before the anchor wallet freezes below the rent floor

### DIFF
--- a/packages/wallet-solana/src/__tests__/memo-submitter.test.ts
+++ b/packages/wallet-solana/src/__tests__/memo-submitter.test.ts
@@ -22,6 +22,7 @@ const latestBlockhashMock = vi.fn();
 const sendRawTransactionMock = vi.fn();
 const confirmTransactionMock = vi.fn();
 const getBalanceMock = vi.fn();
+const getMinimumBalanceForRentExemptionMock = vi.fn();
 
 vi.mock("@solana/web3.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@solana/web3.js")>();
@@ -33,6 +34,7 @@ vi.mock("@solana/web3.js", async (importOriginal) => {
     sendRawTransaction = sendRawTransactionMock;
     confirmTransaction = confirmTransactionMock;
     getBalance = getBalanceMock;
+    getMinimumBalanceForRentExemption = getMinimumBalanceForRentExemptionMock;
   }
   return {
     ...actual,
@@ -176,6 +178,19 @@ describe("SolanaMemoSubmitter", () => {
       network: SOLANA_DEVNET_CAIP2,
     });
     expect(submitter.network).toBe(SOLANA_DEVNET_CAIP2);
+  });
+
+  it("getFeePayerSolvency reads balance + rent-exempt-min for the identity wallet", async () => {
+    getBalanceMock.mockResolvedValueOnce(895_000);
+    getMinimumBalanceForRentExemptionMock.mockResolvedValueOnce(890_880);
+    const submitter = new SolanaMemoSubmitter({
+      rpcUrl: "https://api.mainnet-beta.solana.com",
+      identitySeed: seed,
+    });
+    const solvency = await submitter.getFeePayerSolvency();
+    expect(solvency).toEqual({ balanceLamports: 895_000, rentExemptMinLamports: 890_880 });
+    // rent-exempt-min is queried for a 0-data account (the plain wallet).
+    expect(getMinimumBalanceForRentExemptionMock).toHaveBeenCalledWith(0, "confirmed");
   });
 
   it("derives address from seed", () => {

--- a/packages/wallet-solana/src/memo-submitter.ts
+++ b/packages/wallet-solana/src/memo-submitter.ts
@@ -74,6 +74,32 @@ export class SolanaMemoSubmitter implements ChainAnchorSubmitter {
     return this.keypair.publicKey.toBase58();
   }
 
+  /**
+   * Read the fee-payer's on-chain solvency: its native SOL balance and the
+   * rent-exempt minimum for a bare (0-data) account. The fee-payer IS this
+   * submitter's identity wallet, which pays the base fee on every anchor
+   * (settlement / credential / revocation / transparency) memo.
+   *
+   * Solana rejects any transaction that would leave the fee-payer below the
+   * rent-exempt minimum — so the *spendable* headroom is
+   * `balance - rentExemptMin`, NOT the raw balance. A wallet sitting just
+   * above the rent floor (headroom < one base fee) is effectively FROZEN:
+   * every anchor fails at simulation with an empty-log error, silently
+   * stalling all on-chain anchoring. Callers use this to alert before that
+   * threshold, not after. (Observed in prod 2026-07-25: 895_000 lamports
+   * balance, 890_880 rent-min ⇒ 4_120 headroom < 5_000 fee ⇒ frozen.)
+   */
+  async getFeePayerSolvency(): Promise<{
+    balanceLamports: number;
+    rentExemptMinLamports: number;
+  }> {
+    const [balanceLamports, rentExemptMinLamports] = await Promise.all([
+      this.connection.getBalance(this.keypair.publicKey, this.commitment),
+      this.connection.getMinimumBalanceForRentExemption(0, this.commitment),
+    ]);
+    return { balanceLamports, rentExemptMinLamports };
+  }
+
   async submitMerkleRoot(
     root: string,
     _relayId: string,

--- a/services/relay/src/__tests__/fee-payer-guard.test.ts
+++ b/services/relay/src/__tests__/fee-payer-guard.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Fee-payer solvency guard tests.
+ *
+ * The guard exists because Solana freezes a fee-payer that would drop below the
+ * rent-exempt floor — spendable headroom is `balance - rentExemptMin`, not the
+ * raw balance. These tests pin the decision boundary with the exact prod
+ * incident numbers (2026-07-25) and the throw-to-alert behavior.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  classifyFeePayerSolvency,
+  checkFeePayerSolvencyOnce,
+  startFeePayerBalanceGuardLoop,
+  BASE_TX_FEE_LAMPORTS,
+  DEFAULT_WARN_HEADROOM_TXS,
+  type FeePayerSolvencySource,
+} from "../fee-payer-guard.js";
+import { LoopSupervisor } from "../loop-supervisor.js";
+
+// The prod incident: balance sat just above the rent floor → frozen.
+const INCIDENT_BALANCE = 895_000;
+const INCIDENT_RENT_MIN = 890_880;
+
+describe("classifyFeePayerSolvency — rent-floor-aware headroom", () => {
+  it("headroom is balance MINUS rent-exempt-min, not the raw balance", () => {
+    const s = classifyFeePayerSolvency(INCIDENT_BALANCE, INCIDENT_RENT_MIN);
+    expect(s.headroomLamports).toBe(4_120); // 895_000 - 890_880
+    // The trap the guard exists to close: 895_000 / 5_000 = 179 "txs" if you
+    // ignore rent — but the real capacity is 0.
+    expect(s.headroomTxs).toBe(0);
+  });
+
+  it("flags the incident state as frozen AND low", () => {
+    const s = classifyFeePayerSolvency(INCIDENT_BALANCE, INCIDENT_RENT_MIN);
+    expect(s.frozen).toBe(true); // 4_120 < 5_000 base fee
+    expect(s.status).toBe("low");
+  });
+
+  it("a well-funded fee-payer is ok and not frozen", () => {
+    const s = classifyFeePayerSolvency(25_000_000, INCIDENT_RENT_MIN);
+    expect(s.frozen).toBe(false);
+    expect(s.status).toBe("ok");
+    expect(s.headroomTxs).toBeGreaterThan(DEFAULT_WARN_HEADROOM_TXS);
+  });
+
+  it("warns BEFORE the freeze — low while still spendable (proactive lead time)", () => {
+    // Headroom for 50 txs: spendable but below the 200-tx warn threshold.
+    const balance = INCIDENT_RENT_MIN + 50 * BASE_TX_FEE_LAMPORTS;
+    const s = classifyFeePayerSolvency(balance, INCIDENT_RENT_MIN);
+    expect(s.frozen).toBe(false); // can still anchor
+    expect(s.status).toBe("low"); // but already alerting
+    expect(s.headroomTxs).toBe(50);
+  });
+
+  it("is exactly at the boundary: warnHeadroomTxs is the first ok count", () => {
+    const rent = 1_000_000;
+    const atThreshold = rent + DEFAULT_WARN_HEADROOM_TXS * BASE_TX_FEE_LAMPORTS;
+    expect(classifyFeePayerSolvency(atThreshold, rent).status).toBe("ok");
+    expect(classifyFeePayerSolvency(atThreshold - BASE_TX_FEE_LAMPORTS, rent).status).toBe("low");
+  });
+
+  it("clamps a below-rent-min balance to 0 txs (never negative)", () => {
+    const s = classifyFeePayerSolvency(500_000, INCIDENT_RENT_MIN);
+    expect(s.headroomLamports).toBeLessThan(0);
+    expect(s.headroomTxs).toBe(0);
+    expect(s.frozen).toBe(true);
+    expect(s.status).toBe("low");
+  });
+});
+
+describe("checkFeePayerSolvencyOnce — throw-to-alert", () => {
+  const source = (
+    balanceLamports: number,
+    rentExemptMinLamports: number,
+  ): FeePayerSolvencySource => ({
+    address: "TreasuryAddr1111111111111111111111111111111",
+    getFeePayerSolvency: async () => ({ balanceLamports, rentExemptMinLamports }),
+  });
+
+  it("throws a descriptive, frozen-labeled error on the incident state", async () => {
+    await expect(
+      checkFeePayerSolvencyOnce(source(INCIDENT_BALANCE, INCIDENT_RENT_MIN)),
+    ).rejects.toThrow(/solvency LOW.*FROZEN.*Top up/s);
+  });
+
+  it("throws (alerts) while low-but-not-yet-frozen — the proactive window", async () => {
+    const balance = INCIDENT_RENT_MIN + 50 * BASE_TX_FEE_LAMPORTS;
+    await expect(checkFeePayerSolvencyOnce(source(balance, INCIDENT_RENT_MIN))).rejects.toThrow(
+      /solvency LOW/,
+    );
+    // Not frozen, so the message must NOT claim the freeze.
+    await expect(checkFeePayerSolvencyOnce(source(balance, INCIDENT_RENT_MIN))).rejects.not.toThrow(
+      /FROZEN/,
+    );
+  });
+
+  it("returns ok (no throw) when well-funded", async () => {
+    const s = await checkFeePayerSolvencyOnce(source(25_000_000, INCIDENT_RENT_MIN));
+    expect(s.status).toBe("ok");
+    expect(s.frozen).toBe(false);
+  });
+
+  it("propagates an RPC read failure (a distinct unhappy signal)", async () => {
+    const failing: FeePayerSolvencySource = {
+      address: "TreasuryAddr1111111111111111111111111111111",
+      getFeePayerSolvency: async () => {
+        throw new Error("429 Too Many Requests");
+      },
+    };
+    await expect(checkFeePayerSolvencyOnce(failing)).rejects.toThrow("429 Too Many Requests");
+  });
+});
+
+describe("startFeePayerBalanceGuardLoop — supervised registration", () => {
+  it("registers `fee-payer-balance-guard` on the supervisor and returns a clearable handle", () => {
+    const supervisor = new LoopSupervisor();
+    const source: FeePayerSolvencySource = {
+      address: "TreasuryAddr1111111111111111111111111111111",
+      getFeePayerSolvency: async () => ({
+        balanceLamports: 25_000_000,
+        rentExemptMinLamports: 890_880,
+      }),
+    };
+    // Huge interval so the first tick never fires during the test; the loop is
+    // registered synchronously by superviseInterval before any tick.
+    const handle = startFeePayerBalanceGuardLoop(source, () => false, supervisor, {
+      intervalMs: 2_147_483_646,
+    });
+    expect(supervisor.snapshot().map((l) => l.name)).toContain("fee-payer-balance-guard");
+    clearInterval(handle);
+  });
+});

--- a/services/relay/src/fee-payer-guard.ts
+++ b/services/relay/src/fee-payer-guard.ts
@@ -1,0 +1,158 @@
+/**
+ * Fee-payer solvency guard — proactive alerting before the anchor fee-payer
+ * freezes below Solana's rent-exempt floor.
+ *
+ * Every on-chain anchor (settlement / credential / revocation / identity-log /
+ * transparency) pays a base fee from the relay's identity wallet. Solana
+ * rejects any transaction that would leave the fee-payer below the rent-exempt
+ * minimum, so the *spendable* headroom is `balance - rentExemptMin`, not the
+ * raw balance. A wallet resting just above the rent floor (headroom < one base
+ * fee) is FROZEN: every anchor fails at simulation, silently stalling all
+ * on-chain anchoring.
+ *
+ * That happened in prod 2026-07-25 — the treasury sat at 895_000 lamports
+ * against an 890_880 rent-min (4_120 headroom < 5_000 fee) and every anchor
+ * had been failing for ~38h, invisibly. The transparency-anchor supervision
+ * loop surfaced the *symptom* (an erroring anchor loop) only AFTER the freeze;
+ * this guard surfaces the *cause* BEFORE it, by watching the headroom directly.
+ *
+ * Design (rule 18): a supervised loop that reads the fee-payer's solvency each
+ * tick and — when spendable headroom drops below a transaction-count threshold —
+ * logs a structured warning AND throws, so the loop shows `fee-payer-balance-guard`
+ * `erroring` on `GET /api/v1/admin/health` (and flips `anyUnhealthy()`). A
+ * healthy balance is a quiet `ok` tick. The RPC read itself failing also throws
+ * (a distinct message) — both are legitimately "this guard is unhappy."
+ *
+ * Doctrine: `services/relay/CLAUDE.md` rule 18; sibling of the transparency
+ * anchor supervision (`transparency.ts`).
+ */
+
+import { createLogger } from "./logger.js";
+import { superviseInterval, type LoopSupervisor } from "./loop-supervisor.js";
+
+const logger = createLogger({ service: "relay", module: "fee-payer-guard" });
+
+/** Solana base transaction fee (1 signature), in lamports. */
+export const BASE_TX_FEE_LAMPORTS = 5000;
+
+/**
+ * Default alert threshold: warn once spendable headroom falls below this many
+ * transactions' worth of fees. 200 txs (~1_000_000 lamports ≈ 0.001 SOL over
+ * the rent floor) gives comfortable lead time to top up before a freeze, even
+ * under the bursty identity-log-anchor backlog that can drain quickly.
+ */
+export const DEFAULT_WARN_HEADROOM_TXS = 200;
+
+/** Default cadence — balance moves slowly; 5 min is ample given the 200-tx buffer. */
+export const DEFAULT_FEE_PAYER_GUARD_INTERVAL_MS = 5 * 60_000;
+
+/** What the guard needs from the fee-payer (implemented by `SolanaMemoSubmitter`). */
+export interface FeePayerSolvencySource {
+  readonly address: string;
+  getFeePayerSolvency(): Promise<{
+    balanceLamports: number;
+    rentExemptMinLamports: number;
+  }>;
+}
+
+export interface FeePayerSolvency {
+  /** `low` once headroom < the warn threshold; `ok` otherwise. */
+  status: "ok" | "low";
+  balanceLamports: number;
+  rentExemptMinLamports: number;
+  /** Spendable lamports above the rent floor — the real capacity, not `balance`. */
+  headroomLamports: number;
+  /** Whole transactions the headroom can pay for at the base fee. */
+  headroomTxs: number;
+  /** Headroom is below a single base fee — the fee-payer cannot anchor at all. */
+  frozen: boolean;
+}
+
+/**
+ * Pure classification of a fee-payer's solvency. Separated from I/O so the
+ * decision boundary is exhaustively unit-testable with the real incident
+ * numbers.
+ */
+export function classifyFeePayerSolvency(
+  balanceLamports: number,
+  rentExemptMinLamports: number,
+  opts: { warnHeadroomTxs?: number; txFeeLamports?: number } = {},
+): FeePayerSolvency {
+  const txFee = opts.txFeeLamports ?? BASE_TX_FEE_LAMPORTS;
+  const warnTxs = opts.warnHeadroomTxs ?? DEFAULT_WARN_HEADROOM_TXS;
+  const headroomLamports = balanceLamports - rentExemptMinLamports;
+  // Clamp negatives to 0 txs (a below-rent-min account can pay for none).
+  const headroomTxs = Math.max(0, Math.floor(headroomLamports / txFee));
+  const frozen = headroomLamports < txFee;
+  const status = headroomTxs < warnTxs ? "low" : "ok";
+  return {
+    status,
+    balanceLamports,
+    rentExemptMinLamports,
+    headroomLamports,
+    headroomTxs,
+    frozen,
+  };
+}
+
+/**
+ * One solvency check. Reads the fee-payer, classifies, and — on `low` — logs a
+ * structured warning and THROWS a descriptive error so the supervised loop
+ * records it as `erroring`. Returns the solvency on `ok`. Extracted from the
+ * loop so it is testable without timers.
+ */
+export async function checkFeePayerSolvencyOnce(
+  source: FeePayerSolvencySource,
+  opts: { warnHeadroomTxs?: number } = {},
+): Promise<FeePayerSolvency> {
+  const { balanceLamports, rentExemptMinLamports } = await source.getFeePayerSolvency();
+  const s = classifyFeePayerSolvency(balanceLamports, rentExemptMinLamports, opts);
+  if (s.status === "low") {
+    logger.warn("fee_payer.solvency_low", {
+      address: source.address,
+      balance_lamports: s.balanceLamports,
+      rent_exempt_min_lamports: s.rentExemptMinLamports,
+      headroom_lamports: s.headroomLamports,
+      headroom_txs: s.headroomTxs,
+      frozen: s.frozen,
+    });
+    throw new Error(
+      `fee-payer ${source.address} solvency LOW: spendable headroom ${s.headroomLamports} lamports ` +
+        `(${s.headroomTxs} txs) above the rent-exempt floor` +
+        (s.frozen
+          ? " — FROZEN: below one base fee, every on-chain anchor fails at simulation"
+          : "") +
+        `. Top up SOL to keep on-chain anchoring alive.`,
+    );
+  }
+  logger.debug("fee_payer.solvency_ok", {
+    address: source.address,
+    headroom_txs: s.headroomTxs,
+  });
+  return s;
+}
+
+/**
+ * Start the supervised fee-payer balance guard loop. Runs only where an
+ * on-chain submitter is configured (the same `SOLANA_RPC_URL` gate as the
+ * anchoring loops). Registered on the supervisor as `fee-payer-balance-guard`;
+ * a low balance surfaces as `erroring` on `/api/v1/admin/health` before the
+ * fee-payer freezes.
+ */
+export function startFeePayerBalanceGuardLoop(
+  source: FeePayerSolvencySource,
+  isFrozen: () => boolean,
+  supervisor?: LoopSupervisor,
+  opts: { intervalMs?: number; warnHeadroomTxs?: number } = {},
+): ReturnType<typeof setInterval> {
+  const intervalMs = opts.intervalMs ?? DEFAULT_FEE_PAYER_GUARD_INTERVAL_MS;
+  return superviseInterval(
+    supervisor,
+    "fee-payer-balance-guard",
+    intervalMs,
+    async () => {
+      await checkFeePayerSolvencyOnce(source, { warnHeadroomTxs: opts.warnHeadroomTxs });
+    },
+    { isFrozen },
+  );
+}

--- a/services/relay/src/index.ts
+++ b/services/relay/src/index.ts
@@ -1107,6 +1107,7 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
   let solanaTreasuryAddress: string | undefined;
   let solanaTreasuryReconciliationInterval: ReturnType<typeof setInterval> | undefined;
   let transparencyAnchorInterval: ReturnType<typeof setInterval> | undefined;
+  let feePayerGuardInterval: ReturnType<typeof setInterval> | undefined;
 
   // Admin: treasury reconciliation overview (recent records + aggregated stats).
   // Response shape is per-chain: `chains[]` carries one entry per active or
@@ -1542,6 +1543,20 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
       () => getEmergencyFreeze(),
       loopSupervisor,
     );
+
+    // --- Fee-payer solvency guard ---
+    // The memo submitter's identity wallet pays the base fee on every anchor.
+    // Solana freezes a fee-payer that would drop below the rent-exempt floor,
+    // silently stalling ALL anchoring (prod incident 2026-07-25). This guard
+    // watches spendable headroom and surfaces `fee-payer-balance-guard`
+    // erroring on /api/v1/admin/health BEFORE the freeze — the proactive
+    // complement to the transparency loop's after-the-fact symptom. Rule 18.
+    const { startFeePayerBalanceGuardLoop } = await import("./fee-payer-guard.js");
+    feePayerGuardInterval = startFeePayerBalanceGuardLoop(
+      memoSubmitter,
+      () => getEmergencyFreeze(),
+      loopSupervisor,
+    );
   }
 
   // --- Settlement anchor batching (relay-federation-v1.md §7.6) ---
@@ -1862,6 +1877,7 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
     if (bondVerifierInterval) clearInterval(bondVerifierInterval);
     if (solanaTreasuryReconciliationInterval) clearInterval(solanaTreasuryReconciliationInterval);
     if (transparencyAnchorInterval) clearInterval(transparencyAnchorInterval);
+    if (feePayerGuardInterval) clearInterval(feePayerGuardInterval);
     clearInterval(sweepInterval);
     clearInterval(batchWithdrawalInterval);
     clearInterval(orchestrationWorkerInterval);


### PR DESCRIPTION
## Why

Prod incident (2026-07-25): the relay's Solana fee-payer sat at **895,000 lamports** against an **890,880** rent-exempt minimum. Solana rejects any transaction that would drop the fee-payer below rent-exemption, so *spendable* headroom was **4,120 lamports — less than one 5,000-lamport base fee**. Every on-chain anchor (settlement / credential / revocation / identity-log / transparency) failed at simulation for ~38h, invisibly.

#406's supervision surfaced the *symptom* (an erroring anchor loop) only **after** the freeze. This guard surfaces the **cause** before it, by watching spendable headroom directly.

## What

- **`@motebit/wallet-solana`** — `SolanaMemoSubmitter.getFeePayerSolvency()` reads the identity wallet's SOL balance + `getMinimumBalanceForRentExemption(0)`. The fee-payer already owns the `Connection` (rule 5 reference submitter).
- **`services/relay/fee-payer-guard.ts`**:
  - `classifyFeePayerSolvency` (pure) — headroom = `balance − rentExemptMin`, **not** balance; `frozen` when headroom < one base fee; `low` when headroom < a tx-count threshold (default **200 txs** of lead time).
  - `checkFeePayerSolvencyOnce` — logs a structured warning **and throws** on `low`, so the loop reads `fee-payer-balance-guard` **erroring** on `GET /api/v1/admin/health` (and flips `anyUnhealthy()`). An RPC read failure throws too (distinct message).
  - `startFeePayerBalanceGuardLoop` — supervised (`superviseInterval`, rule 18), 5-min cadence, `SOLANA_RPC_URL`-gated, shutdown-cleaned.

## The lesson it encodes

**"balance ÷ fee" is NOT transaction headroom on Solana** — subtract `getMinimumBalanceForRentExemption(dataLen)` first. A fee-payer resting just above the rent floor is *frozen*, not *low*. Tests pin the decision boundary with the exact incident numbers (895k / 890,880 → 0 txs, frozen), the proactive warn-before-freeze window, the below-rent-min clamp, throw-to-alert / ok / RPC-failure paths, and supervised registration.

## Verified
- `@motebit/wallet-solana`: 176 tests · `services/relay`: 1503 tests
- 136 hard gates + full pre-push gauntlet (build, audit, check, gate-effectiveness, typecheck, lint, test:coverage, format) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)