### PR TITLE
chore(husky): make the pre-push gauntlet legible + diff-scope the expensive meta-check

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,10 +3,44 @@
 
 # Skip on tag pushes (changesets pushes 4 tags in parallel → lock conflicts)
 if git symbolic-ref -q HEAD >/dev/null 2>&1; then
+
+  # --- Legibility ---------------------------------------------------------
+  # This gauntlet runs for minutes. Run silently, it is indistinguishable
+  # from a hung process — on 2026-07-25 an agent misread the silent run as a
+  # network stall and killed legitimate pushes mid-gauntlet, wasting ~30min.
+  # So every phase announces itself and reports its own wall-time, with a
+  # total at the end. Executable legibility (docs/doctrine/agentic-era-
+  # engineering.md) applied to the tooling itself. `run_phase` runs its
+  # command in an `if` (a tested context, so the `sh -e` errexit the husky
+  # wrapper sets is handled explicitly here): success prints ✓ + timing,
+  # failure prints ✗ + the code and aborts the push with that code — the same
+  # fail-closed behavior as before, now legible. Set MOTEBIT_PREPUSH_QUIET=1
+  # to mute the banners (timings still print on failure).
+  _gauntlet_t0=$(date +%s)
+  run_phase() {
+    _label=$1
+    shift
+    [ -z "$MOTEBIT_PREPUSH_QUIET" ] && printf '\n▶ pre-push: %s…\n' "$_label" >&2
+    _phase_t0=$(date +%s)
+    # `_rc=$?` MUST live in the `else` (where $? is the failed command's code);
+    # after `fi` $? is the `if` statement's own status (0), which would print
+    # "code 0" and `exit 0` — a fail-OPEN that lets a broken push through.
+    if "$@"; then
+      [ -z "$MOTEBIT_PREPUSH_QUIET" ] &&
+        printf '  ✓ %s (%ss)\n' "$_label" "$(($(date +%s) - _phase_t0))" >&2
+      return 0
+    else
+      _rc=$?
+      printf '  ✗ %s FAILED (code %s) after %ss — push aborted\n' \
+        "$_label" "$_rc" "$(($(date +%s) - _phase_t0))" >&2
+      exit "$_rc"
+    fi
+  }
+
   # Full build is required before drift defenses: check-api-surface shells out
   # to api-extractor, which reads protocol/crypto/sdk .d.ts from dist/. Turbo
   # caches aggressively, so the second push after a build is near-instant.
-  pnpm build
+  run_phase "build" pnpm build
 
   # Hard gates — must match .github/workflows/ci.yml → jobs.check and
   # jobs.gate-effectiveness. If this list diverges from CI's, the local loop
@@ -19,35 +53,42 @@ if git symbolic-ref -q HEAD >/dev/null 2>&1; then
   # `--ignore-registry-errors` is the documented, intended workaround: audit
   # still runs and reports findings, only the exit code tolerates registry-
   # side errors. Mirrors the CI workflow's audit step.
-  pnpm audit --audit-level=critical --ignore-registry-errors
-  pnpm check                   # all 7 drift defenses (scripts/check.ts)
-  pnpm check-gates-effective   # prove every gate actually fires
+  run_phase "audit" pnpm audit --audit-level=critical --ignore-registry-errors
+  run_phase "gates (pnpm check)" pnpm check
+
+  # check-gates-effective PERTURBS every gate (re-runs each gate under an
+  # injected failure to prove it bites) — the most expensive step, and its
+  # result changes ONLY when GATE CODE changes. So run it locally only when
+  # this push touches scripts/ (the gate + probe + report surface); otherwise
+  # CI's dedicated `gate-effectiveness` job is the backstop. This is diff-
+  # scoping, NOT removal — a gate-editing push still proves effectiveness
+  # locally, before it can ship a vacuous gate. The detection fails SAFE: if
+  # the diff can't be computed (e.g. origin/main absent), it runs the check.
+  _scripts_changed=$(git diff --name-only origin/main...HEAD -- scripts/ 2>/dev/null || echo __DIFF_ERR__)
+  if [ -n "$_scripts_changed" ]; then
+    run_phase "gate-effectiveness (scripts/ changed)" pnpm check-gates-effective
+  else
+    [ -z "$MOTEBIT_PREPUSH_QUIET" ] &&
+      printf '\n▷ pre-push: gate-effectiveness — SKIPPED (no scripts/ changes; CI runs it)\n' >&2
+  fi
 
   # Typecheck/lint/test scoped to affected packages — cheaper than full run;
   # CI's check job runs these unfiltered across the whole graph.
   #
-  # `--concurrency=2` caps turbo's parallel task count. Without it, a change
+  # `--concurrency` caps turbo's parallel task count. Without a cap, a change
   # low in the dependency graph (crypto, render-engine, runtime) pulls in a
   # ~30-package transitive closure and turbo runs ~10 tasks at once, each
-  # spawning its own vitest worker pool. On a 16GB machine this
-  # oversubscribes CPU + memory: vitest workers get starved of cycles, hooks
-  # and tests cross their default timeouts (5s / 10s), and behaviorally
-  # correct tests false-fail under contention. The cap bounds total in-flight
-  # tasks to a count this host can sustain without contention spikes.
-  #
-  # Concurrency=6 was the prior setting and still flaked consistently on
-  # this host (session 2026-05-07 saw `@motebit/web#test` fail twice in a
-  # row under turbo at concurrency=6; identical tests passed standalone and
-  # at concurrency=1). Empirical lower bound for reliability on M1 Pro 16GB
-  # is 2. Slower wall-clock (~1m vs ~30s) but no false-fail flakes.
-  #
-  # This is the right level to solve it — one config line, harness-scoped,
-  # reversible with one edit. NOT per-test timeout bumps: those embed
-  # per-machine workarounds in test files that outlive the hardware and
-  # confuse readers ("why is this timeout 15s when the test runs in 1s?").
-  # Raise this number on a more capable host or delete the flag entirely.
-  # CI itself skips this hook (`$CI` check at the top of the file), so
-  # production CI runs at its own full parallelism regardless.
+  # spawning its own vitest worker pool. On a 16GB machine this oversubscribes
+  # CPU + memory: vitest workers get starved, hooks/tests cross their default
+  # timeouts, and behaviorally correct tests false-fail under contention. The
+  # empirical lower bound for reliability on an M1 Pro 16GB is 2 (concurrency
+  # 6 flaked @motebit/web#test twice in a row, session 2026-05-07). It is now
+  # env-driven — the default stays the safe floor, but a more capable host
+  # sets MOTEBIT_PREPUSH_CONCURRENCY (e.g. 6 or 8) without editing this shared
+  # hook. CI skips this hook entirely (the `$CI` check above) and runs at its
+  # own full parallelism regardless.
+  _concurrency=${MOTEBIT_PREPUSH_CONCURRENCY:-2}
+
   # `test:coverage`, not `test`: CI's `check` job runs `test:coverage` (tests +
   # coverage-threshold enforcement). Running plain `test` here let three pushes
   # (vitest-4 upgrade arc, 2026-06) ship with CI red on coverage — the gate hole
@@ -57,9 +98,15 @@ if git symbolic-ref -q HEAD >/dev/null 2>&1; then
   # warning; CI still enforces coverage regardless).
   if [ -n "$SKIP_COVERAGE" ]; then
     echo "⚠ SKIP_COVERAGE set — running 'test' without coverage thresholds (CI still enforces them)"
-    pnpm turbo run typecheck lint test --filter="...[origin/main]" --concurrency=2
+    run_phase "typecheck+lint+test (affected, concurrency=$_concurrency)" \
+      pnpm turbo run typecheck lint test --filter="...[origin/main]" --concurrency="$_concurrency"
   else
-    pnpm turbo run typecheck lint test:coverage --filter="...[origin/main]" --concurrency=2
+    run_phase "typecheck+lint+test:coverage (affected, concurrency=$_concurrency)" \
+      pnpm turbo run typecheck lint test:coverage --filter="...[origin/main]" --concurrency="$_concurrency"
   fi
-  pnpm format:check
+
+  run_phase "format:check" pnpm format:check
+
+  [ -z "$MOTEBIT_PREPUSH_QUIET" ] &&
+    printf '\n✓ pre-push gauntlet passed in %ss — pushing\n' "$(($(date +%s) - _gauntlet_t0))" >&2
 fi


### PR DESCRIPTION
## Why

The pre-push hook runs a multi-minute gauntlet in **total silence**, so a normal run is indistinguishable from a hung process. On 2026-07-25 that opacity caused a real failure: a silent run was misread as a network stall and legitimate pushes were killed mid-gauntlet (~30 min lost, wrong diagnosis). This makes the tooling obey the repo's own **executable-legibility** principle, and trims the one genuinely redundant step — with no loss of safety.

## Three changes

1. **Legible.** A `run_phase` helper announces each phase (`▶`), reports its wall-time on success (`✓ … (Ns)`), and prints a total at the end. Fail-closed is preserved *and made explicit*: a failing phase prints `✗` + the real exit code and aborts the push with it.

2. **Diff-scoped `check-gates-effective`.** It perturbs every gate (the single most expensive step) and its result changes **only when gate code changes**. It now runs locally only when the push touches `scripts/`; otherwise CI's dedicated `gate-effectiveness` job is the backstop. Detection **fails safe** (runs the check if the diff can't be computed).

3. **Env-driven concurrency.** The hardcoded `--concurrency=2` (an M1-16GB reliability floor) becomes `MOTEBIT_PREPUSH_CONCURRENCY` (default 2) — a capable host raises it without editing this shared hook.

All existing steps + their load-bearing comments are preserved; the hook still mirrors CI's `check` + `gate-effectiveness` jobs. `MOTEBIT_PREPUSH_QUIET=1` mutes banners.

## Proof (end-to-end, before merge)

- **A fail-open bug was caught by proving it.** The first `run_phase` put `_rc=$?` after `fi`, which reads the `if` statement's status (`0`), not the failed command's code — it would have printed "code 0" and `exit 0`, letting a broken push through. A harness under `sh -e` (husky's exact invocation) exposed it (`exit = 0`, expected `7`); moved to the `else` branch → now propagates the real code.
- **Syntax:** `sh -n` clean.
- **Diff-scope, against real history:** a hook-only push → **SKIP**; the #406 gate-editing commit (touched `check-gates-effective.ts` + `check-transparency-onchain-anchored.ts`) → **RUN**.
- **Live:** pushing *this* PR ran the new hook end-to-end — legible timeline, `gate-effectiveness — SKIPPED`, passed + pushed in 209s.

## Bonus finding the legibility surfaced

The timeline immediately exposed the real bottleneck: **`pnpm audit` takes 127s** — more than gates (46s) + format (35s) combined. It hits npm's flaky registry, rarely changes between pushes, and CI runs it anyway. Strong candidate for CI-only / caching in a follow-up. Invisible before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)