### PR TITLE
chore(husky): diff-scope pre-push audit to dependency changes — 209s → 87s

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -52,8 +52,24 @@ if git symbolic-ref -q HEAD >/dev/null 2>&1; then
   # with fallback) — merged 2026-02-19, only in v11.0.0-alpha, not backported.
   # `--ignore-registry-errors` is the documented, intended workaround: audit
   # still runs and reports findings, only the exit code tolerates registry-
-  # side errors. Mirrors the CI workflow's audit step.
-  run_phase "audit" pnpm audit --audit-level=critical --ignore-registry-errors
+  # side errors.
+  #
+  # That slow endpoint also makes audit the SLOWEST phase (~127s, measured
+  # 2026-07-25 — more than gates + format combined) — yet its result changes
+  # only when DEPENDENCIES change. So run it locally only when this push
+  # touches pnpm-lock.yaml (the canonical dependency-change signal); otherwise
+  # CI's audit step (ci.yml, on every pull_request to main) is the backstop.
+  # Diff-scoping, NOT removal — a dependency-changing push still audits before
+  # it can ship a vuln. Fails SAFE: audits if the diff can't be computed. Same
+  # shape as the gate-effectiveness scoping below.
+  _deps_changed=$(git diff --name-only origin/main...HEAD -- pnpm-lock.yaml 2>/dev/null || echo __DIFF_ERR__)
+  if [ -n "$_deps_changed" ]; then
+    run_phase "audit (pnpm-lock.yaml changed)" pnpm audit --audit-level=critical --ignore-registry-errors
+  else
+    [ -z "$MOTEBIT_PREPUSH_QUIET" ] &&
+      printf '\n▷ pre-push: audit — SKIPPED (no pnpm-lock.yaml changes; CI runs it)\n' >&2
+  fi
+
   run_phase "gates (pnpm check)" pnpm check
 
   # check-gates-effective PERTURBS every gate (re-runs each gate under an


### PR DESCRIPTION
## Why

#408's legibility immediately exposed the real bottleneck: **`pnpm audit` is the slowest pre-push phase at ~127s** — more than gates (46s) + format (35s) combined — because it hits npm's slow/flaky legacy `/security/audits` endpoint. Its result changes **only when dependencies change**.

## What

Run audit locally only when the push touches `pnpm-lock.yaml` (the canonical dependency-change signal); otherwise CI's audit step (`ci.yml`, runs on **every** `pull_request` to main — confirmed) is the backstop. Diff-scoping, **not** removal — a dependency-changing push still audits before it can ship a vuln. Fails **safe** (audits if the diff can't be computed). Same shape as the gate-effectiveness scoping #408 added.

## Proof

- **Syntax:** `sh -n` clean.
- **Diff-detection, against real history:** a hook-only push → **SKIP**; the #398 bridge commit (added relay devDeps → `pnpm-lock.yaml` change) → **RUN**.
- **CI backstop confirmed:** `ci.yml` runs `pnpm audit` on every `pull_request` to main.
- **Live:** pushing *this* PR ran the new hook — `audit — SKIPPED`, gauntlet passed in **87s vs the prior 209s** (a 58% cut, exactly the audit phase removed):

```
▷ audit — SKIPPED (no pnpm-lock.yaml changes; CI runs it)
✓ pre-push gauntlet passed in 87s — pushing
```

## Net effect

A code-only push (the common case) drops ~127s; a dependency-changing push is unchanged and still audits locally. Combined with #408, the pre-push loop is now legible, diff-scoped, and ~2.4× faster on the typical push — without weakening what CI enforces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)