### PR TITLE
feat(relay): fee-payer guard logs first healthy check at INFO (boot-time liveness)

### DIFF
--- a/services/relay/src/__tests__/fee-payer-guard.test.ts
+++ b/services/relay/src/__tests__/fee-payer-guard.test.ts
@@ -14,6 +14,7 @@ import {
   BASE_TX_FEE_LAMPORTS,
   DEFAULT_WARN_HEADROOM_TXS,
   type FeePayerSolvencySource,
+  type FeePayerGuardState,
 } from "../fee-payer-guard.js";
 import { LoopSupervisor } from "../loop-supervisor.js";
 
@@ -108,6 +109,27 @@ describe("checkFeePayerSolvencyOnce — throw-to-alert", () => {
       },
     };
     await expect(checkFeePayerSolvencyOnce(failing)).rejects.toThrow("429 Too Many Requests");
+  });
+
+  it("marks the first healthy check once (boot-time liveness INFO), then stays marked", async () => {
+    const state: FeePayerGuardState = { firstHealthyLogged: false };
+    const src = source(25_000_000, INCIDENT_RENT_MIN);
+    await checkFeePayerSolvencyOnce(src, {}, state);
+    expect(state.firstHealthyLogged).toBe(true); // first healthy → INFO emitted
+    await checkFeePayerSolvencyOnce(src, {}, state);
+    expect(state.firstHealthyLogged).toBe(true); // subsequent → debug, no repeat INFO
+  });
+
+  it("does not mark first-healthy on a low check — INFO waits for the first RECOVERED-healthy tick", async () => {
+    const state: FeePayerGuardState = { firstHealthyLogged: false };
+    // Low at boot: throws (visible at warn), never counts as the healthy signal.
+    await expect(
+      checkFeePayerSolvencyOnce(source(INCIDENT_BALANCE, INCIDENT_RENT_MIN), {}, state),
+    ).rejects.toThrow();
+    expect(state.firstHealthyLogged).toBe(false);
+    // Recovers → the first healthy tick now emits the liveness INFO.
+    await checkFeePayerSolvencyOnce(source(25_000_000, INCIDENT_RENT_MIN), {}, state);
+    expect(state.firstHealthyLogged).toBe(true);
   });
 });
 

--- a/services/relay/src/fee-payer-guard.ts
+++ b/services/relay/src/fee-payer-guard.ts
@@ -101,9 +101,19 @@ export function classifyFeePayerSolvency(
  * records it as `erroring`. Returns the solvency on `ok`. Extracted from the
  * loop so it is testable without timers.
  */
+/**
+ * Mutable per-loop state. Tracks whether the boot-time healthy-liveness INFO
+ * line has been emitted, so it fires exactly once (the first healthy check)
+ * rather than every tick.
+ */
+export interface FeePayerGuardState {
+  firstHealthyLogged: boolean;
+}
+
 export async function checkFeePayerSolvencyOnce(
   source: FeePayerSolvencySource,
   opts: { warnHeadroomTxs?: number } = {},
+  state?: FeePayerGuardState,
 ): Promise<FeePayerSolvency> {
   const { balanceLamports, rentExemptMinLamports } = await source.getFeePayerSolvency();
   const s = classifyFeePayerSolvency(balanceLamports, rentExemptMinLamports, opts);
@@ -125,10 +135,25 @@ export async function checkFeePayerSolvencyOnce(
         `. Top up SOL to keep on-chain anchoring alive.`,
     );
   }
-  logger.debug("fee_payer.solvency_ok", {
-    address: source.address,
-    headroom_txs: s.headroomTxs,
-  });
+  // Boot-time liveness signal: log the FIRST healthy check at INFO so an
+  // operator can confirm from logs that the guard is running — the loop is
+  // otherwise silent when healthy (debug ok ticks) and /admin/health is
+  // master-token-gated, so there was no easy "guard alive" signal. Subsequent
+  // healthy checks stay at debug to avoid a per-tick INFO stream. A low check
+  // never reaches here (it throws above, visibly, at warn).
+  if (state && !state.firstHealthyLogged) {
+    state.firstHealthyLogged = true;
+    logger.info("fee_payer.guard_healthy", {
+      address: source.address,
+      headroom_lamports: s.headroomLamports,
+      headroom_txs: s.headroomTxs,
+    });
+  } else {
+    logger.debug("fee_payer.solvency_ok", {
+      address: source.address,
+      headroom_txs: s.headroomTxs,
+    });
+  }
   return s;
 }
 
@@ -146,12 +171,13 @@ export function startFeePayerBalanceGuardLoop(
   opts: { intervalMs?: number; warnHeadroomTxs?: number } = {},
 ): ReturnType<typeof setInterval> {
   const intervalMs = opts.intervalMs ?? DEFAULT_FEE_PAYER_GUARD_INTERVAL_MS;
+  const state: FeePayerGuardState = { firstHealthyLogged: false };
   return superviseInterval(
     supervisor,
     "fee-payer-balance-guard",
     intervalMs,
     async () => {
-      await checkFeePayerSolvencyOnce(source, { warnHeadroomTxs: opts.warnHeadroomTxs });
+      await checkFeePayerSolvencyOnce(source, { warnHeadroomTxs: opts.warnHeadroomTxs }, state);
     },
     { isFrozen },
   );


### PR DESCRIPTION
## Why

The #407 fee-payer guard is silent when healthy (debug `ok` ticks) and `/api/v1/admin/health` is master-token-gated — so after deploying it, there was no easy way to confirm from logs that the guard is actually running. "The thing that proves a guard is watching should itself be visible."

## What

The **first** healthy check emits `fee_payer.guard_healthy` at INFO (address + headroom lamports/txs) — a one-time boot-time "guard alive" signal. Subsequent healthy checks stay at debug (no per-tick INFO stream). A low check never reaches it (it throws first, visibly at warn), so the INFO fires on the first *recovered*-healthy tick after a low spell.

Threaded via a small `FeePayerGuardState { firstHealthyLogged }` the loop owns — mirrors the transparency anchor's state pattern. `state` is optional on `checkFeePayerSolvencyOnce`, so it stays backward compatible.

## Tests
- first healthy check marks the flag (INFO once); subsequent stays marked (debug)
- a low check does NOT mark it — the liveness INFO waits for the first recovered-healthy tick
- relay 1505 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)