### PR TITLE
feat(relay): p2p-eligibility pre-flight returns canonical expected amounts — close the amount-mismatch fund-loss window

### DIFF
--- a/services/relay/src/__tests__/p2p-cycle-e2e.test.ts
+++ b/services/relay/src/__tests__/p2p-cycle-e2e.test.ts
@@ -380,6 +380,70 @@ describe("P2P Settlement Cycle E2E", () => {
     expect(((await masterRes.json()) as { allowed: boolean }).allowed).toBe(true);
   });
 
+  it("p2p-eligibility returns the canonical expected amounts (closes the amount-mismatch window)", async () => {
+    // The pre-flight returns the SAME amounts the submission gate validates, so
+    // a client pays EXACTLY right — closing the broadcast-then-amount-mismatch
+    // fund-loss window the eligibility check alone doesn't cover. worker leg =
+    // toMicro(unit_cost 0.5) = 500000; fee = computeP2pFeeMicro(500000, 0.05) = 26316.
+    const tok = await makeSignedToken(
+      delegator.motebitId,
+      delegator.deviceId,
+      delegatorKp.privateKey,
+      "market:listing",
+    );
+    const r = await relay.app.request(
+      `/api/v1/agents/${worker.motebitId}/p2p-eligibility?capability=web_search&acknowledge_no_history_risk=true`,
+      { headers: { Authorization: `Bearer ${tok}` } },
+    );
+    const body = (await r.json()) as {
+      allowed: boolean;
+      expected_amount_micro?: number;
+      expected_fee_micro?: number;
+    };
+    expect(body.allowed).toBe(true);
+    expect(body.expected_amount_micro).toBe(500000);
+    expect(body.expected_fee_micro).toBe(26316);
+  });
+
+  it("p2p-eligibility omits the amounts when the worker has no priced listing", async () => {
+    const noListingWorker = "00000000-0000-4000-8000-000000000000";
+    const r = await relay.app.request(`/api/v1/agents/${noListingWorker}/p2p-eligibility`, {
+      headers: AUTH,
+    });
+    const body = (await r.json()) as { expected_amount_micro?: number };
+    expect(body.expected_amount_micro).toBeUndefined();
+  });
+
+  it("expected_fee_micro reflects the INJECTED platformFeeRate, not a hardcoded 0.05", async () => {
+    // The #383 fee-split class: a hint hardcoding 0.05 would mislead a client on
+    // a non-default-rate relay. At 10%, fee = computeP2pFeeMicro(500000, 0.1) = 55556.
+    const r10 = await createTestRelay({ platformFeeRate: 0.1 });
+    try {
+      const workerId = "11111111-1111-4111-8111-111111111111";
+      await r10.app.request(`/api/v1/agents/${workerId}/listing`, {
+        method: "POST",
+        headers: JSON_AUTH,
+        body: JSON.stringify({
+          capabilities: ["web_search"],
+          pricing: [{ capability: "web_search", unit_cost: 0.5, currency: "USD", per: "task" }],
+          pay_to_address: WORKER_SOLANA_ADDR,
+        }),
+      });
+      const res = await r10.app.request(
+        `/api/v1/agents/${workerId}/p2p-eligibility?capability=web_search`,
+        { headers: AUTH },
+      );
+      const body = (await res.json()) as {
+        expected_amount_micro?: number;
+        expected_fee_micro?: number;
+      };
+      expect(body.expected_amount_micro).toBe(500000);
+      expect(body.expected_fee_micro).toBe(55556); // 10% rate — NOT 26316 (5%)
+    } finally {
+      await r10.close();
+    }
+  });
+
   it("full p2p cycle: eligible → submit with proof → receipt → audit record", async () => {
     // === STEP 1: SUBMIT P2P TASK ===
     const taskRes = await relay.app.request(`/agent/${worker.motebitId}/task`, {

--- a/services/relay/src/agents.ts
+++ b/services/relay/src/agents.ts
@@ -102,8 +102,12 @@ import {
   isAgentRevocationReason,
   type AgentRevocationReason,
   isBondCommitment,
+  toMicro,
+  computeP2pFeeMicro,
+  PLATFORM_FEE_RATE,
 } from "@motebit/protocol";
 import { recordBondCommitment, getBestLiveBond } from "./bond-store.js";
+import { getListingUnitCost } from "./tasks.js";
 import {
   buildSignedRevocationRecord,
   insertRevocationRecord,
@@ -375,6 +379,8 @@ export interface AgentsDeps {
   connections: Map<string, ConnectedDevice[]>;
   taskRouter: TaskRouter;
   apiToken?: string;
+  /** Platform fee rate for the P2P eligibility pre-flight's expected-fee hint. Defaults to PLATFORM_FEE_RATE. */
+  platformFeeRate?: number;
   federationConfig?: { displayName?: string; endpointUrl?: string };
   federationQueryCache: Map<string, number>;
   /** Auth helpers from relay auth layer */
@@ -563,6 +569,7 @@ export function registerAgentRoutes(deps: AgentsDeps): void {
     connections,
     taskRouter,
     apiToken,
+    platformFeeRate,
     federationConfig,
     federationQueryCache,
     parseTokenPayloadUnsafe,
@@ -570,6 +577,10 @@ export function registerAgentRoutes(deps: AgentsDeps): void {
     isTokenBlacklisted,
     isAgentRevoked,
   } = deps;
+  // Fee rate for the P2P eligibility pre-flight's expected-fee hint — the SAME
+  // rate the submission gate uses, so the hint cannot disagree with what the
+  // relay will accept.
+  const p2pFeeRate = platformFeeRate ?? PLATFORM_FEE_RATE;
 
   // GET /agent/:motebitId/settlements — settlement history for this agent
   /** @internal */
@@ -1730,11 +1741,30 @@ export function registerAgentRoutes(deps: AgentsDeps): void {
     // identified (master/service token with no `mid`), returns `allowed: true`
     // (advisory — the submission gate still enforces; a privileged caller is not
     // a cold-start sybil risk).
+    //
+    // It ALSO returns the canonical expected P2P payment amounts for the given
+    // `capability`, so a client pays EXACTLY what the submission gate validates
+    // — closing the sibling broadcast-then-AMOUNT-mismatch window (a price
+    // change between the client's listing read and submission, or client-side
+    // unit arithmetic drift — the listing unit_cost is in DOLLARS). The amounts
+    // MIRROR the submission gate (`tasks.ts`): worker leg = toMicro(unit_cost),
+    // fee = computeP2pFeeMicro(worker leg, feeRate). Absent when the worker has
+    // no priced listing for the capability.
     const workerId = asMotebitId(c.req.param("motebitId"));
     const callerMotebitId = c.get("callerMotebitId" as never) as string | undefined;
     const ack = c.req.query("acknowledge_no_history_risk") === "true";
+    const capability = c.req.query("capability") ?? undefined;
+
+    const unitCostDollars = getListingUnitCost(moteDb, workerId, capability);
+    const amounts: { expected_amount_micro?: number; expected_fee_micro?: number } = {};
+    if (unitCostDollars > 0) {
+      const expectedAmountMicro = toMicro(unitCostDollars);
+      amounts.expected_amount_micro = expectedAmountMicro;
+      amounts.expected_fee_micro = computeP2pFeeMicro(expectedAmountMicro, p2pFeeRate);
+    }
+
     if (callerMotebitId == null || callerMotebitId === workerId) {
-      return c.json({ allowed: true, reason: "caller not identified — advisory only" });
+      return c.json({ allowed: true, reason: "caller not identified — advisory only", ...amounts });
     }
     const eligibility = await evaluateSettlementEligibility(
       moteDb.db,
@@ -1742,7 +1772,7 @@ export function registerAgentRoutes(deps: AgentsDeps): void {
       workerId,
       ack,
     );
-    return c.json({ allowed: eligibility.allowed, reason: eligibility.reason });
+    return c.json({ allowed: eligibility.allowed, reason: eligibility.reason, ...amounts });
   });
 
   // POST /api/v1/agents/:motebitId/bond — submit a signed commitment bond.

--- a/services/relay/src/index.ts
+++ b/services/relay/src/index.ts
@@ -1352,6 +1352,7 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
     connections,
     taskRouter,
     apiToken,
+    platformFeeRate,
     federationConfig,
     federationQueryCache,
     parseTokenPayloadUnsafe,


### PR DESCRIPTION
## Why

The `p2p-eligibility` pre-flight exists — per its own comment — "so [a client] never pays a worker the relay would reject at submission." But it only checked **eligibility**, not **amount**. A client could pass the pre-flight, broadcast an irreversible payment, then get `400 TASK_P2P_AMOUNT_MISMATCH` — real fund loss. Two triggers:
- a **price-change race** (worker re-prices between the client's listing read and submission), and
- **client-side unit arithmetic drift** — the listing `unit_cost` is in **dollars**, converted to micro. A live footgun, surfaced by the prod money-path probe (2026-07-26): a hand-rolled payment read the unit as micro, priced the listing as "$50,000," and the relay rejected the amount — *after* the broadcast.

## What

The pre-flight now **also returns the canonical expected P2P amounts** for the given `capability`, mirroring the submission gate exactly:
- `expected_amount_micro = toMicro(getListingUnitCost(worker, capability))` — the **same** `getListingUnitCost` + `toMicro` the submission validates against (`tasks.ts`), so the hint can't disagree with what the relay accepts.
- `expected_fee_micro = computeP2pFeeMicro(expected_amount_micro, platformFeeRate)` — the **injected** rate (threaded into `AgentsDeps`, `?? PLATFORM_FEE_RATE`, like the task routes), not a hardcoded 0.05.

So the relay becomes the single source of truth for the payment amount, instead of client-side listing math. Amounts are absent when the worker has no priced listing.

**Advisory-only** (the submission gate stays the law → low safety risk); it just lets a client pay exactly right and refuse to broadcast on a mismatch.

## Tests (+3, `p2p-cycle-e2e`)
- canonical amounts: `500000` + fee `26316` (@ 5%)
- omitted when the worker has no listing
- fee reflects an **injected 10%** rate (`55556`, not `26316`) — guards the #383 fee-split class (hardcoded-rate regression)

## Verified
- relay: 1508 tests · 136 gates · full pre-push gauntlet green
- no import cycle (`tasks.ts` does not import `agents.ts`)

Follow-up (noted): the SDK `resolveP2pPaymentRequest` can consume these amounts instead of re-deriving from the listing — the client-side half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)