### PR TITLE
feat(runtime): P2P client consumes the pre-flight's canonical amounts (client-side half of #411)

### DIFF
--- a/packages/runtime/src/__tests__/relay-delegation.test.ts
+++ b/packages/runtime/src/__tests__/relay-delegation.test.ts
@@ -354,6 +354,65 @@ describe("resolveAndSubmitP2pDelegation", () => {
     if (!result.ok) expect(result.error.code).toBe("malformed_request");
   });
 
+  it("prefers the pre-flight's canonical amounts over the listing (single source of truth)", async () => {
+    // The relay's pre-flight returns the SAME amounts the submission gate
+    // validates. The client pays those EXACT figures and never re-derives from
+    // the listing — closing the amount-mismatch window (unit drift / price race).
+    const params = resolveParams();
+    const listingSpy = vi.fn(() =>
+      jsonResponse(200, { pricing: [{ capability: "web_search", unit_cost: 0.99 }] }),
+    );
+    vi.stubGlobal(
+      "fetch",
+      routedFetch({
+        discover: discoverOk([
+          { motebit_id: "bob", settlement_address: "BobAddr", settlement_modes: "p2p,relay" },
+        ]),
+        eligibility: () =>
+          jsonResponse(200, {
+            allowed: true,
+            expected_amount_micro: 500000,
+            expected_fee_micro: 26316,
+          }),
+        listing: listingSpy,
+        submit: () => jsonResponse(400, { code: "TASK_P2P_FEE_AMOUNT_MISMATCH" }),
+      }),
+    );
+
+    const result = await resolveAndSubmitP2pDelegation(params);
+
+    const req = (params.buildP2pPayment as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as SovereignP2pPaymentRequest;
+    // Uses the PRE-FLIGHT amounts (500000/26316), NOT the listing's 0.99 (=990000).
+    expect(req.amountMicro).toBe(500000);
+    expect(req.feeAmountMicro).toBe(26316);
+    expect(req.treasuryAddress).toBe(EXPECTED_TREASURY);
+    // And it never reads the listing — the pre-flight is authoritative.
+    expect(listingSpy).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("malformed_request");
+  });
+
+  it("falls back to the listing read when the pre-flight returns no amounts (older relay)", async () => {
+    const params = resolveParams();
+    vi.stubGlobal(
+      "fetch",
+      routedFetch({
+        discover: discoverOk([
+          { motebit_id: "bob", settlement_address: "BobAddr", settlement_modes: "p2p" },
+        ]),
+        eligibility: () => jsonResponse(200, { allowed: true }), // no amounts
+        listing: listingOk([{ capability: "web_search", unit_cost: 0.5 }]),
+        submit: () => jsonResponse(400, { code: "TASK_P2P_FEE_AMOUNT_MISMATCH" }),
+      }),
+    );
+    await resolveAndSubmitP2pDelegation(params);
+    const req = (params.buildP2pPayment as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as SovereignP2pPaymentRequest;
+    expect(req.amountMicro).toBe(toMicro(0.5)); // listing-derived fallback
+    expect(req.feeAmountMicro).toBe(computeP2pFeeMicro(toMicro(0.5), PLATFORM_FEE_RATE));
+  });
+
   it("maps an insufficient USDC balance to insufficient_balance (nothing submitted)", async () => {
     const buildP2pPayment = vi.fn(async () => {
       throw Object.assign(new Error("need more"), { name: "InsufficientUsdcBalanceError" });

--- a/packages/runtime/src/relay-delegation.ts
+++ b/packages/runtime/src/relay-delegation.ts
@@ -1080,20 +1080,37 @@ export async function resolveP2pPaymentRequest(
     //     for never paying a worker the relay would reject is the correct call
     //     when the payment is irreversible (metabolic principle: deny on error).
     let preflightAllowed = false;
+    // The pre-flight ALSO returns the canonical expected amounts (worker leg +
+    // fee) — the SAME figures the submission gate validates. Preferring them
+    // makes the relay the single source of truth for the payment, closing the
+    // amount-mismatch fund-loss window that client-side listing arithmetic
+    // (the dollars-vs-micro unit boundary) can open. Absent on an older relay →
+    // fall through to the listing read below.
+    let preflightAmountMicro: number | undefined;
+    let preflightFeeMicro: number | undefined;
     try {
       const eligToken = await params.authToken("market:listing");
-      const ackQuery =
-        params.acknowledgeNoHistoryRisk === true ? "?acknowledge_no_history_risk=true" : "";
+      const q = new URLSearchParams();
+      if (params.acknowledgeNoHistoryRisk === true) q.set("acknowledge_no_history_risk", "true");
+      if (capability) q.set("capability", capability);
+      const qs = q.toString() ? `?${q.toString()}` : "";
       const resp = await fetch(
-        `${syncUrl}/api/v1/agents/${worker.motebit_id}/p2p-eligibility${ackQuery}`,
+        `${syncUrl}/api/v1/agents/${worker.motebit_id}/p2p-eligibility${qs}`,
         { headers: { Authorization: `Bearer ${eligToken}` }, signal: params.signal },
       );
       if (resp.ok) {
-        const data = (await resp.json()) as { allowed?: boolean; reason?: string };
+        const data = (await resp.json()) as {
+          allowed?: boolean;
+          reason?: string;
+          expected_amount_micro?: number;
+          expected_fee_micro?: number;
+        };
         if (data.allowed !== true) {
           return fail("p2p_ineligible", data.reason ?? "Not P2P-eligible for this worker");
         }
         preflightAllowed = true;
+        preflightAmountMicro = data.expected_amount_micro;
+        preflightFeeMicro = data.expected_fee_micro;
       }
     } catch (err: unknown) {
       if (err instanceof Error && err.name === "AbortError") {
@@ -1107,6 +1124,24 @@ export async function resolveP2pPaymentRequest(
         "p2p_ineligible",
         "P2P eligibility could not be confirmed (pre-flight unavailable) — refusing to broadcast an unconfirmed payment.",
       );
+    }
+
+    // Prefer the relay's canonical amounts from the pre-flight — pay EXACTLY
+    // what the submission gate validates, with no client-side unit math. The
+    // separate listing read (3b) is the fallback for an older relay that didn't
+    // return them.
+    if (preflightAmountMicro != null && preflightAmountMicro > 0 && preflightFeeMicro != null) {
+      return {
+        ok: true,
+        paymentRequest: {
+          workerAddress: worker.settlement_address,
+          amountMicro: preflightAmountMicro,
+          treasuryAddress,
+          feeAmountMicro: preflightFeeMicro,
+        },
+        workerMotebitId: worker.motebit_id,
+        workerAddress: worker.settlement_address,
+      };
     }
 
     // 3b. Price from the worker's listing (market:listing-audience read).


### PR DESCRIPTION
## Why

#411 made the relay's `p2p-eligibility` pre-flight return `expected_amount_micro` + `expected_fee_micro`. This is the client-side half: `resolveP2pPaymentRequest` already calls that pre-flight for eligibility before broadcasting — it now also **consumes the returned amounts**, so the client pays exactly what the submission gate validates instead of re-deriving from the listing (where the dollars-vs-micro unit boundary lives).

## What

- The pre-flight call now passes `capability` (so the relay prices the right listing) and reads `expected_amount_micro` / `expected_fee_micro`.
- When present, the client builds the payment from **those** figures and returns — the relay is the single source of truth for the amount. No client listing arithmetic → no unit drift, and a price race can't diverge (the amount is the relay's own, fetched at pre-flight time).
- **Fully backward compatible:** on an older relay that returns no amounts, it falls through to the existing listing read + client-side derivation, unchanged.

## Tests (`relay-delegation`, +2)
- **prefers the pre-flight amounts over a differing listing** — asserts `amountMicro=500000`/`fee=26316` (not the listing's `0.99` = 990000) *and* that the listing endpoint is **never read** (the pre-flight is authoritative).
- **falls back to the listing read** when the pre-flight omits amounts (older relay).

## Verified
- runtime: 1224 tests green (the other delegation consumers — execute-granted-delegation, invoke-capability, interactive-delegation — unaffected via the fallback path)
- full pre-push gauntlet green

Together with #411, the amount-mismatch fund-loss window is closed on both sides: the relay offers the canonical amounts, and the canonical client pays them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)