### PR TITLE
docs(cli): fix npm README drift (spec count, providers, dead link) + gate the surface

### DIFF
--- a/.changeset/cli-readme-provider-drift.md
+++ b/.changeset/cli-readme-provider-drift.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+Fix npm README drift and complete the `--help` provider list. The README claimed 19 open specs (actual: 34), listed only 2 of the 7 supported providers, referenced `spec/skills-v1.md` as bare text that resolves to nothing on npmjs.com, and described the package as a "binary". The `--help` Providers section now documents `groq` and `deepseek`, which were fully wired but undocumented.

--- a/.changeset/cli-readme-provider-drift.md
+++ b/.changeset/cli-readme-provider-drift.md
@@ -2,4 +2,4 @@
 "motebit": patch
 ---
 
-Fix npm README drift and complete the `--help` provider list. The README claimed 19 open specs (actual: 34), listed only 2 of the 7 supported providers, referenced `spec/skills-v1.md` as bare text that resolves to nothing on npmjs.com, and described the package as a "binary". The `--help` Providers section now documents `groq` and `deepseek`, which were fully wired but undocumented.
+Fix npm README drift and complete the `--help` provider list. The README claimed 19 open specs (actual: 34), listed only 2 of the 7 supported providers, referenced `spec/skills-v1.md` as bare text that resolves to nothing on npmjs.com, and described the package as a "binary". The `--help` Providers section now documents `groq` and `deepseek`, which were fully wired but undocumented. The README's Providers table now leads with the provider-neutrality framing: motebit binds to your identity, not a model vendor.

--- a/.changeset/cli-readme-provider-drift.md
+++ b/.changeset/cli-readme-provider-drift.md
@@ -2,4 +2,4 @@
 "motebit": patch
 ---
 
-Fix npm README drift and complete the `--help` provider list. The README claimed 19 open specs (actual: 34), listed only 2 of the 7 supported providers, referenced `spec/skills-v1.md` as bare text that resolves to nothing on npmjs.com, and described the package as a "binary". The `--help` Providers section now documents `groq` and `deepseek`, which were fully wired but undocumented. The README's Providers table now leads with the provider-neutrality framing: motebit binds to your identity, not a model vendor.
+Fix npm README drift and complete the `--help` provider list. The README claimed 19 open specs (actual: 34), listed only 2 of the 7 supported providers, referenced `spec/skills-v1.md` as bare text that resolves to nothing on npmjs.com, and described the package as a "binary". The `--help` Providers section now documents `groq` and `deepseek`, which were fully wired but undocumented. The README's Providers table now leads with the provider-neutrality framing: a motebit's identity, memory, and trust persist independently of its model provider.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -125,6 +125,8 @@ subdirectories. Audit events (trust grants, removals) append to
 
 ## Providers
 
+Intelligence is pluggable: motebit binds to your identity, not a model vendor. Bring your own key:
+
 | Provider          | Setup                                                                                                                                                               |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Anthropic**     | `export ANTHROPIC_API_KEY=sk-ant-...` (default)                                                                                                                     |

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -91,7 +91,7 @@ motebit federation mesh <url1> <url2> ... # Pair-wise peer N relays
 User-installable procedural-knowledge files (agentskills.io-compatible) with
 motebit's sovereign extensions: cryptographic provenance, sensitivity-tiered
 loading, hardware-attestation gating. Install is permissive; auto-load is
-provenance-gated. See `spec/skills-v1.md`.
+provenance-gated. See [spec/skills-v1.md](https://github.com/motebit/motebit/blob/main/spec/skills-v1.md).
 
 ```bash
 motebit skills list                       # List installed skills with status badges
@@ -125,10 +125,15 @@ subdirectories. Audit events (trust grants, removals) append to
 
 ## Providers
 
-| Provider      | Setup                                                            |
-| ------------- | ---------------------------------------------------------------- |
-| **Anthropic** | `export ANTHROPIC_API_KEY=sk-ant-...`                            |
-| **Ollama**    | Install [Ollama](https://ollama.ai), `motebit --provider ollama` |
+| Provider          | Setup                                                                                                                                                               |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Anthropic**     | `export ANTHROPIC_API_KEY=sk-ant-...` (default)                                                                                                                     |
+| **OpenAI**        | `export OPENAI_API_KEY=sk-...`, `motebit --provider openai`                                                                                                         |
+| **Google**        | `export GOOGLE_API_KEY=AIza...`, `motebit --provider google`                                                                                                        |
+| **Groq**          | `export GROQ_API_KEY=gsk_...`, `motebit --provider groq`                                                                                                            |
+| **DeepSeek**      | `export DEEPSEEK_API_KEY=sk-...`, `motebit --provider deepseek`                                                                                                     |
+| **Local server**  | [Ollama](https://ollama.ai), LM Studio, llama.cpp, vLLM, or any OpenAI-compatible endpoint — `motebit --provider local-server` (alias: `ollama`); no API key needed |
+| **Motebit Cloud** | `motebit --provider proxy` — subscription via the relay                                                                                                             |
 
 ## Troubleshooting
 
@@ -146,11 +151,11 @@ See [docs.motebit.com](https://docs.motebit.com) for full documentation.
 
 ## How it ships
 
-`motebit` is the bundled reference runtime — relay, policy engine, sync engine, MCP server, and wallet adapters all inlined into a single binary at build time. The CLI is its primary operator-facing surface; there are no internal package versions to track.
+`motebit` is the bundled reference runtime — relay, policy engine, sync engine, MCP server, and wallet adapters all inlined into a single package at build time. The CLI is its primary operator-facing surface; there are no internal package versions to track.
 
 **The public promise of `motebit@1.0` is that operator-facing surface — subcommands, flags, exit codes, `~/.motebit/` layout, relay HTTP routes, MCP server tool list — not the internal workspace package graph.** Breaking changes to that surface require a major bump.
 
-For the wire-format contract third parties build against, see the Apache-2.0 packages: [`@motebit/protocol`](https://www.npmjs.com/package/@motebit/protocol), [`@motebit/crypto`](https://www.npmjs.com/package/@motebit/crypto), [`@motebit/sdk`](https://www.npmjs.com/package/@motebit/sdk), and the [19 open specs](https://github.com/motebit/motebit/tree/main/spec). Those promise stability independently and are gated by `check-api-surface`.
+For the wire-format contract third parties build against, see the Apache-2.0 packages: [`@motebit/protocol`](https://www.npmjs.com/package/@motebit/protocol), [`@motebit/crypto`](https://www.npmjs.com/package/@motebit/crypto), [`@motebit/sdk`](https://www.npmjs.com/package/@motebit/sdk), and the [34 open specs](https://github.com/motebit/motebit/tree/main/spec). Those promise stability independently and are gated by `check-api-surface`.
 
 ## Related
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -125,7 +125,7 @@ subdirectories. Audit events (trust grants, removals) append to
 
 ## Providers
 
-Intelligence is pluggable: motebit binds to your identity, not a model vendor. Bring your own key:
+The intelligence is pluggable: a motebit's identity, memory, and trust persist independently of its model provider. Configure an inference source:
 
 | Provider          | Setup                                                                                                                                                               |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -528,6 +528,10 @@ Providers:
                           Default model: gpt-5.4-mini
   google                  Uses Google API (requires GOOGLE_API_KEY)
                           Default model: gemini-2.5-flash
+  groq                    Uses Groq API (requires GROQ_API_KEY)
+                          Default model: llama-3.3-70b-versatile
+  deepseek                Uses DeepSeek API (requires DEEPSEEK_API_KEY)
+                          Default model: deepseek-chat
   local-server            Uses a local inference server — Ollama, LM Studio,
                           llama.cpp, Jan, vLLM, or any OpenAI-compatible
                           endpoint (no API key needed). Default model: llama3.2.

--- a/scripts/check-doc-counts.ts
+++ b/scripts/check-doc-counts.ts
@@ -11,13 +11,13 @@
  * `apps/docs/content/docs/operator/architecture.mdx` against the
  * filesystem — it caught directory-name drift but missed the prose count
  * claims that sit alongside the tree. This gate closes that gap by
- * extracting every numeric count claim from the three doc surfaces and
+ * extracting every numeric count claim from the covered doc surfaces and
  * comparing against the filesystem-derived truth.
  *
  * Strategy:
  *   1. Compute canonical counts from the filesystem (`apps/`, `packages/`,
  *      `services/`, `spec/*.md`).
- *   2. For each of the three doc surfaces, run a set of probes — each is
+ *   2. For each doc surface in DOCS, run a set of probes — each is
  *      a regex that captures `(\d+) <noun>` and a `noun → key` mapping.
  *   3. Every claim found must equal the canonical count for its noun.
  *
@@ -270,6 +270,20 @@ const DOCS: ReadonlyArray<DocFile> = [
         regex: /\(\[`services\/`\]\(services\/\)\) — (\d+) services in four roles/,
         key: "services",
         label: "Marketplace section — service count",
+      },
+    ],
+  },
+  {
+    // The npm-published CLI README (`motebit` on npmjs.com) — a public
+    // surface with no repo context, so its count claims drift silently.
+    // Caught claiming 19 specs when the actual count was 34 (2026-07-25).
+    path: "apps/cli/README.md",
+    probes: [
+      {
+        regex:
+          /the \[(\d+) open specs\]\(https:\/\/github\.com\/motebit\/motebit\/tree\/main\/spec\)/,
+        key: "specs",
+        label: "How-it-ships section — open-specs count",
       },
     ],
   },


### PR DESCRIPTION
## What

The published `motebit` npm README (1.9.0) drifted from the repo on four claims, and the `--help` provider list on one:

- **Spec count**: claimed **19** open specs; actual is **34** (`ls spec/*.md`)
- **Providers table**: listed 2 of 7 supported providers; now documents all of them — Anthropic (default), OpenAI, Google, Groq, DeepSeek, Local server (Ollama / LM Studio / llama.cpp / vLLM via `--provider local-server`, alias `ollama`), and Motebit Cloud (`proxy`). Env vars and key prefixes taken from `runtime-factory.ts`, not guessed
- **Dead reference**: `spec/skills-v1.md` was bare text — resolves to nothing on npmjs.com; now an absolute GitHub link
- **"single binary"** → **"single package"** — it's an npm package with a native dep (`better-sqlite3`), which the Troubleshooting section itself proves
- **`--help`**: `groq` and `deepseek` were fully wired (`CliProvider` union, `runtime-factory.ts` BYOK arms) but absent from the help-screen provider list; added with their real defaults (`llama-3.3-70b-versatile`, `deepseek-chat`)

## Gate extension

`apps/cli/README.md` is now the **ninth covered surface** in `check-doc-counts`, with a probe locking the open-specs count in the How-it-ships section — npm-surface count drift now goes red in CI instead of shipping silently. Also fixed the gate's stale founding docstring ("three doc surfaces").

Changeset: patch bump for `motebit` (README + help text ship to npm).

## Verification

- `check-doc-counts` ✓ (43 claims across 9 surfaces, 34 specs)
- `check-docs-cli-claims` ✓, `check-docs-default-models` ✓
- CLI package typechecks clean; pre-push gauntlet green

🤖 Generated with [Claude Code](https://claude.com/claude-code)