### PR TITLE
fix(skills): drop the no-op manifest cast that would mask schema drift

### DIFF
--- a/packages/skills/src/parse.ts
+++ b/packages/skills/src/parse.ts
@@ -95,7 +95,7 @@ export function parseSkillFile(rawText: string): {
   }
 
   return {
-    manifest: validation.data as SkillManifest,
+    manifest: validation.data,
     body: new TextEncoder().encode(bodyText),
   };
 }


### PR DESCRIPTION
## What

Removes `validation.data as SkillManifest` in `packages/skills/src/parse.ts` — a no-op assertion flagged by `@typescript-eslint` 8.64 (`no-unnecessary-type-assertion`) on dependabot #306.

The lint is right, and the removal is a strict improvement: the wire-schemas parity block guarantees `z.infer<typeof SkillManifestSchema>` ≡ the protocol's `SkillManifest`, so the cast changed nothing today — and would have kept compiling through a future schema↔protocol divergence. The bare assignment turns this call site into a live assignability check. Same cast-hole class the wire-schemas Relax arc closed (#115), found outside its gate scope by the newer linter.

## Why now

Unblocks #306: per foundational-tool-adoption doctrine, a lint-tooling bump merges only when the defensive gates are clean under it. This makes them clean — `@motebit/skills` typechecks and lints green under both 8.58 (current) and 8.64 (the bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)