### PR TITLE
fix(runtime,relay): paid P2P result recoverable when the task outlives the poll token

### DIFF
--- a/.legC-verify-seam.mts
+++ b/.legC-verify-seam.mts
@@ -1,0 +1,72 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { Buffer } from "node:buffer";
+
+const HOME = process.env.HOME!;
+const cfg = JSON.parse(readFileSync(HOME + "/.motebit-product-test/config.json", "utf8"));
+const idmod = await import("/Users/daniel/src/motebit/apps/cli/src/identity.ts");
+const privHex = await idmod.decryptPrivateKey(cfg.cli_encrypted_key, "product-test-2026");
+const priv = idmod.fromHex(privHex);
+
+const crypto = await import("@motebit/crypto");
+const { resolveAndSubmitP2pDelegation } = await import("@motebit/runtime");
+const { createSolanaWalletRail } = await import("@motebit/wallet-solana");
+
+const RELAY_URL = "https://relay.motebit.com";
+
+const RESEARCHER = "019d8167-406e-74c2-a517-81d3996aa160";
+
+const rail = createSolanaWalletRail({
+  rpcUrl: "https://api.mainnet-beta.solana.com",
+  identitySeed: Buffer.from(privHex, "hex"),
+});
+
+const authToken = async (aud?: string): Promise<string> => {
+  const t = await crypto.mintAudienceToken(
+    { mid: cfg.motebit_id, did: cfg.device_id, aud: (aud ?? "task:submit") as never },
+    priv,
+  );
+  return t.token;
+};
+
+console.log("delegator:", cfg.motebit_id);
+console.log("pinned relay key:", cfg.relay_public_key.slice(0, 16) + "…");
+
+const result = await resolveAndSubmitP2pDelegation({
+  motebitId: cfg.motebit_id,
+  syncUrl: RELAY_URL,
+  authToken,
+  prompt: "What is SPIFFE/SPIRE and what problem does workload identity solve? Cite sources.",
+  capability: "research",
+  targetWorkerId: RESEARCHER,
+  relayPublicKeyHex: cfg.relay_public_key,
+  buildP2pPayment: (req: never) => rail.buildP2pPayment!(req),
+  acknowledgeNoHistoryRisk: true,
+  timeoutMs: 180000,
+  logger: { warn: (m: string, ctx?: unknown) => console.warn("warn:", m, ctx ?? "") },
+} as never);
+
+if (!(result as { ok: boolean }).ok) {
+  const e = (result as { error: { code: string; message: string } }).error;
+  console.error("FAILED:", e.code, e.message);
+  process.exit(1);
+}
+const receipt = (result as { receipt: Record<string, unknown> }).receipt;
+writeFileSync(HOME + "/.motebit-product-test/legC-receipt.json", JSON.stringify(receipt, null, 2));
+console.log("RECEIPT saved. task_id:", receipt["task_id"], "status fields:", Object.keys(receipt).slice(0, 12).join(","));
+
+const { verifyReceiptVerdict } = await import("@motebit/verifier");
+const verdict = await verifyReceiptVerdict(receipt as never);
+console.log("receipt verdict:", JSON.stringify({ integrity: verdict.integrity, binding: verdict.identityBinding, sovereign: (verdict as never as Record<string, unknown>)["sovereign"] }));
+
+const payload = JSON.parse(String(receipt["result"] ?? "{}"));
+if (payload.attestation) {
+  const att = payload.attestation;
+  const vres = await (crypto as never as { verifyEvalAttestation: (a: unknown) => Promise<unknown> }).verifyEvalAttestation(att).catch((e: Error) => ({ err: e.message }));
+  writeFileSync(HOME + "/.motebit-product-test/legB-attestation.json", JSON.stringify(att, null, 2));
+  console.log("attestation subject:", att.subject ?? att.target ?? "?");
+  console.log("attestation verify:", JSON.stringify(vres).slice(0, 300));
+  console.log("checks:", JSON.stringify(payload.attestation.measurements ?? payload.attestation.checks ?? payload.summary ?? {}).slice(0, 500));
+} else {
+  console.log("result payload keys:", Object.keys(payload));
+  console.log("raw result head:", String(receipt["result"]).slice(0, 400));
+}

--- a/.poll-task.mts
+++ b/.poll-task.mts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+const cfg = JSON.parse(readFileSync(process.env.HOME + "/.motebit-product-test/config.json", "utf8"));
+const idmod = await import("/Users/daniel/src/motebit/apps/cli/src/identity.ts");
+const privHex = await idmod.decryptPrivateKey(cfg.cli_encrypted_key, "product-test-2026");
+const priv = idmod.fromHex(privHex);
+const crypto = await import("@motebit/crypto");
+const TASK = "22fc5f94-202a-4c31-98f5-9d4a03d3a449";
+for (const aud of ["task:query", "task:submit"]) {
+  const t = await crypto.mintAudienceToken({ mid: cfg.motebit_id, did: cfg.device_id, aud: aud as never }, priv);
+  const r = await fetch(`https://relay.motebit.com/agent/${cfg.motebit_id}/task/${TASK}`, { headers: { authorization: "Bearer " + t.token } });
+  const body = await r.text();
+  console.log(aud, r.status, body.slice(0, 200));
+  if (r.ok) {
+    const d = JSON.parse(body);
+    console.log("STATUS:", d.status, "has receipt:", d.receipt != null);
+    if (d.receipt) { const fs = await import("node:fs"); fs.writeFileSync(process.env.HOME + "/.motebit-product-test/legC-receipt.json", JSON.stringify(d.receipt, null, 2)); console.log("receipt saved"); }
+    break;
+  }
+}

--- a/packages/runtime/src/__tests__/relay-delegation.test.ts
+++ b/packages/runtime/src/__tests__/relay-delegation.test.ts
@@ -187,6 +187,33 @@ describe("submitP2pDelegation", () => {
     }
   });
 
+  it("re-mints the task:query token on every poll attempt so long tasks outlive the token TTL (#424)", async () => {
+    vi.useFakeTimers();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { task_id: "task-ttl" })) // submit
+      .mockResolvedValueOnce(jsonResponse(200, { task: { status: "running" }, receipt: null }))
+      // A stale-token-style failure mid-poll: warned and retried, and the NEXT
+      // attempt carries a freshly minted token — the #424 recovery.
+      .mockResolvedValueOnce(jsonResponse(401, { code: "AUTH_TOKEN_EXPIRED" }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, { task: { status: "completed" }, receipt: { result_hash: "rh" } }),
+      );
+
+    const params = baseParams();
+    const promise = submitP2pDelegation(params);
+    await vi.advanceTimersByTimeAsync(2100); // poll 1 (running)
+    await vi.advanceTimersByTimeAsync(2100); // poll 2 (401 — retried)
+    await vi.advanceTimersByTimeAsync(2100); // poll 3 (receipt)
+    const result = await promise;
+
+    expect(result.ok).toBe(true);
+    const auds = params.authToken.mock.calls.map((c) => c[0]);
+    // One submit mint, then one FRESH task:query mint per poll attempt —
+    // never a pre-minted token reused across the task's lifetime.
+    expect(auds.filter((a) => a === "task:submit")).toHaveLength(1);
+    expect(auds.filter((a) => a === "task:query")).toHaveLength(3);
+  });
+
   it("sums both fee legs into settlement.feeMicro for a federated 3-leg proof", async () => {
     vi.useFakeTimers();
     fetchMock

--- a/packages/runtime/src/relay-delegation.ts
+++ b/packages/runtime/src/relay-delegation.ts
@@ -315,17 +315,12 @@ export async function submitAndPollDelegation(
   const timeoutMs = params.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const startedAt = Date.now();
 
-  // Mint audience-specific tokens. The relay enforces `aud` binding:
-  // task:submit for POST, task:query for GET on the task record.
+  // Mint the submit token (used once, immediately). The relay enforces `aud`
+  // binding: task:submit for POST; the task:query token for GET is minted
+  // per poll attempt inside pollForReceipt (see PollForReceiptArgs.getQueryHeader).
   let submitHeader: string;
-  let queryHeader: string;
   try {
-    const [submitToken, queryToken] = await Promise.all([
-      params.authToken("task:submit"),
-      params.authToken("task:query"),
-    ]);
-    submitHeader = `Bearer ${submitToken}`;
-    queryHeader = `Bearer ${queryToken}`;
+    submitHeader = `Bearer ${await params.authToken("task:submit")}`;
   } catch (err: unknown) {
     return {
       ok: false,
@@ -400,7 +395,7 @@ export async function submitAndPollDelegation(
     syncUrl: params.syncUrl,
     motebitId: params.motebitId,
     taskId,
-    queryHeader,
+    getQueryHeader: async () => `Bearer ${await params.authToken("task:query")}`,
     timeoutMs,
     startedAt,
     logger: params.logger,
@@ -416,7 +411,15 @@ interface PollForReceiptArgs {
   syncUrl: string;
   motebitId: string;
   taskId: string;
-  queryHeader: string;
+  /**
+   * Re-minting thunk, called PER poll attempt — never a pre-minted header.
+   * A task can legitimately outlive the 5-minute signed-token TTL (a paid
+   * molecule doing per-hop onchain settlement runs tens of minutes); a
+   * static token then 403s every remaining poll while the relay's task TTL
+   * reaps the completed record — a paid receipt lost to the payer (#424).
+   * Minting is a local Ed25519 sign, so per-attempt cost is negligible.
+   */
+  getQueryHeader: () => Promise<string>;
   timeoutMs: number;
   startedAt: number;
   logger: { warn(message: string, context?: Record<string, unknown>): void };
@@ -451,9 +454,20 @@ async function pollForReceipt(args: PollForReceiptArgs): Promise<DelegationResul
       /* abort — handled on next iteration */
     });
 
+    let queryHeader: string;
+    try {
+      queryHeader = await args.getQueryHeader();
+    } catch (err: unknown) {
+      args.logger.warn("delegation poll token mint failed", {
+        taskId: args.taskId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
+
     try {
       const resp = await fetch(`${args.syncUrl}/agent/${args.motebitId}/task/${args.taskId}`, {
-        headers: { Authorization: args.queryHeader },
+        headers: { Authorization: queryHeader },
         signal: args.signal,
       });
 
@@ -584,14 +598,8 @@ export async function submitP2pDelegation(
   const startedAt = Date.now();
 
   let submitHeader: string;
-  let queryHeader: string;
   try {
-    const [submitToken, queryToken] = await Promise.all([
-      params.authToken("task:submit"),
-      params.authToken("task:query"),
-    ]);
-    submitHeader = `Bearer ${submitToken}`;
-    queryHeader = `Bearer ${queryToken}`;
+    submitHeader = `Bearer ${await params.authToken("task:submit")}`;
   } catch (err: unknown) {
     return {
       ok: false,
@@ -682,7 +690,7 @@ export async function submitP2pDelegation(
     syncUrl: params.syncUrl,
     motebitId: params.motebitId,
     taskId,
-    queryHeader,
+    getQueryHeader: async () => `Bearer ${await params.authToken("task:query")}`,
     timeoutMs,
     startedAt,
     logger: params.logger,

--- a/services/relay/src/__tests__/dogfood-e2e.test.ts
+++ b/services/relay/src/__tests__/dogfood-e2e.test.ts
@@ -424,6 +424,32 @@ describe("Dogfood E2E — Two-Motebit Delegation", () => {
     expect(body.status).toBe("completed");
   });
 
+  it("12a. An expired task:query token gets the honest AUTH_TOKEN_EXPIRED, never device-not-authorized (#424)", async () => {
+    // A long-running task legitimately outlives the 5-minute token TTL. The
+    // boolean device-verify collapses every failure into AUTHZ_DEVICE_NOT_AUTHORIZED,
+    // which misdirects the client toward device re-registration when the real
+    // remedy is re-minting. Expiry must be named before the collapse.
+    const now = Date.now();
+    const expiredToken = await createSignedToken(
+      {
+        mid: motebitIdA,
+        did: relayDeviceIdA,
+        iat: now - 10 * 60 * 1000,
+        exp: now - 5 * 60 * 1000,
+        jti: crypto.randomUUID(),
+        aud: "task:query",
+      },
+      keypairA.privateKey,
+    );
+    const res = await relay.app.request(`/agent/${motebitIdB}/task/${sharedTaskId}`, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${expiredToken}` },
+    });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("AUTH_TOKEN_EXPIRED");
+  });
+
   it("12. Agent A polls the completed task with a signed device token (task:query audience)", async () => {
     // Agent A uses its own device token with "task:query" audience to poll.
     // The relay verifies the token against A's identity (from token claims.mid),

--- a/services/relay/src/__tests__/p2p-cycle-e2e.test.ts
+++ b/services/relay/src/__tests__/p2p-cycle-e2e.test.ts
@@ -512,6 +512,14 @@ describe("P2P Settlement Cycle E2E", () => {
     });
     expect(receiptRes.status).toBe(200);
 
+    // Paid-result retention (#424): a completed P2P task's record must outlive
+    // the free-task TTL — the delegator already settled onchain, so reaping the
+    // receipt at 10min makes a paid artifact unrecoverable after a stalled poll.
+    const queueRow = relay.moteDb.db
+      .prepare("SELECT expires_at FROM relay_task_queue WHERE task_id = ?")
+      .get(taskId) as { expires_at: number };
+    expect(queueRow.expires_at).toBeGreaterThan(Date.now() + 10 * 60 * 1000);
+
     // === STEP 3: VERIFY SETTLEMENT AUDIT RECORD ===
     const allSettlements = relay.moteDb.db
       .prepare("SELECT * FROM relay_settlements WHERE task_id = ?")

--- a/services/relay/src/tasks.ts
+++ b/services/relay/src/tasks.ts
@@ -101,6 +101,18 @@ const logger = createLogger({ service: "tasks" });
 // receipt-time extension below) — sweeping a live task's allocation would
 // open a refund/settlement double-credit race.
 export const TASK_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+/**
+ * Retention for a COMPLETED task the delegator paid for (P2P settlement).
+ * A paid artifact must outlive a slow client: the payer already settled
+ * onchain, so reaping the receipt at the free-task TTL makes the paid
+ * result unrecoverable when polling stalls (token expiry, network) — the
+ * #424 fund-loss-adjacent shape. Allocation-horizon safety: P2P tasks hold
+ * NO budget allocation (they settle onchain, not from a relay-custody
+ * allocation), so the `STALE_ALLOCATION_HORIZON_MS >= 3 * TASK_TTL_MS`
+ * refund-race guard in index.ts is not implicated by this longer retention.
+ */
+export const PAID_TASK_RESULT_RETENTION_MS = 60 * 60 * 1000; // 1 hour
 const MAX_TASK_QUEUE_SIZE = 100_000; // Hard cap prevents memory exhaustion
 
 /** Shape of each entry in the in-memory task queue. */
@@ -3154,6 +3166,17 @@ export async function registerTaskRoutes(deps: TasksDeps): Promise<void> {
       if (!claims?.mid) {
         throw new AuthenticationError("AUTH_INVALID_TOKEN", "Invalid token");
       }
+      // Expiry gets its own honest error BEFORE the boolean verify collapses
+      // every failure into "device not authorized" (#424): a long-running task
+      // outlives the 5-minute token TTL, and the client's correct remedy is
+      // re-mint — not device re-registration. Reading exp from the unverified
+      // payload is safe here: it only selects the error message, never grants.
+      if (typeof claims.exp === "number" && claims.exp < Date.now()) {
+        throw new AuthenticationError(
+          "AUTH_TOKEN_EXPIRED",
+          "Token expired — mint a fresh task:query token and retry",
+        );
+      }
       const verified = await verifySignedTokenForDevice(
         token,
         claims.mid,
@@ -3175,7 +3198,7 @@ export async function registerTaskRoutes(deps: TasksDeps): Promise<void> {
     if (!entry) {
       throw new TaskError(
         "TASK_NOT_FOUND",
-        `Task not found — it may have expired (TTL ${Math.round(TASK_TTL_MS / 60_000)}min) or the task_id is invalid`,
+        `Task not found — it may have expired (TTL ${Math.round(TASK_TTL_MS / 60_000)}min; paid results retained ${Math.round(PAID_TASK_RESULT_RETENTION_MS / 60_000)}min) or the task_id is invalid`,
         404,
       );
     }
@@ -3216,6 +3239,14 @@ export async function registerTaskRoutes(deps: TasksDeps): Promise<void> {
     if (apiToken == null || token !== apiToken) {
       // Verify as device signed token
       if (enableDeviceAuth && token.includes(".")) {
+        // Same expiry-before-verify honesty as the task:query poll route (#424).
+        const resultClaims = parseTokenPayloadUnsafe(token);
+        if (typeof resultClaims?.exp === "number" && resultClaims.exp < Date.now()) {
+          throw new AuthenticationError(
+            "AUTH_TOKEN_EXPIRED",
+            "Token expired — mint a fresh task:result token and retry",
+          );
+        }
         const verified = await verifySignedTokenForDevice(
           token,
           motebitId,
@@ -3236,7 +3267,7 @@ export async function registerTaskRoutes(deps: TasksDeps): Promise<void> {
     if (!entry) {
       throw new TaskError(
         "TASK_NOT_FOUND",
-        `Task not found — it may have expired (TTL ${Math.round(TASK_TTL_MS / 60_000)}min) or the task_id is invalid`,
+        `Task not found — it may have expired (TTL ${Math.round(TASK_TTL_MS / 60_000)}min; paid results retained ${Math.round(PAID_TASK_RESULT_RETENTION_MS / 60_000)}min) or the task_id is invalid`,
         404,
       );
     }
@@ -3294,9 +3325,15 @@ export async function registerTaskRoutes(deps: TasksDeps): Promise<void> {
       );
     }
 
-    // Update task status and store receipt before settlement
+    // Update task status and store receipt before settlement. Paid (P2P)
+    // results are retained longer than the free-task TTL — the payer settled
+    // onchain and must be able to recover the artifact after a stalled poll.
+    const resultRetentionMs =
+      entry.settlement_mode === "p2p" || entry.p2p_payment_proof != null
+        ? PAID_TASK_RESULT_RETENTION_MS
+        : TASK_TTL_MS;
     entry.receipt = receipt;
-    entry.expiresAt = Math.max(entry.expiresAt, Date.now() + TASK_TTL_MS);
+    entry.expiresAt = Math.max(entry.expiresAt, Date.now() + resultRetentionMs);
     entry.task.status =
       receipt.status === "completed"
         ? AgentTaskStatus.Completed


### PR DESCRIPTION
## What

Closes #424 — found live during the Researcher money-seam verification: a seam-flipped run legitimately exceeded the 5-minute token TTL, polls 403'd with the misleading `AUTHZ_DEVICE_NOT_AUTHORIZED`, and the 10-minute task TTL reaped the completed record. A fully-paid, fully-executed delegation whose signed artifact the payer could never retrieve.

Three independent fixes:

1. **Client re-mints per poll** — `pollForReceipt` takes a `getQueryHeader` thunk called per attempt (local Ed25519 sign, negligible); both submit paths converted. A mid-poll 401 self-heals on the next attempt. No task can outlive its polling credentials.
2. **Relay names expiry honestly** — `AUTH_TOKEN_EXPIRED` (401) thrown *before* the boolean device-verify collapses every failure into device-not-authorized, on both `task:query` and `task:result` routes. Reading `exp` from the unverified payload only selects the error message, never grants — gate-repair-instructions discipline applied to API errors: the error carries its own remedy.
3. **Paid results outlive free-task TTL** — completed P2P tasks retain their record 60 min (`PAID_TASK_RESULT_RETENTION_MS`) vs the 10-min free TTL. The `STALE_ALLOCATION_HORIZON_MS ≥ 3×TASK_TTL_MS` refund-race guard is not implicated: P2P tasks hold no budget allocation (documented at the constant). The 404 message names both TTLs.

## Tests

- runtime: re-mint-per-attempt count (1 submit mint, 1 query mint *per* poll) with mid-poll 401 recovery — 40/40 pass
- relay: dogfood 12a (expired token → 401 `AUTH_TOKEN_EXPIRED`, never device-not-authorized) + paid-retention assertion inside the full p2p cycle — 37/37 pass
- Both packages typecheck clean; full pre-push gauntlet green

Sibling audit done: both runtime submit paths, both relay task-fetch routes. The middleware `sync`-route verify has the same boolean collapse but a different client contract (sync loops re-auth continuously) — left as-is deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)