### PR TITLE
fix(cli,runtime): plain `delegate --sovereign` pays P2P — no silent flag-ignore

### DIFF
--- a/.changeset/sovereign-plain-delegate.md
+++ b/.changeset/sovereign-plain-delegate.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+`motebit delegate --sovereign` now works without `--plan`: the plain delegate path pays the worker directly from the sovereign Solana wallet via a single-step paid P2P delegation (discovery or `--target`, cold-start via `--pay-new-agents`, honest `Paid:` settlement line). Previously the flag was silently ignored — the command fell through to relay-custody, hit the empty virtual account, and misdirected a funded sovereign user to `motebit fund`. Every missing prerequisite now refuses loudly with its remedy, and nothing falls back to relay-custody. `--budget` is enforced as a hard pre-broadcast ceiling over the entire resolved payment (worker + all fee legs) — an over-budget resolution fails `budget_exceeded` with no money moved. (`@motebit/protocol` becomes a declared CLI dependency — previously reached only transitively.)

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -95,6 +95,7 @@
     "@motebit/mcp-server": "workspace:*",
     "@motebit/memory-graph": "workspace:*",
     "@motebit/persistence": "workspace:*",
+    "@motebit/protocol": "workspace:*",
     "@motebit/planner": "workspace:*",
     "@motebit/policy": "workspace:*",
     "@motebit/privacy-layer": "workspace:*",

--- a/apps/cli/src/subcommands/delegate.ts
+++ b/apps/cli/src/subcommands/delegate.ts
@@ -352,6 +352,97 @@ export async function handleDelegate(config: CliConfig): Promise<void> {
   const capability = config.capability ?? "web_search";
   let targetMotebitId = config.target;
 
+  // --sovereign: pay the worker directly from the sovereign Solana wallet —
+  // single-step paid P2P delegation (#423). This path NEVER falls back to
+  // relay-custody: every missing prerequisite refuses loudly with its remedy
+  // (the pre-fix behavior silently ignored the flag, hit the empty virtual
+  // account, and misdirected a funded sovereign user to `motebit fund`).
+  if (config.sovereign) {
+    const fullConfig = loadFullConfig();
+    if (fullConfig.relay_public_key == null || fullConfig.relay_public_key === "") {
+      console.error(
+        "Sovereign delegation requires a pinned relay key (the fee leg's treasury derives from it).",
+      );
+      console.error("Run `motebit register` to pair with the relay first.");
+      process.exit(1);
+    }
+    const { loadActiveSigningKey } = await import("../identity.js");
+    let signing: { privateKey: Uint8Array };
+    try {
+      signing = await loadActiveSigningKey(fullConfig, {
+        promptLabel: "Passphrase (for sovereign wallet): ",
+      });
+    } catch (err: unknown) {
+      console.error(
+        `Sovereign delegation requires identity keys: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      process.exit(1);
+    }
+    const { createSolanaWalletRail } = await import("@motebit/wallet-solana");
+    const rail = createSolanaWalletRail({
+      rpcUrl: config.solanaRpcUrl ?? "https://api.mainnet-beta.solana.com",
+      identitySeed: signing.privateKey,
+    });
+    const buildP2pPayment = rail.buildP2pPayment?.bind(rail);
+    if (buildP2pPayment == null) {
+      console.error("The sovereign rail cannot build atomic P2P payments on this platform.");
+      process.exit(1);
+    }
+    const { resolveAndSubmitP2pDelegation } = await import("@motebit/runtime");
+    const { toMicro, fromMicro } = await import("@motebit/protocol");
+    const mintToken = async (aud?: TokenAudience): Promise<string> => {
+      const h = await getRelayAuthHeaders(config, { aud: aud ?? "task:submit", json: true });
+      return (h["Authorization"] ?? "").replace("Bearer ", "");
+    };
+
+    console.log(
+      `Delegating (sovereign P2P) ${targetMotebitId != null ? `to ${targetMotebitId.slice(0, 12)}...` : `— discovering a payable "${capability}" worker`}`,
+    );
+    const result = await resolveAndSubmitP2pDelegation({
+      motebitId,
+      syncUrl: relayUrl,
+      authToken: mintToken,
+      prompt,
+      capability,
+      ...(targetMotebitId != null ? { targetWorkerId: targetMotebitId } : {}),
+      relayPublicKeyHex: fullConfig.relay_public_key,
+      buildP2pPayment,
+      ...(config.payNewAgents ? { acknowledgeNoHistoryRisk: true } : {}),
+      // `--budget` is a hard pre-broadcast ceiling over worker + fee legs.
+      ...(config.budget != null ? { maxTotalMicro: toMicro(parseFloat(config.budget)) } : {}),
+      logger: { warn: (m, ctx) => console.error(`  warn: ${m}`, ctx ?? "") },
+    });
+
+    if (!result.ok) {
+      console.error(`Sovereign delegation failed (${result.error.code}): ${result.error.message}`);
+      if (result.error.code === "p2p_ineligible" && !config.payNewAgents) {
+        console.error(
+          "Hint: a pair with no trust history needs `--pay-new-agents` (cold-start acknowledgment).",
+        );
+      }
+      process.exit(1);
+    }
+
+    const r = result.receipt;
+    if (r.status === "completed") {
+      console.log(`\n--- Result ---\n`);
+      console.log(r.result);
+      console.log();
+      if (r.tools_used != null && r.tools_used.length > 0) {
+        console.log(`Tools: ${r.tools_used.join(", ")}`);
+      }
+    } else {
+      console.log(`Task ${r.status}: ${r.result || "(no result)"}`);
+    }
+    const s = result.settlement;
+    if (s != null && s.paidMicro != null && s.feeMicro != null && s.txHash != null) {
+      console.log(
+        `Paid: $${fromMicro(s.paidMicro).toFixed(4)} to worker + $${fromMicro(s.feeMicro).toFixed(4)} fee (tx ${s.txHash.slice(0, 12)}…)`,
+      );
+    }
+    return;
+  }
+
   // Discover a worker if no target specified
   if (!targetMotebitId) {
     try {

--- a/packages/runtime/src/__tests__/relay-delegation.test.ts
+++ b/packages/runtime/src/__tests__/relay-delegation.test.ts
@@ -381,6 +381,45 @@ describe("resolveAndSubmitP2pDelegation", () => {
     if (!result.ok) expect(result.error.code).toBe("malformed_request");
   });
 
+  it("refuses an over-budget resolution BEFORE broadcasting — budget_exceeded, nothing paid (#423)", async () => {
+    // Worker $0.50 + 5% fee > the $0.40 ceiling. The guard runs on the
+    // RESOLVED total (relay-priced), after pricing and before any money moves.
+    const params = resolveParams({ maxTotalMicro: toMicro(0.4) });
+    vi.stubGlobal(
+      "fetch",
+      routedFetch({
+        discover: discoverOk([
+          { motebit_id: "bob", settlement_address: "BobAddr", settlement_modes: "p2p,relay" },
+        ]),
+        listing: listingOk([{ capability: "web_search", unit_cost: 0.5 }]),
+      }),
+    );
+
+    const result = await resolveAndSubmitP2pDelegation(params);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("budget_exceeded");
+    expect(params.buildP2pPayment).not.toHaveBeenCalled();
+  });
+
+  it("a ceiling exactly equal to the resolved total passes (budget is inclusive)", async () => {
+    const total = toMicro(0.5) + computeP2pFeeMicro(toMicro(0.5), PLATFORM_FEE_RATE);
+    const params = resolveParams({ maxTotalMicro: total });
+    vi.stubGlobal(
+      "fetch",
+      routedFetch({
+        discover: discoverOk([
+          { motebit_id: "bob", settlement_address: "BobAddr", settlement_modes: "p2p,relay" },
+        ]),
+        listing: listingOk([{ capability: "web_search", unit_cost: 0.5 }]),
+        submit: () => jsonResponse(400, { code: "TASK_P2P_FEE_AMOUNT_MISMATCH" }),
+      }),
+    );
+
+    await resolveAndSubmitP2pDelegation(params);
+    expect(params.buildP2pPayment).toHaveBeenCalledTimes(1);
+  });
+
   it("prefers the pre-flight's canonical amounts over the listing (single source of truth)", async () => {
     // The relay's pre-flight returns the SAME amounts the submission gate
     // validates. The client pays those EXACT figures and never re-derives from

--- a/packages/runtime/src/relay-delegation.ts
+++ b/packages/runtime/src/relay-delegation.ts
@@ -81,6 +81,12 @@ export type DelegationErrorCode =
    */
   | "no_sovereign_rail"
   /**
+   * Pre-broadcast. The resolved payment total (worker leg + all fee legs)
+   * exceeds the caller's `maxTotalMicro` ceiling. Nothing was broadcast and
+   * nothing was submitted — the budget is enforced BEFORE money moves.
+   */
+  | "budget_exceeded"
+  /**
    * Pre-flight. A worker was discovered but cannot be paid directly — it has no
    * service listing, no positive price, or no settlement address. Distinct from
    * `no_routing` (no worker at all) and `insufficient_balance` (the delegator's
@@ -805,6 +811,14 @@ export interface ResolveAndSubmitP2pDelegationParams {
   buildP2pPayment?: (request: SovereignP2pPaymentRequest) => Promise<P2pPaymentProof>;
   /** Invocation provenance — signature-bound on the resulting receipt. */
   invocationOrigin?: IntentOrigin;
+  /**
+   * Budget ceiling in micro-units over the ENTIRE resolved payment (worker
+   * leg + every fee leg). Checked after pricing and BEFORE the atomic
+   * broadcast — an over-budget resolution fails `budget_exceeded` with no
+   * money moved and nothing submitted. Absent ⇒ no ceiling (caller trusts
+   * the listing price).
+   */
+  maxTotalMicro?: number;
   /** Upper bound on end-to-end wait. Default 120s. */
   timeoutMs?: number;
   /** Structured logger. */
@@ -1227,6 +1241,22 @@ export async function resolveAndSubmitP2pDelegation(
     ...(params.signal ? { signal: params.signal } : {}),
   });
   if (!resolved.ok) return { ok: false, error: resolved.error };
+
+  // 3b. Budget ceiling — enforced on the RESOLVED total (worker + all fee
+  //     legs), before any irreversible broadcast. The relay's price is the
+  //     truth being checked, so client-side listing math can't under-guard.
+  if (params.maxTotalMicro != null) {
+    const totalMicro =
+      resolved.paymentRequest.amountMicro +
+      resolved.paymentRequest.feeAmountMicro +
+      (resolved.paymentRequest.executorFeeAmountMicro ?? 0);
+    if (totalMicro > params.maxTotalMicro) {
+      return fail(
+        "budget_exceeded",
+        `Resolved payment total ${totalMicro} micro (worker + fees) exceeds the budget ceiling ${params.maxTotalMicro} micro — nothing was broadcast.`,
+      );
+    }
+  }
 
   // 4. Broadcast the atomic payment ONCE. A throw here means nothing settled on
   //    the relay — the proof is never submitted without a confirmed payment.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,9 @@ importers:
       '@motebit/privacy-layer':
         specifier: workspace:*
         version: link:../../packages/privacy-layer
+      '@motebit/protocol':
+        specifier: workspace:*
+        version: link:../../packages/protocol
       '@motebit/relay':
         specifier: workspace:*
         version: link:../../services/relay


### PR DESCRIPTION
## What

Closes #423 — plain `motebit delegate --sovereign` silently ignored the flag (the only surface reaching the sovereign payment adapter was `--plan`), submitted relay-custody, 402'd against the empty virtual account, and told a funded sovereign user to deposit via Stripe.

- **CLI**: a sovereign branch in `handleDelegate` drives `resolveAndSubmitP2pDelegation` — the proven primitive — with the pinned relay key (fee-leg treasury derives from the pairing root, never a fetched value), the wallet rail from the identity seed, and `--pay-new-agents` cold-start threading. Every missing prerequisite refuses loudly with its remedy; nothing falls back to relay-custody. Success prints an honest `Paid:` settlement line (worker + fee + tx).
- **Runtime**: new `maxTotalMicro` ceiling on `resolveAndSubmitP2pDelegation`, checked on the **resolved** total (worker + all fee legs, relay-priced) after pricing and **before** broadcast — over-budget fails typed `budget_exceeded` with no money moved. The CLI wires `--budget` to it; every consumer (conformance, Clerk) can now use it.
- `@motebit/protocol` becomes a declared CLI dependency (`check-deps` caught the transitive reach).

## Verification

- Tests: budget refusal (`buildP2pPayment` never called — nothing broadcast) + inclusive-boundary pass; runtime suite 42/42; CLI typecheck/lint/build clean; gauntlet green.
- **Live in prod, real money**: the originally-failing command from the product test now completes end to end — $0.0100 to The Auditor + $0.0005 fee in one atomic tx, signed `EvalAttestation` returned, `Paid:` line printed.

Sibling audit: `--plan --sovereign` path untouched (already worked); REPL delegation rides `enableInteractiveDelegation` (already threaded `--pay-new-agents`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)