### PR TITLE
fix(research): interior recalls are context, not automatic citations

### DIFF
--- a/services/research/src/__tests__/research.test.ts
+++ b/services/research/src/__tests__/research.test.ts
@@ -27,6 +27,7 @@ vi.mock("@motebit/mcp-client", () => ({
   },
 }));
 
+import { querySelfKnowledge } from "@motebit/self-knowledge";
 import type { AdapterFactory, AtomAdapter, ResearchConfig, SignedReceipt } from "../research.js";
 import { research } from "../research.js";
 
@@ -790,9 +791,16 @@ describe("research — cryptographic citation chain (via mcp-client)", () => {
 
   // ── Interior tier (Ring 1: recall_self) ──
 
-  it("recall_self runs locally with no adapter call and emits interior-source citations", async () => {
+  it("recall_self runs locally with no adapter call and emits interior-source citations for report-cited chunks", async () => {
     const ws = new StubAtomAdapter([]);
     const ru = new StubAtomAdapter([]);
+    // The report must CITE an interior chunk for it to become a citation
+    // (interior recalls are context, not automatic sources). Learn the real
+    // corpus hit so the mocked final report can list its locator exactly as
+    // the system prompt contracts (`interior:{source}#{title}`).
+    const expectedHits = querySelfKnowledge("what is motebit", { limit: 2 });
+    expect(expectedHits.length).toBeGreaterThan(0);
+    const cited = expectedHits[0]!;
     mockCreate
       .mockResolvedValueOnce({
         content: [
@@ -805,7 +813,12 @@ describe("research — cryptographic citation chain (via mcp-client)", () => {
         ],
       })
       .mockResolvedValueOnce({
-        content: [{ type: "text", text: "Synthesized from interior knowledge." }],
+        content: [
+          {
+            type: "text",
+            text: `Synthesized from interior knowledge. [1]\n\nSources\n[1] ${cited.title} — interior:${cited.source}#${cited.title}`,
+          },
+        ],
       });
 
     const result = await research("tell me about Motebit", {
@@ -827,13 +840,49 @@ describe("research — cryptographic citation chain (via mcp-client)", () => {
     expect(result.fetch_count).toBe(0);
     // No signed receipts — interior tier is self-attested via corpus hash.
     expect(result.delegation_receipts).toEqual([]);
-    // Citations are populated with source:"interior" and no receipt_task_id.
-    expect(result.citations.length).toBeGreaterThan(0);
+    // Only the report-cited chunk becomes a citation.
+    expect(result.citations).toHaveLength(1);
     for (const c of result.citations) {
       expect(c.source).toBe("interior");
       expect(c.receipt_task_id).toBeUndefined();
-      expect(c.locator).toMatch(/\.md#/);
+      expect(c.locator).toBe(`${cited.source}#${cited.title}`);
     }
+  });
+
+  it("interior recalls the report does not cite are context, not citations (count still discloses)", async () => {
+    const ws = new StubAtomAdapter([]);
+    const ru = new StubAtomAdapter([]);
+    mockCreate
+      .mockResolvedValueOnce({
+        content: [
+          {
+            type: "tool_use",
+            id: "tu-interior-uncited",
+            name: "motebit_recall_self",
+            input: { query: "what is motebit", limit: 2 },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        // Report never lists any interior locator — the speculative recall
+        // was consulted context only. It must not pad the citation list.
+        content: [{ type: "text", text: "An answer that used no interior sources." }],
+      });
+
+    const result = await research("something off-topic", {
+      ...baseConfig,
+      adapterFactory: makeFactory(
+        new Map([
+          ["web-search", ws],
+          ["read-url", ru],
+        ]),
+      ),
+    });
+
+    expect(result.citations).toEqual([]);
+    // The recall still HAPPENED and is disclosed — filtering citations never
+    // hides that interior knowledge was consulted.
+    expect(result.recall_self_count).toBe(1);
   });
 
   it("treats recall_self with missing query as an empty-query miss (no crash)", async () => {

--- a/services/research/src/research.ts
+++ b/services/research/src/research.ts
@@ -28,6 +28,25 @@ import { McpClientAdapter } from "@motebit/mcp-client";
 import type { Citation, ExecutionReceipt } from "@motebit/sdk";
 import { querySelfKnowledge } from "@motebit/self-knowledge";
 
+/**
+ * Interior citations are minted only when the REPORT actually cites them.
+ * `motebit_recall_self` is a free, speculative, prompt-encouraged first look —
+ * its hits are model CONTEXT, not automatically report SOURCES; unconditionally
+ * citing them padded off-topic reports with irrelevant self-knowledge excerpts
+ * (observed live: 3 of 5 citations on a pure-web question were droplet-physics
+ * chunks). The system prompt already contracts the model to list interior
+ * sources by locator (`interior:{source}#{title}`), so the filter keeps an
+ * interior citation iff its locator appears in the report text. This is an
+ * INTERSECTION (recalled ∩ report-listed): the model's Sources list can only
+ * shrink the recalled set, never mint provenance for content that was not
+ * actually recalled — a hallucinated Sources line cannot fabricate a citation.
+ * Web citations are receipt-anchored paid acts and always cite;
+ * `recall_self_count` still discloses that interior recalls occurred.
+ */
+function filterInteriorCitations(citations: Citation[], report: string): Citation[] {
+  return citations.filter((c) => c.source !== "interior" || report.includes(c.locator));
+}
+
 const SYSTEM_PROMPT = `You are a research analyst. Given a question, your job is to investigate it thoroughly using the available tools and produce a clear, well-structured report.
 
 You have three tools, ordered by preference:
@@ -88,11 +107,14 @@ export interface ResearchResult {
    */
   routing_transcripts: Record<string, unknown>[];
   /**
-   * One citation per tool call that produced source content (interior recall
-   * or URL fetch; bare web_search hits are not cited — only content actually
-   * read is). Citation.source discriminates interior (self-attested, no
-   * receipt) from web (receipt-bound via receipt_task_id). Aligns 1:1 with
-   * the outer `CitedAnswer.citations` surface built by the service.
+   * Provenance of the report's sources. Web citations: one per URL actually
+   * read (receipt-bound via receipt_task_id; bare web_search hits are not
+   * cited). Interior citations: only recalled chunks the REPORT itself lists
+   * as sources (see `filterInteriorCitations` — speculative recalls that
+   * didn't make the Sources section are context, not citations;
+   * `recall_self_count` discloses they happened). Citation.source
+   * discriminates interior (self-attested, no receipt) from web. Aligns 1:1
+   * with the outer `CitedAnswer.citations` surface built by the service.
    */
   citations: Citation[];
   /** Number of motebit_recall_self calls (interior tier). */
@@ -618,7 +640,7 @@ export async function research(question: string, config: ResearchConfig): Promis
           delegation_receipts: delegationReceipts,
           sub_settlements: subSettlements,
           routing_transcripts: routingTranscripts,
-          citations,
+          citations: filterInteriorCitations(citations, report),
           recall_self_count: recallSelfCount,
           search_count: searchCount,
           fetch_count: fetchCount,
@@ -655,7 +677,7 @@ export async function research(question: string, config: ResearchConfig): Promis
       delegation_receipts: delegationReceipts,
       sub_settlements: subSettlements,
       routing_transcripts: routingTranscripts,
-      citations,
+      citations: filterInteriorCitations(citations, report),
       recall_self_count: recallSelfCount,
       search_count: searchCount,
       fetch_count: fetchCount,


### PR DESCRIPTION
## What

Closes the interior-citation finding from the 2026-07-27 product test: 3 of 5 citations on a pure-web question (the OSAA report) were droplet-physics self-knowledge excerpts. `motebit_recall_self` is a free, speculative, prompt-encouraged first look — but every BM25 hit was minted into the citation list unconditionally.

**The fix**: interior citations now require the *report* to cite them. The system prompt already contracts the Sources format (`interior:{source}#{title}`), so `filterInteriorCitations` keeps an interior citation iff its locator appears in the report text.

**Why this shape** (and not a score threshold): a raw BM25 floor is corpus-dependent — the threshold-drift class. The report's own Sources section is the model's explicit claim about what supported the findings, and the filter is an **intersection** (recalled ∩ report-listed): it can only shrink the recalled set, never fabricate provenance for content that was never actually recalled — a hallucinated Sources line cannot mint a citation. Web citations stay unconditional (receipt-anchored paid acts), and `recall_self_count` still discloses that interior recalls occurred, so context consultation is never hidden.

## Tests

- Report-cited chunk becomes the sole citation (real-corpus locator round-trip through `querySelfKnowledge`)
- Uncited speculative recall → zero citations, count still disclosed
- 45/45 pass; typecheck + lint clean; gauntlet green

🤖 Generated with [Claude Code](https://claude.com/claude-code)