### PR TITLE
fix(cli): wrong-passphrase prompt retries; never leads with rm (fund-loss safety)

### DIFF
--- a/.changeset/passphrase-error-no-destroy.md
+++ b/.changeset/passphrase-error-no-destroy.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+Wrong-passphrase handling no longer leads with a destructive remedy. The prompt now retries a few times within one run (offline, no lockout), and on giving up it warns — instead of instructing `rm ~/.motebit/config.json`, which erases the identity key and any wallet funds it controls — that attempts are unlimited and offline, and that deletion is irreversible without a recovery seed. A non-interactive session (`MOTEBIT_PASSPHRASE`) still gets a single attempt.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -535,15 +535,38 @@ async function main(): Promise<void> {
   let passphrase: string;
 
   if (fullConfig.cli_encrypted_key) {
-    // Returning user — just the prompt
-    passphrase = envPassphrase ?? (await promptPassphrase("  Passphrase: "));
-    try {
-      await decryptPrivateKey(fullConfig.cli_encrypted_key, passphrase);
-    } catch {
+    // Returning user. Unlocking is local PBKDF2 — offline, no lockout, no
+    // server — so a wrong entry is never terminal. Retry a few times within
+    // this run (interactive only); a non-interactive session with a fixed
+    // MOTEBIT_PASSPHRASE gets one attempt, since looping a constant is futile.
+    const interactive = envPassphrase == null;
+    const maxAttempts = interactive ? 3 : 1;
+    let unlocked = false;
+    passphrase = "";
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      passphrase = envPassphrase ?? (await promptPassphrase("  Passphrase: "));
+      try {
+        await decryptPrivateKey(fullConfig.cli_encrypted_key, passphrase);
+        unlocked = true;
+        break;
+      } catch {
+        if (attempt < maxAttempts) {
+          console.log(`  ${dim(`Incorrect — try again (${maxAttempts - attempt} left).`)}`);
+        }
+      }
+    }
+    if (!unlocked) {
+      // NEVER lead with deletion. `rm ~/.motebit/config.json` erases the
+      // identity key — and any wallet funds it controls — irreversibly. The
+      // real remedy for a forgotten passphrase is to keep trying (unlimited,
+      // offline) or restore from a recovery seed if one was exported.
       console.log();
-      console.log(`  ${dim("Incorrect. Try again, or start fresh:")}`);
+      console.log(`  ${dim("Passphrase not recognized. Attempts are offline and unlimited —")}`);
+      console.log(`  ${dim("re-run `motebit` to keep trying. There is no lockout.")}`);
       console.log();
-      console.log(`     ${dim("rm ~/.motebit/config.json && motebit")}`);
+      console.log(`  ${errorColor("Do not delete ~/.motebit/config.json.")}`);
+      console.log(`  ${dim("It holds your identity key and any wallet funds it controls;")}`);
+      console.log(`  ${dim("deletion is irreversible without a recovery seed.")}`);
       console.log();
       process.exit(1);
     }


### PR DESCRIPTION
## What

Found live during the real-motebit product test: the founder forgot his passphrase and the CLI's only offered remedy was `rm ~/.motebit/config.json && motebit` — which erases the identity key **and any wallet funds it controls**, irreversibly. The header said "Try again" but the code `process.exit(1)`'d immediately, so retry wasn't even offered. He was one manual guess from permanent loss.

**Fix:**
- Interactive sessions retry **3× within one run** (unlocking is offline PBKDF2 — no lockout, no server, so a wrong entry is never terminal).
- On giving up, the message says attempts are unlimited/offline (re-run to keep trying) and **warns NOT to delete** `config.json` (identity key + wallet funds, irreversible without a recovery seed) — instead of instructing the deletion.
- Non-interactive (`MOTEBIT_PASSPHRASE`) keeps a single attempt (looping a constant is futile).
- **No fabricated restore command** — there is no CLI restore-from-seed subcommand today (`migrate-keyring` is a different failure mode); recovery-UX gap filed as #428.

Same misdirecting-remedy class as #423's `motebit fund` message, aggravated because following this one strands funds.

## Verification

CLI typecheck/lint/build clean. The deeper recovery gaps (seed backfill for legacy identities, OS-keyring enrollment, README pairing) are the design arc #428; this PR is the safety-critical, design-free piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)