### PR TITLE
fix(runtime): a human "no" is terminal, and a paid hire never re-pays

### DIFF
--- a/.changeset/denial-terminal-no-repay.md
+++ b/.changeset/denial-terminal-no-repay.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+Money-safety and human-veto integrity for paid delegation. A human "no" on an approval is now terminal: the model is told the refusal is a decision (not a retryable failure), and a re-proposal of the same tool + arguments is never shown to the human again. A paid delegation whose result could not be retrieved now reports `PAYMENT_ALREADY_SETTLED` with the amount, tx hash, and task id — so an autonomous caller cannot mistake a delivery failure for a failed hire and broadcast a second payment for work already bought.

--- a/packages/runtime/src/__tests__/relay-delegation.test.ts
+++ b/packages/runtime/src/__tests__/relay-delegation.test.ts
@@ -381,6 +381,64 @@ describe("resolveAndSubmitP2pDelegation", () => {
     if (!result.ok) expect(result.error.code).toBe("malformed_request");
   });
 
+  it("carries the settled payment on a post-broadcast poll failure so a caller cannot re-pay (#433)", async () => {
+    vi.useFakeTimers();
+    const params = resolveParams({ timeoutMs: 1 });
+    vi.stubGlobal(
+      "fetch",
+      routedFetch({
+        discover: discoverOk([
+          { motebit_id: "bob", settlement_address: "BobAddr", settlement_modes: "p2p,relay" },
+        ]),
+        listing: listingOk([{ capability: "web_search", unit_cost: 0.5 }]),
+        submit: () => jsonResponse(200, { task_id: "task-paid" }),
+        // The payment settled; only the RESULT poll fails (the transient
+        // relay 5xx / reaped-task shape that caused the live double-hire).
+        poll: () => jsonResponse(503, ""),
+      }),
+    );
+
+    const promise = resolveAndSubmitP2pDelegation(params);
+    await vi.advanceTimersByTimeAsync(5000);
+    const result = await promise;
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // The failure is still a failure — but it now names the money, so the
+      // caller can tell "paid, undelivered" from "nothing happened".
+      expect(result.error.settledPayment).toBeDefined();
+      expect(result.error.settledPayment?.txHash).toBe("p2p-tx");
+      expect(result.error.settledPayment?.paidMicro).toBe(toMicro(0.5));
+      expect(result.error.settledPayment?.taskId).toBe("task-paid");
+    }
+    // Exactly one broadcast — the payment is never re-built on a poll failure.
+    expect(params.buildP2pPayment).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves settledPayment ABSENT when the failure precedes any broadcast (#433)", async () => {
+    // The negative half: a pre-broadcast failure must NOT claim money moved,
+    // or every honest retry would be suppressed as a phantom double-pay.
+    const params = resolveParams({ maxTotalMicro: toMicro(0.4) });
+    vi.stubGlobal(
+      "fetch",
+      routedFetch({
+        discover: discoverOk([
+          { motebit_id: "bob", settlement_address: "BobAddr", settlement_modes: "p2p,relay" },
+        ]),
+        listing: listingOk([{ capability: "web_search", unit_cost: 0.5 }]),
+      }),
+    );
+
+    const result = await resolveAndSubmitP2pDelegation(params);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("budget_exceeded");
+      expect(result.error.settledPayment).toBeUndefined();
+    }
+    expect(params.buildP2pPayment).not.toHaveBeenCalled();
+  });
+
   it("refuses an over-budget resolution BEFORE broadcasting — budget_exceeded, nothing paid (#423)", async () => {
     // Worker $0.50 + 5% fee > the $0.40 ceiling. The guard runs on the
     // RESOLVED total (relay-priced), after pricing and before any money moves.

--- a/packages/runtime/src/__tests__/streaming.test.ts
+++ b/packages/runtime/src/__tests__/streaming.test.ts
@@ -1038,6 +1038,76 @@ describe("resumeAfterApproval — signed consent decision", () => {
     expect(await verifyApprovalDecision(d, keypair.publicKey)).toBe(true);
   });
 
+  it("a denial tells the model the refusal is TERMINAL, not a retryable failure (#433)", async () => {
+    await enterPendingApproval("tc-terminal", "delegate_to_agent", { prompt: "research X" });
+    await collectChunks(runtime.resumeAfterApproval(false));
+
+    const history = runtime.getConversationHistory();
+    const injected = history.map((m) => String(m.content)).join("\n");
+    // The wording is the fix: a neutral "denied" reads as a retryable fault,
+    // so the model re-plans and re-proposes the identical spend.
+    expect(injected).toContain("REFUSED_BY_HUMAN");
+    expect(injected).toContain('"terminal":true');
+    expect(injected).toMatch(/do NOT retry/i);
+    expect(injected).toMatch(/reworded arguments/i);
+  });
+
+  it("never re-prompts the human for an intent they already refused (#433)", async () => {
+    // The live failure: deny → model re-plans → identical hire proposed again
+    // → human prompted again, indefinitely. Ctrl-C was the only exit.
+    const args = { prompt: "research the Open Secure AI Alliance" };
+    await enterPendingApproval("tc-first", "delegate_to_agent", args);
+    await collectChunks(runtime.resumeAfterApproval(false));
+    expect(runtime.hasPendingApproval).toBe(false);
+
+    // The model proposes the byte-identical call again.
+    mockRunTurnStreaming.mockReturnValueOnce(
+      yieldChunks(
+        {
+          type: "approval_request",
+          tool_call_id: "tc-second",
+          name: "delegate_to_agent",
+          args,
+          risk_level: 4,
+        },
+        { type: "result", result: makeTurnResult() },
+      ),
+    );
+    await collectChunks(runtime.sendMessageStreaming("go on then"));
+
+    // No pending approval — the request was suppressed, so no surface can
+    // render a prompt and no keystroke can approve an already-refused spend.
+    expect(runtime.hasPendingApproval).toBe(false);
+    const injected = runtime
+      .getConversationHistory()
+      .map((m) => String(m.content))
+      .join("\n");
+    expect(injected).toContain("REFUSED_BY_HUMAN_ALREADY");
+  });
+
+  it("a DIFFERENT intent still reaches the human after an unrelated denial (#433)", async () => {
+    // The suppression must be exact — a blanket block would swallow genuinely
+    // new requests and break the approval gate itself.
+    await enterPendingApproval("tc-a", "delegate_to_agent", { prompt: "task A" });
+    await collectChunks(runtime.resumeAfterApproval(false));
+
+    mockRunTurnStreaming.mockReturnValueOnce(
+      yieldChunks(
+        {
+          type: "approval_request",
+          tool_call_id: "tc-b",
+          name: "delegate_to_agent",
+          args: { prompt: "task B — a different job" },
+          risk_level: 4,
+        },
+        { type: "result", result: makeTurnResult() },
+      ),
+    );
+    await collectChunks(runtime.sendMessageStreaming("now do B"));
+
+    expect(runtime.hasPendingApproval).toBe(true);
+  });
+
   it("buffers the decision in getRecentApprovalDecisions(), verifiable, same contract as getRecentReceipts()", async () => {
     await enterPendingApproval("tc-buffer", "transfer", { amt: 1 });
     await collectChunks(runtime.resumeAfterApproval(true));

--- a/packages/runtime/src/interactive-delegation.ts
+++ b/packages/runtime/src/interactive-delegation.ts
@@ -275,6 +275,26 @@ export class InteractiveDelegationManager {
         });
 
         if (!result.ok) {
+          // A failure AFTER the onchain payment settled is categorically
+          // different from a failure that spent nothing, and flattening both
+          // into one string is how a transient poll error becomes a second
+          // real-money charge (#433): the model reads "timeout", concludes the
+          // hire didn't happen, and delegates again. Name the money.
+          const settled = result.error.settledPayment;
+          if (settled) {
+            return {
+              ok: false,
+              error:
+                `PAYMENT_ALREADY_SETTLED — the hire SUCCEEDED and you have already paid ` +
+                `${(settled.paidMicro / 1_000_000).toFixed(4)} USDC (+ ` +
+                `${(settled.feeMicro / 1_000_000).toFixed(4)} fee) onchain, tx ${settled.txHash}. ` +
+                `Only RESULT DELIVERY failed (${result.error.code}: ${result.error.message}). ` +
+                `Do NOT delegate this task again — a second delegation broadcasts a SECOND ` +
+                `payment for work already bought. The task id is ${settled.taskId}; the worker's ` +
+                `result may still arrive or be recoverable. Tell the user the work was paid for ` +
+                `and the result did not come back, and let them decide.`,
+            };
+          }
           return { ok: false, error: `${result.error.code}: ${result.error.message}` };
         }
 

--- a/packages/runtime/src/relay-delegation.ts
+++ b/packages/runtime/src/relay-delegation.ts
@@ -161,6 +161,26 @@ export interface DelegationError {
    * field is safe to relay in a signed refusal receipt.
    */
   denial?: string;
+  /**
+   * Set ONLY when the delegator's onchain payment ALREADY SETTLED but the
+   * result could not be retrieved (poll timeout, transient relay 5xx, task
+   * record reaped). The hire happened and the money is gone; only delivery
+   * failed.
+   *
+   * Load-bearing for money safety (#433): without this, a post-broadcast
+   * poll failure is indistinguishable from a never-hired failure
+   * (`worker_not_payable`, `p2p_ineligible`), so an autonomous caller reads
+   * "it failed" and RE-DELEGATES — broadcasting a SECOND payment for work
+   * already bought. A caller seeing this field MUST resolve by re-fetching
+   * this `taskId`, never by re-hiring.
+   */
+  settledPayment?: {
+    txHash: string;
+    paidMicro: number;
+    feeMicro: number;
+    /** The relay task the payment bought — the handle to re-fetch, never re-pay. */
+    taskId: string;
+  };
 }
 
 /**
@@ -719,7 +739,23 @@ export async function submitP2pDelegation(
       },
     };
   }
-  return result;
+  // The poll failed AFTER the payment settled onchain. Carry the settlement
+  // fact into the error so the caller cannot mistake "I couldn't fetch the
+  // result" for "the hire never happened" — the #433 double-pay shape. The
+  // remedy for this failure is re-FETCHING `taskId`, never re-delegating.
+  const paidProof = params.paymentProof;
+  return {
+    ok: false,
+    error: {
+      ...result.error,
+      settledPayment: {
+        txHash: paidProof.tx_hash,
+        paidMicro: paidProof.amount_micro,
+        feeMicro: paidProof.fee_amount_micro + (paidProof.b_fee_amount_micro ?? 0),
+        taskId,
+      },
+    },
+  };
 }
 
 /** Trivial hex → bytes (deterministic parse, no crypto/state/IO) — inlined per

--- a/packages/runtime/src/streaming.ts
+++ b/packages/runtime/src/streaming.ts
@@ -24,6 +24,23 @@ import type { StreamChunk } from "./runtime-config.js";
 
 // Re-import the helper — it's file-local in index.ts, so we duplicate it here.
 // Exact copy of the function from index.ts.
+/**
+ * Stable identity for "the human refused THIS action" (#433). Tool name plus
+ * the exact arguments, key-sorted so object-key order can't mint a fresh
+ * identity for a byte-identical intent.
+ *
+ * Deliberately EXACT, not fuzzy: this key gates a re-prompt suppression, so a
+ * false match would silently swallow a genuinely different request. A model
+ * that meaningfully reworks its arguments gets to ask once more; the prompt
+ * text it just received tells it not to.
+ */
+function deniedIntentKey(toolName: string, args: Record<string, unknown>): string {
+  const canonical = JSON.stringify(
+    Object.fromEntries(Object.entries(args).sort(([a], [b]) => a.localeCompare(b))),
+  );
+  return `${toolName}:${canonical}`;
+}
+
 function stripDisplayTags(text: string): { clean: string; pending: string } {
   const clean = text
     .replace(/<memory\s+[^>]*>[\s\S]*?<\/memory>/g, "")
@@ -221,6 +238,24 @@ interface PendingApproval {
 export class StreamingManager {
   private _pendingApproval: PendingApproval | null = null;
   private approvalTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * Intents the human has REFUSED this session, keyed by tool + exact args
+   * (`deniedIntentKey`). A human "no" is the strongest halt signal in the
+   * system and must behave like one (#433).
+   *
+   * Why this lives on the manager and not the turn context: a denial resumes
+   * through a FRESH `runTurnStreaming` continuation, which mints a new turn
+   * context — so `maxCallsPerTurn` resets to zero and the loop's
+   * consecutive-same-tool brake resets too. Every per-turn counter is blind
+   * across an approval boundary, which is exactly the boundary a denial
+   * crosses. Session-scoped state is the only thing that survives it.
+   *
+   * Observed 2026-07-28 with real money: denying a paid delegation returned a
+   * neutral "User denied this tool call.", the model re-planned, re-proposed
+   * the identical hire, and re-prompted — indefinitely. Ctrl-C was the only
+   * exit.
+   */
+  private readonly deniedIntents = new Map<string, number>();
   private approvalExpiredCallback: (() => void) | null = null;
   private _isProcessing = false;
 
@@ -425,6 +460,42 @@ export class StreamingManager {
         }
       }
 
+      // Approval request. A re-proposal of an intent the human already
+      // refused NEVER reaches the human again (#433): re-asking after a "no"
+      // is the loop, and with a money-blind prompt an exhausted user is one
+      // keystroke from an unwanted irreversible spend. Suppress the request
+      // (the chunk is not yielded, so no surface renders a prompt) and hand
+      // the model a terminal refusal instead.
+      if (
+        chunk.type === "approval_request" &&
+        this.deniedIntents.has(deniedIntentKey(chunk.name, chunk.args))
+      ) {
+        const times = this.deniedIntents.get(deniedIntentKey(chunk.name, chunk.args)) ?? 1;
+        this.deps.injectIntermediateMessages(
+          {
+            role: "assistant" as const,
+            content: `[tool_use: ${chunk.name}(${JSON.stringify(chunk.args)})]`,
+          },
+          {
+            role: "user" as const,
+            content: `[tool_result: ${JSON.stringify({
+              ok: false,
+              error: "REFUSED_BY_HUMAN_ALREADY",
+              terminal: true,
+              message:
+                `You already proposed this exact ${chunk.name} call and the human refused it ` +
+                `(${times}×). It was NOT shown to them again. Stop retrying this action ` +
+                `entirely and answer the user directly instead.`,
+            })}]`,
+          },
+        );
+        yield {
+          type: "text" as const,
+          text: `\n[refused already — not asking again: ${chunk.name}]\n`,
+        };
+        continue;
+      }
+
       // Approval request: capture pending state and start timeout
       if (chunk.type === "approval_request") {
         this._pendingApproval = {
@@ -565,7 +636,17 @@ export class StreamingManager {
           { role: "user" as const, content: `[tool_result: ${JSON.stringify(sanitized)}]` },
         );
       } else {
-        // Push denial into conversation history
+        // Record the refusal BEFORE the continuation turn runs, so a
+        // re-proposal of this exact intent is short-circuited rather than
+        // re-prompting the human (#433).
+        const key = deniedIntentKey(pending.toolName, pending.args);
+        this.deniedIntents.set(key, (this.deniedIntents.get(key) ?? 0) + 1);
+
+        // Push denial into conversation history. The wording is load-bearing:
+        // a neutral "denied" reads to the model as a retryable failure — the
+        // same shape as a network error — so it re-plans and re-proposes the
+        // identical action. A refusal is a DECISION, not a fault; say so, and
+        // name the only legitimate next move (ask the human).
         this.deps.injectIntermediateMessages(
           {
             role: "assistant" as const,
@@ -573,7 +654,17 @@ export class StreamingManager {
           },
           {
             role: "user" as const,
-            content: `[tool_result: {"ok":false,"error":"User denied this tool call."}]`,
+            content: `[tool_result: ${JSON.stringify({
+              ok: false,
+              error: "REFUSED_BY_HUMAN",
+              terminal: true,
+              message:
+                `The human reviewed this exact ${pending.toolName} call and refused it. ` +
+                `This is a decision, not a failure — do NOT retry it, do NOT re-propose it ` +
+                `with reworded arguments, and do NOT route around it with a different tool. ` +
+                `Stop this line of action and tell the user plainly what you were going to do ` +
+                `and that they declined, then ask what they would like instead.`,
+            })}]`,
           },
         );
       }


### PR DESCRIPTION
## What

Closes #433 — found with **real money** during the real-motebit product test. A transient relay 503 on the result poll made the model conclude a **paid** delegation had failed, so it re-planned and proposed hiring again. Typing `n` to deny **did not stop it**: the model re-proposed the identical hire and the human was re-prompted, indefinitely. Ctrl-C was the only exit. Only the human pausing to ask prevented a second real charge.

Three root causes, three fixes.

### 1. Post-broadcast failure was indistinguishable from never-hired

`submitP2pDelegation` dropped the settlement on a failed poll (`return result`), and the tool handler flattened every error to `"<code>: <message>"`. So `timeout` after a confirmed onchain payment looked exactly like `worker_not_payable` (nothing spent).

`DelegationError.settledPayment` now carries tx hash, amounts, and `taskId` when money already moved, and the tool result reads `PAYMENT_ALREADY_SETTLED — the hire SUCCEEDED and you have already paid …` with the remedy named: re-fetch that task, **never** re-delegate.

### 2. A denial read as a retryable fault

The injected tool result was a neutral `"User denied this tool call."` — the same shape as a network error, which is precisely why the model treated it as retryable. It now carries `REFUSED_BY_HUMAN` + `terminal: true` and names the only legitimate next move: tell the user what you were about to do, that they declined, and ask what they'd like instead. Explicitly forbids retrying, rewording the arguments, and routing around it with a different tool.

### 3. Nothing bounded the loop

Denials never reach `recordToolCall`, so they don't consume `maxCallsPerTurn` — **and** a denial resumes through a fresh turn context, resetting that budget *and* the consecutive-same-tool brake. Every per-turn counter is blind across exactly the boundary a denial crosses.

A **session-scoped denied-intent ledger** (tool name + key-sorted exact args) now lives on the streaming manager — the only state that survives an approval boundary. On a repeat proposal the `approval_request` chunk is **never yielded**, so no surface can render a prompt and no keystroke can approve an already-refused spend.

The suppression key is deliberately **exact, not fuzzy**: a loose match would swallow genuinely different requests and break the approval gate itself.

## Tests (5 new, including the negative halves)

- `settledPayment` present on a post-broadcast poll failure, with exactly **one** broadcast
- `settledPayment` **absent** on a pre-broadcast failure — so honest retries aren't suppressed as phantom double-pays
- denial wording is terminal (`REFUSED_BY_HUMAN`, `terminal:true`, "do NOT retry", "reworded arguments")
- an identical re-proposal never re-prompts (`hasPendingApproval` stays false)
- a **different** intent still reaches the human after an unrelated denial

Runtime suite: **1232 passing**, lint + typecheck clean, full pre-push gauntlet green.

## Known adjacent surface (not this PR)

An `autonomous` preset **with a standing grant** can auto-execute a paid delegation without ever prompting — the ledger only guards what a human actually refused. That path is protected by the money meter and `verifyGrantForTurn`; it deserves its own review with the same skepticism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)