### PR TITLE
fix(cli): make the approval decision legible — money, progress, plain language

### DIFF
--- a/.changeset/approval-legibility.md
+++ b/.changeset/approval-legibility.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+The approval prompt now names the stakes. A money action renders a distinct `⚠ MONEY · IRREVERSIBLE` band, states that it pays from your sovereign wallet, and shows either the `--budget` ceiling or an honest "amount set by the worker's listing at hire time" — never a fabricated figure, since a delegation's price is late-bound. The action itself reads in human language ("Hire an agent on the motebit network to: …") instead of raw tool JSON, and the context renders as output with a single-line prompt, which also fixes the block duplicating on screen as you typed your answer. Delegation progress now animates on the post-approval execution path, which previously rendered nothing at all while a paid task ran.

--- a/apps/cli/src/__tests__/approval-render.test.ts
+++ b/apps/cli/src/__tests__/approval-render.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The approval prompt is a consent boundary — what it shows (and what it
+ * refuses to invent) is a correctness property, not styling. Locked here
+ * because the live failure was a founder approving a $0.26 irreversible
+ * onchain spend from a prompt that never said "money" (#432).
+ */
+import { describe, it, expect } from "vitest";
+import { renderApprovalRequest } from "../approval-render.js";
+
+/** Strip ANSI so assertions read the text a human sees, not the escapes. */
+// eslint-disable-next-line no-control-regex -- stripping ANSI is the point
+const plain = (lines: string[]): string => lines.join("\n").replace(/\[[0-9;]*m/g, "");
+
+describe("renderApprovalRequest", () => {
+  it("names MONEY and IRREVERSIBLE for an R4 spend", () => {
+    const out = plain(
+      renderApprovalRequest({
+        name: "delegate_to_agent",
+        args: { prompt: "Research the Open Secure AI Alliance" },
+        riskLevel: 4,
+      }),
+    );
+    expect(out).toContain("MONEY");
+    expect(out).toContain("IRREVERSIBLE");
+    // The funding source is the fact the founder most needed and least had.
+    expect(out).toMatch(/sovereign wallet/i);
+  });
+
+  it("states the pricing RULE instead of inventing an amount (late-bound spend)", () => {
+    const out = plain(
+      renderApprovalRequest({
+        name: "delegate_to_agent",
+        args: { prompt: "do research" },
+        riskLevel: 4,
+      }),
+    );
+    // A delegation's price materializes at quote resolution inside execution,
+    // so no exact figure exists at consent time. Displaying a fabricated or
+    // stale number at a consent boundary is worse than displaying none.
+    expect(out).toMatch(/worker's listing at hire time/);
+    expect(out).toMatch(/no --budget ceiling set/);
+    expect(out).not.toMatch(/\$\d/); // no dollar figure when none is known
+  });
+
+  it("shows the --budget ceiling when the session set one", () => {
+    const out = plain(
+      renderApprovalRequest({
+        name: "delegate_to_agent",
+        args: { prompt: "do research" },
+        riskLevel: 4,
+        budgetUsd: 0.5,
+      }),
+    );
+    expect(out).toContain("$0.50");
+    expect(out).not.toMatch(/no --budget ceiling set/);
+  });
+
+  it("renders the action in human language, never raw tool JSON", () => {
+    const out = plain(
+      renderApprovalRequest({
+        name: "delegate_to_agent",
+        args: { prompt: "Research OSAIA", required_capabilities: ["research"] },
+        riskLevel: 4,
+      }),
+    );
+    expect(out).toContain("Hire an agent on the motebit network to:");
+    expect(out).toContain('"Research OSAIA"');
+    expect(out).toContain("capability: research");
+    // The old rendering leaked implementation into a consent decision.
+    expect(out).not.toContain('{"prompt"');
+    expect(out).not.toContain("delegate_to_agent(");
+  });
+
+  it("stays quiet about money for a non-money tool", () => {
+    const out = plain(
+      renderApprovalRequest({ name: "web_search", args: { query: "solana" }, riskLevel: 0 }),
+    );
+    expect(out).not.toMatch(/MONEY/);
+    expect(out).not.toMatch(/wallet/i);
+    expect(out).toContain("Run web_search with:");
+    expect(out).toContain("query: solana");
+  });
+
+  it("surfaces quorum progress when multi-party approval is required", () => {
+    const out = plain(
+      renderApprovalRequest({
+        name: "delegate_to_agent",
+        args: { prompt: "x" },
+        riskLevel: 4,
+        quorum: { required: 3, approvers: ["a", "b", "c"], collected: ["a"] },
+      }),
+    );
+    expect(out).toContain("1/3 approvals collected");
+  });
+
+  it("clips a long prompt without letting it wrap the decision off-screen", () => {
+    const out = plain(
+      renderApprovalRequest({
+        name: "delegate_to_agent",
+        args: { prompt: "x".repeat(500) },
+        riskLevel: 4,
+      }),
+    );
+    expect(out).toContain("…");
+    for (const line of out.split("\n")) expect(line.length).toBeLessThan(140);
+  });
+});

--- a/apps/cli/src/approval-render.ts
+++ b/apps/cli/src/approval-render.ts
@@ -1,0 +1,115 @@
+/**
+ * Approval-request rendering — the decision moment made legible.
+ *
+ * The approval prompt is the single most consequential surface in the CLI:
+ * it is where a human authorizes an irreversible act, sometimes a real-money
+ * one. It previously rendered as raw implementation —
+ * `delegate_to_agent({"prompt":"Research the Open…})` — in the same dim gray
+ * as every other line, naming neither the stakes nor the source of funds. A
+ * founder approved a $0.26 onchain spend from that prompt without the amount,
+ * the recipient, or the word "money" appearing anywhere (#432).
+ *
+ * Calm software is not silent software. Motebit's own felt-interior doctrine
+ * draws the line: minimum display ≠ minimum legibility to the owner — "an
+ * interior the sovereign cannot feel is, to them, no interior." The money
+ * decision is exactly where the owner must feel what is happening.
+ *
+ * Honesty constraint (load-bearing): a delegation's price is LATE-BOUND — it
+ * materializes at quote resolution inside execution, not in the tool args
+ * (`moneyBinding: "late"`), so at approval time the exact amount is genuinely
+ * unknown. This renderer therefore states the funding SOURCE and the pricing
+ * RULE rather than inventing a number. Displaying a fabricated or stale
+ * figure at a consent boundary would be worse than displaying none.
+ *
+ * Pure: takes the request, returns lines. No I/O, no color decisions the
+ * caller cannot override — testable as data.
+ */
+
+import { warn, dim, bold, action, meta } from "./colors.js";
+
+/** `RiskLevel.R4_MONEY` — the band whose side effect is spending. */
+const RISK_MONEY = 4;
+
+export interface ApprovalRequestView {
+  name: string;
+  args: Record<string, unknown>;
+  riskLevel?: number;
+  quorum?: { required: number; approvers: string[]; collected: string[] };
+  /** Hard ceiling from `--budget`, in USD, when the session set one. */
+  budgetUsd?: number;
+}
+
+/** Truncate for display without lying about it. */
+function clip(text: string, max: number): string {
+  const flat = text.replace(/\s+/g, " ").trim();
+  return flat.length <= max ? flat : `${flat.slice(0, max - 1)}…`;
+}
+
+/**
+ * Human-readable statement of what the tool will DO, in the second person.
+ * Falls back to the tool name plus its most salient argument — never raw
+ * JSON, which is implementation detail leaking into a consent decision.
+ */
+function describeAction(name: string, args: Record<string, unknown>): string[] {
+  if (name === "delegate_to_agent") {
+    const prompt = typeof args.prompt === "string" ? args.prompt : "(no prompt)";
+    const caps = Array.isArray(args.required_capabilities)
+      ? (args.required_capabilities as unknown[]).filter((c) => typeof c === "string")
+      : [];
+    return [
+      "Hire an agent on the motebit network to:",
+      `  "${clip(prompt, 120)}"`,
+      ...(caps.length > 0 ? [`  capability: ${caps.join(", ")}`] : []),
+    ];
+  }
+
+  // Generic: name the tool, then its arguments one per line as key: value.
+  const entries = Object.entries(args);
+  if (entries.length === 0) return [`Run ${name}`];
+  return [
+    `Run ${name} with:`,
+    ...entries.map(
+      ([k, v]) => `  ${k}: ${clip(typeof v === "string" ? v : JSON.stringify(v), 100)}`,
+    ),
+  ];
+}
+
+/**
+ * Render the approval context block. The caller writes these lines, then
+ * prompts on a SINGLE line — a multi-line prompt string is redrawn by the
+ * line editor on every keystroke, which is what duplicated the block on
+ * screen when the user answered (#432).
+ */
+export function renderApprovalRequest(req: ApprovalRequestView): string[] {
+  const lines: string[] = [""];
+  const isMoney = (req.riskLevel ?? 0) >= RISK_MONEY;
+
+  if (isMoney) {
+    // The stakes lead. A money act must never be visually indistinguishable
+    // from a read — this is the line the founder's $0.26 slipped past.
+    lines.push(`  ${warn(bold("⚠ MONEY · IRREVERSIBLE"))}`);
+  }
+
+  for (const [i, line] of describeAction(req.name, req.args).entries()) {
+    lines.push(`  ${i === 0 ? action("?") + " " + bold(line) : dim(line)}`);
+  }
+
+  if (isMoney) {
+    lines.push(`  ${dim("Pays from your sovereign wallet — onchain, not refundable.")}`);
+    lines.push(
+      req.budgetUsd != null
+        ? `  ${dim(`Amount: the worker's listing price, capped at $${req.budgetUsd.toFixed(2)} by --budget.`)}`
+        : // No ceiling set: say so plainly rather than implying one exists.
+          `  ${dim("Amount: set by the worker's listing at hire time (no --budget ceiling set).")}`,
+    );
+  }
+
+  if (req.quorum && req.quorum.required > 1) {
+    lines.push(
+      `  ${meta(`[${req.quorum.collected.length}/${req.quorum.required} approvals collected]`)}`,
+    );
+  }
+
+  lines.push("");
+  return lines;
+}

--- a/apps/cli/src/attached-repl.ts
+++ b/apps/cli/src/attached-repl.ts
@@ -8,6 +8,7 @@
 import type { RuntimeHostClient } from "@motebit/runtime-host";
 import { dim, warn, meta, prompt as promptColor } from "./colors.js";
 import { askQuestion, destroyTerminal, readInput, writeOutput } from "./terminal.js";
+import { renderApprovalRequest } from "./approval-render.js";
 
 /** The chunk fields the attached renderer reads. Wire chunks are the
  * coordinator runtime's StreamChunk values, JSON round-tripped. */
@@ -22,12 +23,14 @@ interface WireChunk {
   message?: string;
   code?: string;
   tool_name?: string;
+  risk_level?: number;
   receipt?: { task_id?: string; status?: string };
 }
 
 interface PendingApproval {
   name: string;
   args: Record<string, unknown>;
+  riskLevel?: number;
 }
 
 async function renderStream(
@@ -50,6 +53,7 @@ async function renderStream(
           pendingApproval = {
             name: chunk.name ?? "tool",
             args: chunk.args ?? {},
+            ...(chunk.risk_level != null ? { riskLevel: chunk.risk_level } : {}),
           };
           break;
         case "delegation_start":
@@ -95,10 +99,17 @@ async function renderTurn(
   for (;;) {
     const { pendingApproval } = await renderStream(current);
     if (pendingApproval === null) return;
-    const argsPreview = JSON.stringify(pendingApproval.args).slice(0, 120);
-    const answer = await askQuestion(
-      `\n  ${warn("?")} ${pendingApproval.name}(${argsPreview})\n  Allow? (y/n) `,
-    );
+    // Context as output, prompt on one line — a multi-line prompt string is
+    // redrawn by the line editor per keystroke (#432). Same treatment as the
+    // coordinator-owned REPL in stream.ts.
+    for (const line of renderApprovalRequest({
+      name: pendingApproval.name,
+      args: pendingApproval.args,
+      ...(pendingApproval.riskLevel != null ? { riskLevel: pendingApproval.riskLevel } : {}),
+    })) {
+      writeOutput(line + "\n");
+    }
+    const answer = await askQuestion(`  ${warn("Allow?")} ${dim("(y/n)")} `);
     const approved = answer.trim().toLowerCase() === "y";
     current = client.resolveApproval(approved, motebitId);
   }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1044,6 +1044,11 @@ async function main(): Promise<void> {
           runtime,
           {
             voice: voiceController,
+            // Surfaced at the approval prompt so a money decision shows its
+            // ceiling instead of an unbounded "amount set at hire time" (#432).
+            ...(config.budget != null && Number.isFinite(parseFloat(config.budget))
+              ? { budgetUsd: parseFloat(config.budget) }
+              : {}),
           },
         );
       }

--- a/apps/cli/src/stream.ts
+++ b/apps/cli/src/stream.ts
@@ -5,6 +5,7 @@ import { formatBodyAwareness } from "@motebit/ai-core";
 import { action, meta, warn, dim, prompt as promptColor } from "./colors.js";
 import { writeOutput, askQuestion } from "./terminal.js";
 import { archiveReceipt, renderReceipt } from "./receipt.js";
+import { renderApprovalRequest } from "./approval-render.js";
 import { renderAuthorityDelta } from "./authority-delta-render.js";
 import type { VoiceController } from "./voice.js";
 
@@ -27,13 +28,14 @@ function startDotAnimation(): () => void {
 export async function consumeStream(
   stream: AsyncGenerator<StreamChunk>,
   runtime: MotebitRuntime,
-  opts?: { voice?: VoiceController },
+  opts?: { voice?: VoiceController; budgetUsd?: number },
 ): Promise<void> {
   let pendingApproval: {
     tool_call_id: string;
     name: string;
     args: Record<string, unknown>;
     quorum?: { required: number; approvers: string[]; collected: string[] };
+    risk_level?: number;
   } | null = null;
   let stopAnimation: (() => void) | null = null;
   let lastCompletedReceiptResult: string | null = null;
@@ -58,8 +60,16 @@ export async function consumeStream(
           }
           break;
         }
-        // Delegation tools are announced by delegation_start/delegation_complete instead
-        if (chunk.name === "delegate_to_agent") break;
+        // Delegation normally announces itself via delegation_start/complete,
+        // so tool_status is redundant — UNLESS this is the post-approval
+        // execution path, which executes the tool directly and emits ONLY
+        // tool_status. Blanket-skipping delegate_to_agent here meant the one
+        // path that runs after a human approves a PAID hire rendered nothing
+        // at all: the screen went blank for the entire task (#432). Skip only
+        // when an animation is already running (delegation_start beat us).
+        if (chunk.name === "delegate_to_agent" && chunk.status === "calling" && stopAnimation) {
+          break;
+        }
         if (chunk.status === "calling") {
           writeOutput(`\n  ${action("●")} ${action(chunk.name)}${meta("...")}`);
           stopAnimation = startDotAnimation();
@@ -77,10 +87,16 @@ export async function consumeStream(
           name: chunk.name,
           args: chunk.args,
           quorum: chunk.quorum,
+          // Carried so the prompt can name the stakes. Previously dropped —
+          // which is why a money act rendered identically to a read (#432).
+          risk_level: chunk.risk_level,
         };
         break;
 
       case "delegation_start":
+        // Guard against a second animation when tool_status already started
+        // one (the post-approval path emits tool_status first).
+        if (stopAnimation) break;
         writeOutput(
           `\n  ${action("●")} ${dim("[delegating]")} ${action(chunk.tool)}${meta("...")}`,
         );
@@ -146,14 +162,20 @@ export async function consumeStream(
 
   // Handle approval request after stream ends -- deterministic resumption
   if (pendingApproval) {
-    const argsPreview = JSON.stringify(pendingApproval.args).slice(0, 80);
-    const quorumInfo =
-      pendingApproval.quorum && pendingApproval.quorum.required > 1
-        ? ` [${pendingApproval.quorum.collected.length}/${pendingApproval.quorum.required} approvals]`
-        : "";
-    const answer = await askQuestion(
-      `  ${warn("?")} ${pendingApproval.name}(${argsPreview})${quorumInfo}\n  Allow? (y/n) `,
-    );
+    // Write the decision context as OUTPUT, then prompt on a single line.
+    // A multi-line prompt string is redrawn by the line editor on every
+    // keystroke, which duplicated the whole block on screen as the user
+    // typed their answer (#432).
+    for (const line of renderApprovalRequest({
+      name: pendingApproval.name,
+      args: pendingApproval.args,
+      ...(pendingApproval.risk_level != null ? { riskLevel: pendingApproval.risk_level } : {}),
+      ...(pendingApproval.quorum ? { quorum: pendingApproval.quorum } : {}),
+      ...(opts?.budgetUsd != null ? { budgetUsd: opts.budgetUsd } : {}),
+    })) {
+      writeOutput(line + "\n");
+    }
+    const answer = await askQuestion(`  ${warn("Allow?")} ${dim("(y/n)")} `);
 
     const approved = answer.trim().toLowerCase() === "y";
     writeOutput("\n" + promptColor("mote>") + " ");


### PR DESCRIPTION
## What

Closes #432 — found during the real-motebit product test. The founder approved a **$0.26 irreversible onchain spend** from a prompt reading `delegate_to_agent({"prompt":"Research the Open…})`, rendered in the same dim gray as every other line, with no amount, no recipient, and the word "money" appearing nowhere. Then the screen went blank for the entire paid task, so he had to ask whether it was working.

Four defects — one of them a real bug rather than polish.

### 1. Blank screen during a paid task (the actual bug)

`stream.ts` blanket-skipped `tool_status` for `delegate_to_agent`, assuming `delegation_start` would announce it instead. But the **post-approval path executes the tool directly and emits only `tool_status`** (`streaming.ts` `resumeAfterApproval` → `toolRegistry.execute`). So the one path that runs after a human approves a *paid* hire rendered nothing at all. The animation now starts on either signal, with a guard against double-render.

### 2. Money-blind prompt

`risk_level` was already arriving on the approval chunk and was being dropped on the floor. It's now carried and rendered: an R4 act leads with `⚠ MONEY · IRREVERSIBLE` and names the sovereign wallet as the funding source.

### 3. Honest amount, or none

A delegation's price is **late-bound** — it materializes at quote resolution inside execution (`moneyBinding: "late"`), so no exact figure exists at consent time. The prompt shows the `--budget` ceiling when set, otherwise states the pricing rule. A fabricated or stale number at a consent boundary would be worse than none — locked by a test asserting **no dollar figure appears when none is known**.

### 4. Raw JSON + on-screen duplication

The action now reads in human language ("Hire an agent on the motebit network to: …"), and the context block renders as **output** with a single-line prompt. The custom line editor redraws the prompt string on every keystroke, so a multi-line prompt duplicated the whole block as the user typed their answer — same root cause, same fix.

**Sibling-boundary rule:** `attached-repl.ts` carried the identical prompt and got the identical treatment.

## Doctrine

Calm software is not silent software. `felt-interior` draws the line — *minimum display ≠ minimum legibility to the owner; "an interior the sovereign cannot feel is, to them, no interior."* The money decision and the in-flight work are exactly the two moments where the owner must feel what is happening.

## Tests

7 render tests: money band present, no-fabricated-amount, ceiling shown when set, human language not JSON, quiet for non-money tools, quorum progress, long-prompt clipping. CLI suite **273 passing**; typecheck + lint clean; gauntlet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)