### PR TITLE
fix(cli): stale motebit.md heals + export prompt no longer corrupts input

### DIFF
--- a/.changeset/stale-md-export-prompt.md
+++ b/.changeset/stale-md-export-prompt.md
@@ -1,0 +1,6 @@
+---
+"motebit": patch
+---
+
+Three sibling fixes around the identity snapshot and its refresh path. `motebit export` no longer corrupts passphrase input (the masked prompt detaches the caller's readline for the duration of the read — a paused terminal readline kept echoing and consuming keystrokes, so the correct passphrase read as incorrect), and its wrong-passphrase message now names the real remedies (unlimited offline attempts; `motebit restore` resets a forgotten passphrase) instead of advising deletion of the config that holds your key and funds. Export also refreshes `~/.motebit/motebit.md` in place, so the snapshot can no longer silently diverge from the live identity after a key change; `motebit doctor` flags any remaining divergence with an advisory warning — the live key is `config.device_public_key`, never the .md, which is a portable snapshot.
+(The on-disk surface baseline records the refreshed `~/.motebit/motebit.md` path.)

--- a/apps/cli/etc/cli-surface.json
+++ b/apps/cli/etc/cli-surface.json
@@ -350,6 +350,7 @@
     "dev-keyring.json",
     "identity.md",
     "motebit.db",
+    "motebit.md",
     "relay",
     "relay/relay.db",
     "smoke-x402-buyer-eoa.txt",

--- a/apps/cli/src/identity.ts
+++ b/apps/cli/src/identity.ts
@@ -66,9 +66,21 @@ export function promptPassphrase(
   return new Promise((resolve) => {
     stdout.write(promptText + "\x1b[2m(Tab to show/hide)\x1b[22m ");
 
-    // Pause the caller's rl if provided (prevents it from consuming stdin)
+    // Detach the caller's rl if provided. Pausing alone is NOT enough: a
+    // terminal readline keeps its own 'data' listener on stdin, and when
+    // this reader resumes the stream, BOTH listeners fire — readline echoes
+    // every keystroke (so the user sees each character followed by our mask
+    // star) and its line buffer fights ours for the input, corrupting the
+    // captured passphrase. Witnessed live on `motebit export` 2026-07-28:
+    // the correct passphrase read as incorrect. Remove every foreign 'data'
+    // listener for the duration of the read and restore them on resolve.
     const callerRl = typeof rlOrPrompt !== "string" ? rlOrPrompt : null;
     callerRl?.pause();
+    const foreignDataListeners = stdin.listeners("data") as Array<(chunk: Buffer) => void>;
+    for (const listener of foreignDataListeners) stdin.removeListener("data", listener);
+    const restoreForeignListeners = () => {
+      for (const listener of foreignDataListeners) stdin.on("data", listener);
+    };
 
     stdin.setRawMode(true);
     stdin.resume();
@@ -108,6 +120,7 @@ export function promptPassphrase(
           stdout.write("*".repeat(value.length));
         }
         stdout.write("\n");
+        restoreForeignListeners();
         callerRl?.resume();
         resolve(value);
       } else if (c === "\u0003") {

--- a/apps/cli/src/subcommands/doctor.ts
+++ b/apps/cli/src/subcommands/doctor.ts
@@ -104,6 +104,40 @@ export async function handleDoctor(): Promise<void> {
     checks.push({ name: "Identity", ok: true, detail: "not created yet (run motebit to create)" });
   }
 
+  // Stale identity-file divergence (#429). ~/.motebit/motebit.md is a
+  // SNAPSHOT; config.device_public_key is the live truth. A snapshot from
+  // before a key change silently disagrees on the identity key — and it
+  // misled a wallet-address derivation onto the wrong funding address
+  // (2026-07-28, real money). Advisory warn: the file is not load-bearing,
+  // but anything reading it as truth is being lied to.
+  {
+    const mdPath = path.join(CONFIG_DIR, "motebit.md");
+    if (fs.existsSync(mdPath) && fullCfg.device_public_key) {
+      try {
+        const md = fs.readFileSync(mdPath, "utf-8");
+        const keyMatch = /public_key:\s*"?([0-9a-fA-F]{64})"?/.exec(md);
+        const fileKey = keyMatch?.[1]?.toLowerCase();
+        const stale = fileKey != null && fileKey !== fullCfg.device_public_key.toLowerCase();
+        checks.push({
+          name: "Identity file",
+          ok: true,
+          ...(stale ? { warn: true } : {}),
+          detail: stale
+            ? "~/.motebit/motebit.md is STALE — its key differs from the live identity"
+            : "~/.motebit/motebit.md matches the live identity key",
+          ...(stale
+            ? {
+                remedy:
+                  "run `motebit export` — it refreshes the snapshot; the live key is config.device_public_key, never the .md",
+              }
+            : {}),
+        });
+      } catch {
+        // Unreadable file: not a doctor concern beyond its absence.
+      }
+    }
+  }
+
   // Recovery-seed backup posture (#428). Not a failure — a warning with its
   // remedy: an unbacked-up sovereign key has no recovery path an operator
   // can provide, by design, so the self-recovery door must be lit BEFORE

--- a/apps/cli/src/subcommands/export.ts
+++ b/apps/cli/src/subcommands/export.ts
@@ -17,7 +17,7 @@ import { openMotebitDatabase } from "@motebit/persistence";
 import { generate as generateIdentityFile } from "@motebit/identity-file";
 import { hexPublicKeyToDidKey } from "@motebit/encryption";
 import type { CliConfig } from "../args.js";
-import { loadFullConfig, saveFullConfig } from "../config.js";
+import { CONFIG_DIR, loadFullConfig, saveFullConfig } from "../config.js";
 import {
   fromHex,
   promptPassphrase,
@@ -46,14 +46,17 @@ export async function handleExport(config: CliConfig): Promise<void> {
       await decryptPrivateKey(fullConfig.cli_encrypted_key, passphrase);
     } catch {
       // Passphrase remediation — distinct from "no identity" because the
-      // config DOES exist, it just won't decrypt. If the passphrase is
-      // remembered, try again via env; if truly lost, the only path is to
-      // delete the config and regenerate (losing the previous identity).
+      // config DOES exist, it just won't decrypt. Attempts are offline and
+      // unlimited, and since `motebit restore` shipped, a lost passphrase is
+      // recoverable from the seed — NEVER advise deleting config.json (it
+      // holds the identity key and any wallet funds; the pre-#431 copy of
+      // this message did exactly that, missed in that fix's sibling sweep).
       console.error("Error: incorrect passphrase.");
       console.error(
-        "  Retry with the correct passphrase, or set MOTEBIT_PASSPHRASE.\n" +
-          "  If the passphrase is lost, delete `~/.motebit/config.json` and\n" +
-          "  run `motebit` to create a new identity (the previous one is unrecoverable).",
+        "  Attempts are offline and unlimited — try again, or set MOTEBIT_PASSPHRASE.\n" +
+          "  Forgot it? `motebit restore` with your recovery seed resets the passphrase.\n" +
+          "  Do not delete ~/.motebit/config.json — it holds your identity key\n" +
+          "  and any wallet funds it controls.",
       );
       rl.close();
       process.exit(1);
@@ -141,6 +144,18 @@ export async function handleExport(config: CliConfig): Promise<void> {
   const identityPath = path.join(outputDir, "motebit.md");
   fs.writeFileSync(identityPath, identityContent, "utf-8");
   exported.push("identity");
+
+  // Also refresh the config-dir snapshot. `~/.motebit/motebit.md` is written
+  // at creation and was refreshed by NOTHING — after a key change it silently
+  // diverges from the live identity (config.device_public_key is the truth;
+  // the stale file misled a wallet-address derivation onto the wrong funding
+  // address, #429). Export is the natural refresh point: every export now
+  // heals the snapshot, and doctor flags any remaining divergence.
+  try {
+    fs.writeFileSync(path.join(CONFIG_DIR, "motebit.md"), identityContent, "utf-8");
+  } catch {
+    // Best-effort — the primary export above already succeeded.
+  }
 
   // 2. Gradient snapshot from local SQLite
   try {


### PR DESCRIPTION
## What

Closes #429 — three sibling defects, all found live while the founder ran the recovery flow this arc shipped an hour earlier.

### 1. `promptPassphrase(rl, …)` corrupted input (blocked `export` entirely)

The overload paused the caller's readline — but **pausing doesn't detach it**: the terminal readline kept its `data` listener, echoed every keystroke (character + mask star), and its line buffer fought the raw reader, so the **correct passphrase read as incorrect**. Every rl-passing caller was affected (`export`, `rotate`, `attest`); `seed`/`restore` use the promptless overload and were fine. Fixed at the source: foreign `data` listeners removed for the duration of the read, restored on resolve — one fix, three commands healed.

### 2. A destruction-advice sibling that #431 missed — now also false

`export`'s wrong-passphrase message still read *"delete `~/.motebit/config.json` … (the previous one is unrecoverable)."* Missed in #431's sweep, and factually wrong since `motebit restore` merged: a lost passphrase **is** recoverable from the seed. Replaced with the truthful remedies (unlimited offline attempts; restore resets it; never delete the file holding your key and funds).

### 3. The stale snapshot heals itself

`~/.motebit/motebit.md` was written at creation and refreshed by **nothing** — after a key change it silently diverged from the live identity, and it misled a wallet-address derivation onto the wrong funding address (real money, 2026-07-28). Now: `export` refreshes the snapshot in place (best-effort), and `doctor` flags any remaining divergence at the advisory `warn` tier with the canonical rule stated — **the live key is `config.device_public_key`; the .md is a portable snapshot, never the source of truth for the active wallet.**

## Gate

`check-cli-surface` caught the new on-disk path (`~/.motebit/motebit.md` under export's write set) — deliberate baseline signature; the file already exists there from bootstrap, so this is healing, not expansion.

## Verification

Smoke-verified against the founder's real config: doctor flags his actual stale file (`warn — its key differs from the live identity`). CLI suite 282 passing; typecheck/lint clean; gauntlet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)