### PR TITLE
fix(cli): prompt for the identity passphrase once per invocation

### DIFF
--- a/.changeset/cli-passphrase-once.md
+++ b/.changeset/cli-passphrase-once.md
@@ -1,0 +1,9 @@
+---
+"motebit": patch
+---
+
+Prompt for the identity passphrase once per invocation, not once per unlock.
+
+`motebit export` prompted four times in a single run — once at the top, then once per relay-auth header minted through `loadActiveSigningKey`'s default getter — which on screen looked like Enter not registering (the prompt line "duplicating" after every submit). `delegate` could reach six prompts, `market` five.
+
+The passphrase is now cached in process memory for the life of the invocation, seeded only at proof points: a successful AES-GCM decrypt of the identity key, or the encrypt call that sets the passphrase. An unverified prompt never seeds it, `MOTEBIT_PASSPHRASE` still takes precedence, nothing is persisted, and the decrypted key is still securely erased after each use. A cached value that stops decrypting (key replaced mid-process) self-heals by clearing and re-prompting. The relay key passphrase is a different secret on a different path and is unaffected.

--- a/apps/cli/src/__tests__/passphrase-session.test.ts
+++ b/apps/cli/src/__tests__/passphrase-session.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Session-passphrase cache (#445 shape: `motebit export` prompted four
+ * times in one invocation — once at the top, once per relay-auth header —
+ * reading as Enter-not-working). The cache is seeded ONLY at proof
+ * points: a successful AES-GCM decrypt of the identity key, or the
+ * encrypt call that sets the passphrase. Env still wins; unverified
+ * prompts never seed it.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  encryptPrivateKey,
+  decryptPrivateKey,
+  loadActiveSigningKey,
+  clearSessionPassphrase,
+  rememberSessionPassphrase,
+  sessionPassphraseSnapshotForTest,
+} from "../identity.js";
+import type { FullConfig } from "../config.js";
+
+const PRIV_HEX = "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60";
+const PASSPHRASE = "correct horse battery";
+
+async function makeConfig(passphrase: string): Promise<FullConfig> {
+  return {
+    cli_encrypted_key: await encryptPrivateKey(PRIV_HEX, passphrase),
+  } as FullConfig;
+}
+
+describe("session passphrase cache", () => {
+  const savedEnv = process.env["MOTEBIT_PASSPHRASE"];
+
+  beforeEach(() => {
+    delete process.env["MOTEBIT_PASSPHRASE"];
+    clearSessionPassphrase();
+  });
+
+  afterEach(() => {
+    if (savedEnv == null) delete process.env["MOTEBIT_PASSPHRASE"];
+    else process.env["MOTEBIT_PASSPHRASE"] = savedEnv;
+    clearSessionPassphrase();
+  });
+
+  it("a successful decrypt seeds the cache (the proof point)", async () => {
+    const config = await makeConfig(PASSPHRASE);
+    clearSessionPassphrase(); // encryptPrivateKey seeded it — reset to isolate decrypt
+    expect(sessionPassphraseSnapshotForTest()).toBeNull();
+    await decryptPrivateKey(config.cli_encrypted_key!, PASSPHRASE);
+    expect(sessionPassphraseSnapshotForTest()).toBe(PASSPHRASE);
+  });
+
+  it("a FAILED decrypt does not seed the cache (no unverified value ever cached)", async () => {
+    const config = await makeConfig(PASSPHRASE);
+    clearSessionPassphrase();
+    await expect(decryptPrivateKey(config.cli_encrypted_key!, "wrong")).rejects.toThrow();
+    expect(sessionPassphraseSnapshotForTest()).toBeNull();
+  });
+
+  it("setting a passphrase (encrypt) seeds the cache — set is its own proof", async () => {
+    await encryptPrivateKey(PRIV_HEX, "fresh-passphrase");
+    expect(sessionPassphraseSnapshotForTest()).toBe("fresh-passphrase");
+  });
+
+  it("loadActiveSigningKey resolves silently from the cache — no prompt, no env, no getter", async () => {
+    const config = await makeConfig(PASSPHRASE);
+    // Cache is seeded (by encrypt above); with no MOTEBIT_PASSPHRASE and no
+    // injected getter, a cache miss would fall through to an interactive
+    // prompt and hang this test — resolving at all IS the assertion.
+    const { privateKey, source } = await loadActiveSigningKey(config);
+    expect(source).toBe("encrypted-config");
+    expect(privateKey).toHaveLength(32);
+  }, 10_000);
+
+  it("MOTEBIT_PASSPHRASE wins over the cache", async () => {
+    const config = await makeConfig(PASSPHRASE);
+    rememberSessionPassphrase("stale-wrong-value");
+    process.env["MOTEBIT_PASSPHRASE"] = PASSPHRASE;
+    // If the cache were consulted first, decrypt would fail with the
+    // stale value and (per self-heal) re-prompt — env winning means this
+    // resolves with no interaction.
+    const { privateKey } = await loadActiveSigningKey(config);
+    expect(privateKey).toHaveLength(32);
+  }, 10_000);
+
+  it("an injected getPassphrase that succeeds re-seeds the cache via the decrypt proof point", async () => {
+    const config = await makeConfig(PASSPHRASE);
+    clearSessionPassphrase();
+    let calls = 0;
+    await loadActiveSigningKey(config, {
+      getPassphrase: async () => {
+        calls += 1;
+        return PASSPHRASE;
+      },
+    });
+    expect(calls).toBe(1);
+    expect(sessionPassphraseSnapshotForTest()).toBe(PASSPHRASE);
+  });
+
+  it("empty string never seeds the cache", () => {
+    rememberSessionPassphrase("");
+    expect(sessionPassphraseSnapshotForTest()).toBeNull();
+  });
+});

--- a/apps/cli/src/identity.ts
+++ b/apps/cli/src/identity.ts
@@ -33,6 +33,39 @@ export function fromHex(hex: string): Uint8Array {
   return bytes;
 }
 
+// --- Session passphrase: prompt once per invocation ---
+//
+// The identity key is ONE secret, but a single command unlocks it many
+// times: `motebit export` prompts at the top, then each of its three
+// relay-auth headers re-prompts through `loadActiveSigningKey`'s default
+// getter — four identical "Passphrase:" prompts in one run, which reads
+// as Enter-not-working (witnessed live 2026-07-29; `delegate` can reach
+// six). The fix is a process-memory cache seeded ONLY at the two proof
+// points below — a successful AES-GCM decrypt of `cli_encrypted_key`, or
+// the encrypt call that sets the passphrase — never by an unverified
+// prompt. `MOTEBIT_PASSPHRASE` still wins over the cache; nothing is ever
+// persisted; the decrypted key itself is still `secureErase`d after each
+// use, so a long-lived REPL holds no more key material than before. A
+// cached value that later fails to decrypt (key replaced mid-process)
+// self-heals: cleared and re-prompted, never a lockout.
+let sessionPassphrase: string | null = null;
+/** True when the most recent DEFAULT_PASSPHRASE_GETTER resolution came from the cache. */
+let lastResolutionFromSession = false;
+
+export function rememberSessionPassphrase(passphrase: string): void {
+  if (passphrase !== "") sessionPassphrase = passphrase;
+}
+
+export function clearSessionPassphrase(): void {
+  sessionPassphrase = null;
+  lastResolutionFromSession = false;
+}
+
+/** Test-only visibility into the cache — never use in product code. */
+export function sessionPassphraseSnapshotForTest(): string | null {
+  return sessionPassphrase;
+}
+
 export function promptPassphrase(_rl: readline.Interface, prompt: string): Promise<string>;
 export function promptPassphrase(prompt: string): Promise<string>;
 export function promptPassphrase(
@@ -162,6 +195,8 @@ export async function encryptPrivateKey(
   const salt = generateSalt(); // 16 bytes (NIST SP 800-132)
   const key = await deriveKey(passphrase, salt);
   const payload: EncryptedPayload = await encrypt(new TextEncoder().encode(privKeyHex), key);
+  // Setting a passphrase proves it — seed the session cache (see above).
+  rememberSessionPassphrase(passphrase);
   return {
     ciphertext: toHex(payload.ciphertext),
     nonce: toHex(payload.nonce),
@@ -182,6 +217,10 @@ export async function decryptPrivateKey(
     tag: fromHex(encKey.tag),
   };
   const decrypted = await decrypt(payload, key);
+  // Reaching here means the AES-GCM tag verified — the passphrase is
+  // proven correct for the identity key. Seed the session cache so later
+  // unlocks in this invocation resolve silently (see block above).
+  rememberSessionPassphrase(passphrase);
   return new TextDecoder().decode(decrypted);
 }
 
@@ -338,7 +377,15 @@ export interface LoadActiveSigningKeyOptions {
 
 const DEFAULT_PASSPHRASE_GETTER = async (label: string): Promise<string> => {
   const env = process.env["MOTEBIT_PASSPHRASE"];
-  if (env != null && env !== "") return env;
+  if (env != null && env !== "") {
+    lastResolutionFromSession = false;
+    return env;
+  }
+  if (sessionPassphrase != null) {
+    lastResolutionFromSession = true;
+    return sessionPassphrase;
+  }
+  lastResolutionFromSession = false;
   return promptPassphrase(label);
 };
 
@@ -380,11 +427,28 @@ export async function loadActiveSigningKey(
     try {
       privateKeyHex = await decryptPrivateKey(config.cli_encrypted_key, passphrase);
     } catch (err) {
-      throw new IdentityKeyError(
-        "decrypt-failed",
-        `could not decrypt cli_encrypted_key: ${err instanceof Error ? err.message : String(err)}`,
-        "the passphrase is wrong, or the encrypted blob is corrupted",
-      );
+      // Self-heal a stale session cache: if the failed passphrase came
+      // from the cache (not env, not a live prompt), the key must have
+      // changed since it was proven — drop the cache and ask for real.
+      if (lastResolutionFromSession) {
+        clearSessionPassphrase();
+        const fresh = await getPassphrase(promptLabel);
+        try {
+          privateKeyHex = await decryptPrivateKey(config.cli_encrypted_key, fresh);
+        } catch (retryErr) {
+          throw new IdentityKeyError(
+            "decrypt-failed",
+            `could not decrypt cli_encrypted_key: ${retryErr instanceof Error ? retryErr.message : String(retryErr)}`,
+            "the passphrase is wrong, or the encrypted blob is corrupted",
+          );
+        }
+      } else {
+        throw new IdentityKeyError(
+          "decrypt-failed",
+          `could not decrypt cli_encrypted_key: ${err instanceof Error ? err.message : String(err)}`,
+          "the passphrase is wrong, or the encrypted blob is corrupted",
+        );
+      }
     }
     source = "encrypted-config";
   } else if (config.cli_private_key != null && config.cli_private_key !== "") {


### PR DESCRIPTION
## The bug (live report, 2026-07-29)

`motebit export` appeared to ignore Enter — the passphrase line "duplicated" on every submit. The Enter key was fine: export prompts at the top, verifies, discards the passphrase, then mints three relay-auth headers, each of which re-prompts with the identical label through `loadActiveSigningKey`'s default getter. Four prompts in one command; `delegate` can reach six. PTY-reproduced against a sandbox identity: the run hangs at the second hidden prompt.

## The fix

One seam, not twelve call-site patches: a process-memory session cache in `identity.ts`, seeded ONLY at proof points —

- `decryptPrivateKey` success (the AES-GCM tag verifying IS the proof), or
- `encryptPrivateKey` (setting the passphrase is its own proof).

Every unlock site in the CLI funnels through those two chokepoints, so all commands heal with zero per-site edits. Posture unchanged: `MOTEBIT_PASSPHRASE` wins over the cache, nothing persists, the decrypted key is still `secureErase`d after each use, unverified prompts never seed the cache, and a stale cache self-heals (clear + real re-prompt) instead of locking out. The relay key passphrase is a different secret on a different path — untouched.

## Proof

- PTY end-to-end on the rebuilt dist: exactly one prompt, then `Export complete` (previously hung at hidden prompt #2)
- 7 new tests (`passphrase-session.test.ts`); 289 CLI tests green; typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)