### PR TITLE
feat(runtime): paid-intent interlock — a settled-but-unretrieved payment refuses re-hire before broadcast

### DIFF
--- a/.changeset/paid-intent-interlock.md
+++ b/.changeset/paid-intent-interlock.md
@@ -1,0 +1,9 @@
+---
+"motebit": minor
+---
+
+Paid-intent interlock: a delegation whose payment settled without delivering a result can never be paid for twice — mechanically, on every path.
+
+The #433 fix told the model that money already moved; the last line of defense was still the model reading that message correctly, and on the standing-grant auto-execute path there is no human between a retry loop and real money at all. Now a session-scoped ledger, seeded only by verified settled-payment facts, refuses a duplicate hire of the same worker and capability before any broadcast (typed `intent_already_paid`, fail-closed, carrying the prior task and tx), and suspends all new paid delegation once two payments are outstanding. Enforcement lives inside the shared submit chokepoint, so the interactive loop path and the granted deterministic path cannot diverge.
+
+Also from the standing-grant audit: `executeGrantedDelegation` no longer flattens a paid-but-undelivered hire into a bare failure code (the settled-payment facts now survive into the result and the operator log); `motebit grant show` and `grant list` display lifetime spend and remaining headroom read from the durable spend store; the session-start grant preflight shows headroom before the first spend and refuses arming on an exhausted ceiling; and metering real money against an in-memory spend store now warns that the lifetime ceiling re-arms on restart.

--- a/apps/cli/src/grant-preflight.ts
+++ b/apps/cli/src/grant-preflight.ts
@@ -49,6 +49,13 @@ export async function preflightGrant(deps: {
   hasRail: boolean;
   /** Live USDC balance in micro-units; undefined = RPC unavailable (soft-skip). */
   getBalanceMicro?: () => Promise<bigint>;
+  /**
+   * Read-only view of the grant's spend accumulator (the persistent
+   * `GrantSpendStore.peek`). Structural type — apps consume product
+   * vocabulary, never `@motebit/policy` directly (`check-app-primitives`).
+   * Absent = no durable store to read (headroom check soft-skips).
+   */
+  readGrantSpend?: (grantId: string) => { lifetime_spent_micro: number } | undefined;
 }): Promise<GrantPreflight> {
   const { stored, now, fullConfig, hasRail } = deps;
   const checks: PreflightCheck[] = [];
@@ -160,6 +167,27 @@ export async function preflightGrant(deps: {
         detail: "balance unavailable (RPC) — the meter still bounds every spend",
       });
     }
+  }
+
+  // 7. Ceiling headroom — the #436 legibility fix: lifetime spend was
+  //    recorded durably but observable NOWHERE until the meter's denial.
+  //    Show spent/remaining BEFORE the first spend of the session.
+  const limitMicro = stored.grant.spend_ceiling?.lifetime_limit_micro;
+  if (limitMicro != null && deps.readGrantSpend != null) {
+    const spentMicro = deps.readGrantSpend(stored.grant.grant_id)?.lifetime_spent_micro ?? 0;
+    const remainingMicro = Math.max(0, limitMicro - spentMicro);
+    const usd = (m: number): string => `$${(m / 1_000_000).toFixed(2)}`;
+    checks.push({
+      name: "headroom",
+      ok: remainingMicro > 0,
+      detail: `${usd(remainingMicro)} of ${usd(limitMicro)} lifetime remaining (${usd(spentMicro)} spent)`,
+      ...(remainingMicro > 0
+        ? {}
+        : {
+            remedy:
+              "lifetime ceiling exhausted — the meter refuses every further spend; mint a new grant",
+          }),
+    });
   }
 
   return { armed: checks.every((c) => c.ok), checks };

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -402,9 +402,9 @@ async function main(): Promise<void> {
     if (grantCmd === "create") {
       await handleGrantCreate(config);
     } else if (grantCmd === "list") {
-      handleGrantList();
+      await handleGrantList();
     } else if (grantCmd === "show") {
-      handleGrantShow(config.positionals[2]);
+      await handleGrantShow(config.positionals[2]);
     } else if (grantCmd === "revoke") {
       await handleGrantRevoke(config.positionals[2]);
     } else {
@@ -993,6 +993,7 @@ async function main(): Promise<void> {
         fullConfig,
         hasRail: solanaWallet !== undefined,
         ...(solanaWallet !== undefined ? { getBalanceMicro: () => solanaWallet.getBalance() } : {}),
+        readGrantSpend: (gid) => moteDb.grantSpendStore.peek(gid),
       });
       for (const line of renderPreflight(pf, dim)) console.log(line);
     }

--- a/apps/cli/src/subcommands/grant.ts
+++ b/apps/cli/src/subcommands/grant.ts
@@ -42,7 +42,9 @@ import {
   type DelegationRevocation,
   type SpendCeilingV1,
 } from "@motebit/encryption";
+import { openMotebitDatabase } from "@motebit/persistence";
 import { CONFIG_DIR, loadFullConfig } from "../config.js";
+import { getDbPath } from "../runtime-factory.js";
 import { loadActiveSigningKey } from "../identity.js";
 import type { CliConfig } from "../args.js";
 
@@ -381,7 +383,31 @@ export async function handleGrantCreate(config: CliConfig): Promise<void> {
 
 // === motebit grant list / show =======================================
 
-export function handleGrantList(): void {
+/**
+ * Read a grant's durable spend accumulator (the same SQLite store the money
+ * meter writes). Read-only owner legibility (#436): the spend was recorded on
+ * every metered payment but observable NOWHERE until the ceiling denial.
+ * Undefined when the DB is unavailable or the grant has never spent.
+ */
+async function readSpentMicro(grantIds: string[]): Promise<Map<string, number>> {
+  const spent = new Map<string, number>();
+  try {
+    const db = await openMotebitDatabase(getDbPath(undefined));
+    try {
+      for (const id of grantIds) {
+        const state = db.grantSpendStore.peek(id);
+        if (state != null) spent.set(id, state.lifetime_spent_micro);
+      }
+    } finally {
+      db.close();
+    }
+  } catch {
+    // No DB (fresh machine) — grants exist but nothing has ever spent.
+  }
+  return spent;
+}
+
+export async function handleGrantList(): Promise<void> {
   const grants = listStoredGrants();
   if (grants.length === 0) {
     console.log(
@@ -390,17 +416,21 @@ export function handleGrantList(): void {
     return;
   }
   const now = Date.now();
+  const spent = await readSpentMicro(grants.map((s) => s.grant.grant_id));
   for (const stored of grants) {
     const g = stored.grant;
     const state = stored.revocation != null ? "REVOKED" : g.expires_at < now ? "expired" : "active";
     const ceiling = g.spend_ceiling?.lifetime_limit_micro;
-    console.log(
-      `${g.grant_id}  ${state.padEnd(7)}  ${g.subject}  scope=${g.scope}${ceiling != null ? `  ${usd(ceiling)} lifetime` : "  (no ceiling — no money)"}`,
-    );
+    const spentMicro = spent.get(g.grant_id) ?? 0;
+    const money =
+      ceiling != null
+        ? `  ${usd(Math.max(0, ceiling - spentMicro))} of ${usd(ceiling)} lifetime remaining`
+        : "  (no ceiling — no money)";
+    console.log(`${g.grant_id}  ${state.padEnd(7)}  ${g.subject}  scope=${g.scope}${money}`);
   }
 }
 
-export function handleGrantShow(grantId: string | undefined): void {
+export async function handleGrantShow(grantId: string | undefined): Promise<void> {
   if (grantId == null || grantId === "") {
     console.error("Usage: motebit grant show <grant_id>");
     process.exit(1);
@@ -414,6 +444,13 @@ export function handleGrantShow(grantId: string | undefined): void {
   const due = selectDueTick(stored, now);
   console.log(JSON.stringify(stored.grant, null, 2));
   console.log("");
+  const ceiling = stored.grant.spend_ceiling?.lifetime_limit_micro;
+  if (ceiling != null) {
+    const spentMicro = (await readSpentMicro([stored.grant.grant_id])).get(grantId) ?? 0;
+    console.log(
+      `spend: ${usd(spentMicro)} of ${usd(ceiling)} lifetime used · ${usd(Math.max(0, ceiling - spentMicro))} remaining`,
+    );
+  }
   console.log(
     `ticks: ${stored.ticks.length} pre-minted; ${due != null ? `slot due now (issued_at ${new Date(due.issued_at).toISOString()})` : "no slot due now"}`,
   );

--- a/packages/policy/src/grant-blast-radius.ts
+++ b/packages/policy/src/grant-blast-radius.ts
@@ -361,10 +361,20 @@ export interface GrantSpendStore {
     nonce: number;
     now: number;
   }): Promise<BlastRadiusDecision>;
+  /**
+   * Read-only view of a grant's accumulator — the owner-legibility read
+   * (#436: spend was recorded but observable NOWHERE before the ceiling
+   * denial). Never used for enforcement (enforcement is the atomic
+   * `tryConsume` only); consumers render spent/remaining from it.
+   */
+  peek(grant_id: string): GrantSpendState | undefined;
 }
 
 /** Reference in-memory store. Atomic by construction (no await between read and write). */
 export class InMemoryGrantSpendStore implements GrantSpendStore {
+  /** Accumulators reset with the process — lifetime bounds re-arm on restart. */
+  readonly volatile = true;
+
   private readonly states = new Map<string, GrantSpendState>();
 
   tryConsume(input: {

--- a/packages/runtime/src/__tests__/execute-granted-delegation.test.ts
+++ b/packages/runtime/src/__tests__/execute-granted-delegation.test.ts
@@ -971,6 +971,86 @@ describe("executeGrantedDelegation — deterministic granted spend, fail-closed"
     expect(buildP2pPayment).not.toHaveBeenCalled();
   });
 
+  it("post-broadcast poll failure PROPAGATES settledPayment — and the paid-intent interlock refuses the re-hire (#436)", async () => {
+    // The human-absent #433 shape: payment settles onchain, result delivery
+    // fails. Before this fix the granted path flattened it to a bare code —
+    // byte-identical to never-hired — and nothing stopped an immediate re-pay.
+    const operator = await generateKeypair();
+    const clerk = await generateKeypair();
+    const grant = await makeGrant(operator, clerk, { lifetimeMicro: 10_000_000 });
+    const { wallet, buildP2pPayment } = mockWallet(async (r) => ({
+      tx_hash: "tx-settled",
+      chain: "solana",
+      network: "solana:devnet",
+      to_address: r.workerAddress,
+      amount_micro: r.amountMicro,
+      fee_to_address: r.treasuryAddress,
+      fee_amount_micro: r.feeAmountMicro,
+    }));
+    const runtime = clerkRuntime(wallet);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.includes("/api/v1/agents/discover"))
+          return jsonResponse({
+            agents: [
+              {
+                motebit_id: "bob-worker",
+                settlement_address: WORKER_ADDR,
+                settlement_modes: "p2p",
+                pricing: [{ capability: "research", unit_cost: 0.05 }],
+              },
+            ],
+          });
+        if (url.includes("/p2p-eligibility")) return jsonResponse({ allowed: true });
+        if (url.includes("/listing"))
+          return jsonResponse({ pricing: [{ capability: "research", unit_cost: 0.05 }] });
+        if (url.endsWith("/task")) return jsonResponse({ task_id: "t-paid" }, 201);
+        // The payment settled; only the RESULT retrieval fails. `failed` is
+        // the instantly-terminal post-broadcast poll outcome — it rides the
+        // same settledPayment-attach branch as the live 503→timeout shape
+        // without needing 100 fake-timer poll iterations.
+        if (url.includes("/task/"))
+          return jsonResponse({ task: { status: "failed" }, receipt: null });
+        return new Response("not found", { status: 404 });
+      }),
+    );
+
+    const first = await runtime.executeGrantedDelegation({
+      capability: "research",
+      prompt: "survey",
+      delegation: { token: await mintTick(grant, operator), grant },
+      targetWorkerId: "bob-worker",
+    });
+
+    expect(first.ok).toBe(false);
+    if (!first.ok) {
+      // The money fact SURVIVES into the granted result — paid-but-undelivered
+      // is no longer byte-identical to never-hired.
+      expect(first.settledPayment).toBeDefined();
+      expect(first.settledPayment?.txHash).toBe("tx-settled");
+      expect(first.settledPayment?.taskId).toBe("t-paid");
+    }
+    expect(buildP2pPayment).toHaveBeenCalledTimes(1);
+
+    // The retry (fresh tick, fresh nonce — the meter would admit it): the
+    // paid-intent interlock refuses BEFORE broadcast. No human, still stopped.
+    const second = await runtime.executeGrantedDelegation({
+      capability: "research",
+      prompt: "survey",
+      delegation: { token: await mintTick(grant, operator), grant },
+      targetWorkerId: "bob-worker",
+    });
+    vi.unstubAllGlobals();
+    expect(second.ok).toBe(false);
+    if (!second.ok) {
+      expect(second.code).toBe("intent_already_paid");
+      expect(second.settledPayment?.taskId).toBe("t-paid");
+    }
+    // Exactly one broadcast across BOTH attempts.
+    expect(buildP2pPayment).toHaveBeenCalledTimes(1);
+  });
+
   it("threads acknowledgeNoHistoryRisk ⇒ cold-start pair is eligible (happy path reachable)", async () => {
     // The eligibility mock allows ONLY when the ack query is present. This
     // dry-run succeeds ⇒ executeGrantedDelegation sent the ack (Finding #1).

--- a/packages/runtime/src/__tests__/paid-intent-ledger.test.ts
+++ b/packages/runtime/src/__tests__/paid-intent-ledger.test.ts
@@ -1,0 +1,101 @@
+/**
+ * The paid-intent interlock (#435/#436): "never pay twice for the same
+ * job" as a mechanical property, not a prompt convention. The ledger is
+ * seeded ONLY by settled-payment facts; one outstanding entry locks its
+ * worker+capability pair, two suspend all paid delegation for the session.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  PaidIntentLedger,
+  SESSION_SUSPEND_THRESHOLD,
+  type UnretrievedPayment,
+} from "../paid-intent-ledger.js";
+
+function entry(overrides: Partial<UnretrievedPayment> = {}): UnretrievedPayment {
+  return {
+    workerMotebitId: "worker-a",
+    capability: "web_search",
+    taskId: "task-1",
+    txHash: "tx-1",
+    paidMicro: 250_000,
+    feeMicro: 13_158,
+    recordedAt: 1000,
+    ...overrides,
+  };
+}
+
+describe("PaidIntentLedger", () => {
+  let ledger: PaidIntentLedger;
+
+  beforeEach(() => {
+    ledger = new PaidIntentLedger();
+  });
+
+  it("empty ledger locks nothing", () => {
+    expect(ledger.check("worker-a", "web_search")).toEqual({ locked: false });
+  });
+
+  it("a settled-unretrieved payment locks its worker+capability pair (the #433 shape)", () => {
+    ledger.recordSettledUnretrieved(entry());
+    const verdict = ledger.check("worker-a", "web_search");
+    expect(verdict.locked).toBe(true);
+    if (verdict.locked) {
+      expect(verdict.scope).toBe("pair");
+      expect(verdict.prior.taskId).toBe("task-1");
+      expect(verdict.prior.txHash).toBe("tx-1");
+    }
+  });
+
+  it("one outstanding payment does NOT lock a different worker (legitimate fan-out)", () => {
+    ledger.recordSettledUnretrieved(entry());
+    expect(ledger.check("worker-b", "web_search")).toEqual({ locked: false });
+  });
+
+  it("one outstanding payment does NOT lock a different capability on the same worker", () => {
+    ledger.recordSettledUnretrieved(entry());
+    expect(ledger.check("worker-a", "code_review")).toEqual({ locked: false });
+  });
+
+  it(`${SESSION_SUSPEND_THRESHOLD} outstanding payments suspend ALL paid delegation (money is leaking)`, () => {
+    ledger.recordSettledUnretrieved(entry());
+    ledger.recordSettledUnretrieved(
+      entry({ workerMotebitId: "worker-b", taskId: "task-2", txHash: "tx-2", recordedAt: 2000 }),
+    );
+    const verdict = ledger.check("worker-c", "translate");
+    expect(verdict.locked).toBe(true);
+    if (verdict.locked) {
+      expect(verdict.scope).toBe("session");
+      // The oldest entry is the one surfaced — the first leak to chase.
+      expect(verdict.prior.taskId).toBe("task-1");
+    }
+  });
+
+  it("resolving an entry unlocks its pair", () => {
+    ledger.recordSettledUnretrieved(entry());
+    expect(ledger.resolve("task-1")).toBe(true);
+    expect(ledger.check("worker-a", "web_search")).toEqual({ locked: false });
+    expect(ledger.outstandingCount).toBe(0);
+  });
+
+  it("resolving an unknown taskId is a no-op", () => {
+    ledger.recordSettledUnretrieved(entry());
+    expect(ledger.resolve("task-nope")).toBe(false);
+    expect(ledger.outstandingCount).toBe(1);
+  });
+
+  it("re-recording the same pair keeps one entry (latest facts win)", () => {
+    ledger.recordSettledUnretrieved(entry());
+    ledger.recordSettledUnretrieved(entry({ taskId: "task-9", txHash: "tx-9", recordedAt: 3000 }));
+    expect(ledger.outstandingCount).toBe(1);
+    const verdict = ledger.check("worker-a", "web_search");
+    if (verdict.locked) expect(verdict.prior.taskId).toBe("task-9");
+  });
+
+  it("outstanding() renders oldest first", () => {
+    ledger.recordSettledUnretrieved(
+      entry({ workerMotebitId: "worker-b", taskId: "task-2", recordedAt: 2000 }),
+    );
+    ledger.recordSettledUnretrieved(entry());
+    expect(ledger.outstanding().map((e) => e.taskId)).toEqual(["task-1", "task-2"]);
+  });
+});

--- a/packages/runtime/src/__tests__/relay-delegation.test.ts
+++ b/packages/runtime/src/__tests__/relay-delegation.test.ts
@@ -23,6 +23,7 @@ import {
   resolveAndSubmitP2pDelegation,
   selectAndRunDelegation,
 } from "../relay-delegation.js";
+import { PaidIntentLedger, SESSION_SUSPEND_THRESHOLD } from "../paid-intent-ledger.js";
 
 const envelope = (code: string, error = "rejected") => JSON.stringify({ code, error });
 
@@ -413,6 +414,84 @@ describe("resolveAndSubmitP2pDelegation", () => {
     }
     // Exactly one broadcast — the payment is never re-built on a poll failure.
     expect(params.buildP2pPayment).toHaveBeenCalledTimes(1);
+  });
+
+  it("records a settled-unretrieved payment and refuses the NEXT hire of the same worker+capability BEFORE broadcast (#435/#436)", async () => {
+    const ledger = new PaidIntentLedger();
+    const fetchStub = routedFetch({
+      discover: discoverOk([
+        { motebit_id: "bob", settlement_address: "BobAddr", settlement_modes: "p2p,relay" },
+      ]),
+      listing: listingOk([{ capability: "web_search", unit_cost: 0.5 }]),
+      submit: () => jsonResponse(200, { task_id: "task-paid" }),
+      poll: () => jsonResponse(503, ""),
+    });
+    vi.stubGlobal("fetch", fetchStub);
+
+    // Hire 1: payment settles, result delivery fails — the #433 shape.
+    vi.useFakeTimers();
+    const first = resolveAndSubmitP2pDelegation(
+      resolveParams({ timeoutMs: 1, paidIntentLedger: ledger }),
+    );
+    await vi.advanceTimersByTimeAsync(5000);
+    const firstResult = await first;
+    vi.useRealTimers();
+    expect(firstResult.ok).toBe(false);
+    expect(ledger.outstandingCount).toBe(1);
+
+    // Hire 2 (the model's retry): refused mechanically, before any broadcast —
+    // regardless of what the model concluded from the first failure message.
+    const second = resolveParams({ paidIntentLedger: ledger });
+    const secondResult = await resolveAndSubmitP2pDelegation(second);
+    expect(secondResult.ok).toBe(false);
+    if (!secondResult.ok) {
+      expect(secondResult.error.code).toBe("intent_already_paid");
+      // The refusal carries the PRIOR payment's facts — re-fetch, never re-pay.
+      expect(secondResult.error.settledPayment?.taskId).toBe("task-paid");
+      expect(secondResult.error.settledPayment?.txHash).toBe("p2p-tx");
+    }
+    // The interlock fired before the payment was even built.
+    expect(second.buildP2pPayment).not.toHaveBeenCalled();
+  });
+
+  it(`suspends ALL paid delegation once ${SESSION_SUSPEND_THRESHOLD} payments are settled-unretrieved`, async () => {
+    const ledger = new PaidIntentLedger();
+    ledger.recordSettledUnretrieved({
+      workerMotebitId: "worker-x",
+      capability: "translate",
+      taskId: "task-x",
+      txHash: "tx-x",
+      paidMicro: 100_000,
+      feeMicro: 5_000,
+      recordedAt: 1,
+    });
+    ledger.recordSettledUnretrieved({
+      workerMotebitId: "worker-y",
+      capability: "code_review",
+      taskId: "task-y",
+      txHash: "tx-y",
+      paidMicro: 100_000,
+      feeMicro: 5_000,
+      recordedAt: 2,
+    });
+    // A THIRD worker, never hired before — still refused: money is leaking.
+    vi.stubGlobal(
+      "fetch",
+      routedFetch({
+        discover: discoverOk([
+          { motebit_id: "bob", settlement_address: "BobAddr", settlement_modes: "p2p,relay" },
+        ]),
+        listing: listingOk([{ capability: "web_search", unit_cost: 0.5 }]),
+      }),
+    );
+    const params = resolveParams({ paidIntentLedger: ledger });
+    const result = await resolveAndSubmitP2pDelegation(params);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("intent_already_paid");
+      expect(result.error.message).toContain("suspended");
+    }
+    expect(params.buildP2pPayment).not.toHaveBeenCalled();
   });
 
   it("leaves settledPayment ABSENT when the failure precedes any broadcast (#433)", async () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -332,6 +332,14 @@ export type {
   DelegationError,
   DelegationErrorCode,
 } from "./relay-delegation.js";
+// The session paid-intent interlock (#435/#436) — enforced inside the shared
+// submit chokepoint; exported for surfaces/tests that render or probe it.
+export {
+  PaidIntentLedger,
+  SESSION_SUSPEND_THRESHOLD,
+  type UnretrievedPayment,
+  type PaidIntentVerdict,
+} from "./paid-intent-ledger.js";
 // The deterministic surface-affordance entry point (chip tap / button →
 // invokeCapability). Exported so an integration test can drive the REAL entry
 // point against a live relay — the layer above selectAndRunDelegation, where

--- a/packages/runtime/src/interactive-delegation.ts
+++ b/packages/runtime/src/interactive-delegation.ts
@@ -98,6 +98,15 @@ export interface InteractiveDelegationConfig {
    * rail seam are the cryptographic gates.
    */
   getActiveGrantId?: () => string | null;
+  /**
+   * The runtime's session paid-intent ledger — the mechanical interlock
+   * that refuses a duplicate paid delegation BEFORE broadcast while a
+   * prior payment is settled-but-unretrieved (#435/#436). Bound by the
+   * runtime at enable time; the enforcement itself lives in the shared
+   * submit chokepoint so this path and `executeGrantedDelegation` cannot
+   * diverge.
+   */
+  paidIntentLedger?: import("./paid-intent-ledger.js").PaidIntentLedger;
 }
 
 // === Manager ===
@@ -269,6 +278,7 @@ export class InteractiveDelegationManager {
           ...(ack === true ? { acknowledgeNoHistoryRisk: true } : {}),
           ...(config.routingStrategy ? { routingStrategy: config.routingStrategy } : {}),
           ...(grantId != null ? { grantId } : {}),
+          ...(config.paidIntentLedger != null ? { paidIntentLedger: config.paidIntentLedger } : {}),
           invocationOrigin: "ai-loop",
           ...(timeoutMs != null ? { timeoutMs } : {}),
           logger,
@@ -281,6 +291,24 @@ export class InteractiveDelegationManager {
           // real-money charge (#433): the model reads "timeout", concludes the
           // hire didn't happen, and delegates again. Name the money.
           const settled = result.error.settledPayment;
+          // The interlock refused BEFORE broadcast: no NEW money moved — the
+          // settledPayment here is the PRIOR task's. Distinct wording from
+          // PAYMENT_ALREADY_SETTLED so the model cannot read this refusal as
+          // "this call paid" (it didn't) or as a retryable failure (it isn't).
+          if (result.error.code === "intent_already_paid" && settled) {
+            return {
+              ok: false,
+              error:
+                `INTENT_ALREADY_PAID — refused BEFORE broadcasting; no new money moved. ` +
+                `An earlier payment already settled onchain for this work: ` +
+                `${(settled.paidMicro / 1_000_000).toFixed(4)} USDC (+ ` +
+                `${(settled.feeMicro / 1_000_000).toFixed(4)} fee), tx ${settled.txHash}, ` +
+                `task ${settled.taskId} — and its result was never retrieved. ` +
+                `${result.error.message} ` +
+                `Do NOT re-delegate. Tell the user work was already paid for and its result ` +
+                `is outstanding, and let them decide.`,
+            };
+          }
           if (settled) {
             return {
               ok: false,

--- a/packages/runtime/src/money-meter.ts
+++ b/packages/runtime/src/money-meter.ts
@@ -48,10 +48,26 @@ export type MoneyMeter = (
 
 export function createMoneyMeter(
   store: GrantSpendStore,
-  options?: { now?: () => number },
+  options?: {
+    now?: () => number;
+    /** When set, a VOLATILE (in-memory) store warns once at first metered spend. */
+    logger?: { warn(message: string, context?: Record<string, unknown>): void };
+  },
 ): MoneyMeter {
   const now = options?.now ?? Date.now;
+  let warnedVolatile = false;
   return async (verifiedGrant, _toolName, args) => {
+    // Durability honesty (#436): metering REAL money against an accumulator
+    // that resets on restart means the lifetime ceiling silently re-arms.
+    // Warn once, at the moment it matters (first metered spend), not at
+    // construction — most runtimes never move money.
+    if (!warnedVolatile && options?.logger != null && (store as { volatile?: boolean }).volatile) {
+      warnedVolatile = true;
+      options.logger.warn("money_meter.volatile_spend_store", {
+        detail:
+          "grant lifetime ceiling is metered in-memory and re-arms on restart — inject the persistent SqliteGrantSpendStore (@motebit/persistence) for live money",
+      });
+    }
     const ceiling = spendCeilingFromGrant(verifiedGrant);
     if (ceiling == null) return { allowed: false, denial: "ceiling_absent" };
 

--- a/packages/runtime/src/motebit-runtime.ts
+++ b/packages/runtime/src/motebit-runtime.ts
@@ -229,6 +229,7 @@ import {
   InMemoryGrantSpendStore,
 } from "@motebit/policy";
 import { createMoneyMeter, wrapP2pPaymentWithMeter, type MoneyMeter } from "./money-meter.js";
+import { PaidIntentLedger } from "./paid-intent-ledger.js";
 import { verifyGrantForTurn } from "./grant-verifier.js";
 import {
   resolveAndSubmitP2pDelegation,
@@ -481,6 +482,14 @@ export class MotebitRuntime {
   policy: PolicyGate;
   /** R4 money meter (AND-composition enforcer half) — see money-meter.ts. */
   private moneyMeter: MoneyMeter;
+  /**
+   * Session paid-intent interlock (#435/#436): while a paid delegation's
+   * payment has settled onchain without delivering a result, a duplicate
+   * hire refuses BEFORE broadcast — mechanically, on both the loop path
+   * and the granted deterministic path. One instance per runtime = one
+   * session scope; a restart clears it deliberately.
+   */
+  private readonly _paidIntentLedger = new PaidIntentLedger();
   /**
    * The current turn's verified standing authority (null between turns
    * and on grantless turns). Set only from `verifyGrantForTurn`'s output
@@ -890,7 +899,12 @@ export class MotebitRuntime {
     // is ALWAYS metered; the in-memory default resets on restart (see
     // RuntimeConfig.grantSpendStore — live-money deployments inject the
     // persistent SqliteGrantSpendStore).
-    this.moneyMeter = createMoneyMeter(config.grantSpendStore ?? new InMemoryGrantSpendStore());
+    this.moneyMeter = createMoneyMeter(config.grantSpendStore ?? new InMemoryGrantSpendStore(), {
+      // #436 finding 6: an omitted grantSpendStore silently re-arms the
+      // lifetime ceiling on restart. The meter warns at the first REAL
+      // metered spend (not at construction — most runtimes never move money).
+      logger: this._logger,
+    });
 
     // Restore saved state
     if (this.stateSnapshot) {
@@ -4815,6 +4829,7 @@ export class MotebitRuntime {
       ...config,
       ...(buildP2pPayment ? { buildP2pPayment } : {}),
       getActiveGrantId: () => this._activeTurnGrant?.grant_id ?? null,
+      paidIntentLedger: this._paidIntentLedger,
     });
     // Stash the relay coordinates the deterministic granted-spend path needs
     // (executeGrantedDelegation) — only when a pinned relay key is present, as
@@ -5093,6 +5108,7 @@ export class MotebitRuntime {
         ...(params.targetWorkerId != null ? { targetWorkerId: params.targetWorkerId } : {}),
         ...(selectWorker != null ? { selectWorker } : {}),
         ...(ack === true ? { acknowledgeNoHistoryRisk: true } : {}),
+        paidIntentLedger: this._paidIntentLedger,
         logger: this._logger,
       });
       if (!result.ok) {
@@ -5111,8 +5127,28 @@ export class MotebitRuntime {
           ...(result.error.code !== "money_meter_denied" && "message" in result.error
             ? { message: result.error.message }
             : {}),
+          // The money fact must survive into the log: a paid-but-undelivered
+          // hire is categorically different from never-hired (#436 finding 1).
+          ...(result.error.settledPayment != null
+            ? {
+                settled_tx: result.error.settledPayment.txHash,
+                settled_task: result.error.settledPayment.taskId,
+                settled_paid_micro: result.error.settledPayment.paidMicro,
+              }
+            : {}),
         });
-        return { ok: false, code };
+        // ...and into the RESULT: without this, the human-absent caller reads
+        // a bare failure code, concludes never-hired, and re-delegates — the
+        // #433 double-pay, unprotected by any human prompt. The paid-intent
+        // interlock refuses the re-broadcast; this field makes the refusal
+        // legible and the money fact actionable (re-fetch, never re-hire).
+        return {
+          ok: false,
+          code,
+          ...(result.error.settledPayment != null
+            ? { settledPayment: result.error.settledPayment }
+            : {}),
+        };
       }
       // Accumulate first-person trust in the worker we just hired — the write
       // side of first-person routing, without which the selector above reads a

--- a/packages/runtime/src/paid-intent-ledger.ts
+++ b/packages/runtime/src/paid-intent-ledger.ts
@@ -1,0 +1,108 @@
+/**
+ * Paid-intent ledger — the runtime interlock that makes "never pay twice
+ * for the same job" structural instead of a prompt convention (#435, made
+ * mandatory by the #436 audit).
+ *
+ * #434 taught the MODEL that a post-broadcast poll failure means money
+ * already moved (`PAYMENT_ALREADY_SETTLED`). But the last line of defense
+ * was still the model reading that message correctly — and on the
+ * standing-grant auto-execute path there is no human between a retry loop
+ * and real money at all. This ledger is the mechanical stop: while a paid
+ * delegation's payment has SETTLED onchain but its result was never
+ * retrieved, any NEW paid delegation to the same worker + capability is
+ * refused BEFORE broadcast (`intent_already_paid`, fail-closed). Two or
+ * more outstanding unretrieved payments suspend ALL new paid delegation
+ * for the session — money is leaking; stop the bleeding.
+ *
+ * Scope and honesty:
+ * - Session-scoped (one runtime instance = one ledger). A restart clears
+ *   it — the retry loop it guards against is a session phenomenon, and a
+ *   human restarting has seen the refusal message with the prior taskId.
+ * - Keyed on (worker motebit_id, capability) — the observed #433 shape is
+ *   "same job, same worker, re-hired". A different worker for one
+ *   outstanding payment is legitimate fan-out and passes; the session
+ *   threshold bounds the pathological case.
+ * - Recorded ONLY from a `settledPayment` fact (the money independently
+ *   verified as moved), never from an intent or a prompt. No unverified
+ *   state can lock anything.
+ * - Enforced INSIDE the shared submit chokepoint
+ *   (`resolveAndSubmitP2pDelegation`), so the interactive loop path and
+ *   the granted deterministic path cannot diverge
+ *   (docs/doctrine/composition-preserves-enforcement.md).
+ */
+
+/** A payment that settled onchain whose result was never delivered. */
+export interface UnretrievedPayment {
+  workerMotebitId: string;
+  capability: string;
+  /** The relay task the payment bought — the handle to re-fetch, never re-pay. */
+  taskId: string;
+  txHash: string;
+  paidMicro: number;
+  feeMicro: number;
+  recordedAt: number;
+}
+
+export type PaidIntentVerdict =
+  | { locked: false }
+  | {
+      locked: true;
+      /** `pair` = this worker+capability already has settled-unretrieved money;
+       *  `session` = too many outstanding payments — all paid delegation suspended. */
+      scope: "pair" | "session";
+      prior: UnretrievedPayment;
+    };
+
+/**
+ * Outstanding-payment count at which ALL new paid delegation is refused
+ * for the session, regardless of worker. One unretrieved payment can be a
+ * transient delivery blip; two concurrent ones is a failure loop.
+ */
+export const SESSION_SUSPEND_THRESHOLD = 2;
+
+export class PaidIntentLedger {
+  private readonly entries = new Map<string, UnretrievedPayment>();
+
+  private key(workerMotebitId: string, capability: string): string {
+    return `${workerMotebitId}::${capability}`;
+  }
+
+  /** Record a settled-but-unretrieved payment (from a `settledPayment` fact). */
+  recordSettledUnretrieved(entry: UnretrievedPayment): void {
+    this.entries.set(this.key(entry.workerMotebitId, entry.capability), entry);
+  }
+
+  /**
+   * May a NEW paid delegation to this worker+capability broadcast?
+   * Fail-closed: any lock verdict must refuse before money moves.
+   */
+  check(workerMotebitId: string, capability: string): PaidIntentVerdict {
+    const pair = this.entries.get(this.key(workerMotebitId, capability));
+    if (pair != null) return { locked: true, scope: "pair", prior: pair };
+    if (this.entries.size >= SESSION_SUSPEND_THRESHOLD) {
+      const oldest = [...this.entries.values()].sort((a, b) => a.recordedAt - b.recordedAt)[0]!;
+      return { locked: true, scope: "session", prior: oldest };
+    }
+    return { locked: false };
+  }
+
+  /** Resolve one entry — its result was finally retrieved (or a human cleared it). */
+  resolve(taskId: string): boolean {
+    for (const [key, entry] of this.entries) {
+      if (entry.taskId === taskId) {
+        this.entries.delete(key);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  get outstandingCount(): number {
+    return this.entries.size;
+  }
+
+  /** The outstanding entries, oldest first — for owner-facing rendering. */
+  outstanding(): UnretrievedPayment[] {
+    return [...this.entries.values()].sort((a, b) => a.recordedAt - b.recordedAt);
+  }
+}

--- a/packages/runtime/src/relay-delegation.ts
+++ b/packages/runtime/src/relay-delegation.ts
@@ -25,6 +25,7 @@ import {
   PLATFORM_FEE_RATE,
 } from "@motebit/protocol";
 import { verifySovereignBinding } from "@motebit/crypto";
+import type { PaidIntentLedger } from "./paid-intent-ledger.js";
 
 /**
  * The DERIVED settlement-authority binding, inlined here to keep the
@@ -122,6 +123,19 @@ export type DelegationErrorCode =
    * has no meter and cannot produce this.
    */
   | "money_meter_denied"
+  /**
+   * Pre-flight, BEFORE broadcast. The session's paid-intent ledger holds a
+   * SETTLED-but-unretrieved payment that this new delegation would duplicate
+   * (same worker + capability, or too many outstanding payments session-wide).
+   * NO new money moved — the refusal happened before the payment was built.
+   * The prior payment's facts ride in `settledPayment`; the remedy is
+   * re-fetching that `taskId` (or restarting the session after review),
+   * never re-hiring. The mechanical half of the #433 fix: #434 told the
+   * model money moved; this refuses the broadcast even if the model
+   * misreads it (docs/doctrine/memory-never-confers-authority.md posture —
+   * money safety must not end at model compliance).
+   */
+  | "intent_already_paid"
   /** Pre-flight. Trust below the capability's threshold. */
   | "trust_threshold_unmet"
   /** Pre-flight. No agent advertises the capability. */
@@ -234,7 +248,18 @@ export type GrantedDelegationResult =
        */
       routingTranscript?: import("@motebit/protocol").RoutingDecisionTranscript;
     }
-  | { ok: false; code: string };
+  | {
+      ok: false;
+      code: string;
+      /**
+       * Set ONLY when the delegator's onchain payment ALREADY SETTLED but
+       * the result could not be retrieved. Same #433 contract as
+       * `DelegationError.settledPayment` — without it, the human-absent
+       * granted path flattened a paid-but-undelivered hire into a bare
+       * failure code, indistinguishable from never-hired (#436 finding 1).
+       */
+      settledPayment?: DelegationError["settledPayment"];
+    };
 
 export interface SubmitAndPollParams {
   /** This motebit's identity (the submitter/owner of the task). */
@@ -802,6 +827,15 @@ export type WorkerSelector = (
 export interface ResolveAndSubmitP2pDelegationParams {
   /** Standing-grant id (advisory; engages the relay revocation fence). */
   grantId?: string;
+  /**
+   * The session's paid-intent ledger. When present, a settled-but-
+   * unretrieved prior payment refuses a duplicate delegation BEFORE
+   * broadcast (`intent_already_paid`), and a new settled-unretrieved
+   * failure is recorded. The runtime passes its instance on every paid
+   * path (loop + granted) — enforcement lives HERE, in the shared
+   * chokepoint, so the two paths cannot diverge.
+   */
+  paidIntentLedger?: PaidIntentLedger;
   /** The delegator's identity (submitter / owner of the task). */
   motebitId: string;
   /** Base URL of the relay. */
@@ -1278,6 +1312,40 @@ export async function resolveAndSubmitP2pDelegation(
   });
   if (!resolved.ok) return { ok: false, error: resolved.error };
 
+  // 3a-bis. Paid-intent interlock — BEFORE any broadcast. If a prior payment
+  //         to this worker+capability settled onchain and its result was never
+  //         retrieved, a new delegation would buy the same work twice; refuse
+  //         mechanically instead of trusting the caller to have read the
+  //         PAYMENT_ALREADY_SETTLED message (#435/#436 — on the granted path
+  //         there is no human between a retry loop and real money).
+  if (params.paidIntentLedger != null) {
+    const verdict = params.paidIntentLedger.check(resolved.workerMotebitId, params.capability);
+    if (verdict.locked) {
+      const prior = verdict.prior;
+      return {
+        ok: false,
+        error: {
+          code: "intent_already_paid",
+          message:
+            verdict.scope === "pair"
+              ? `A payment to this worker for "${prior.capability}" already settled onchain ` +
+                `(tx ${prior.txHash}) and its result was never retrieved (task ${prior.taskId}). ` +
+                `Refused before broadcast — no new money moved. Re-fetch that task; do not re-hire.`
+              : `${params.paidIntentLedger.outstandingCount} paid delegations have settled onchain ` +
+                `without delivering results — all new paid delegation is suspended for this session. ` +
+                `Refused before broadcast — no new money moved. Oldest unretrieved: task ${prior.taskId} ` +
+                `(tx ${prior.txHash}).`,
+          settledPayment: {
+            txHash: prior.txHash,
+            paidMicro: prior.paidMicro,
+            feeMicro: prior.feeMicro,
+            taskId: prior.taskId,
+          },
+        },
+      };
+    }
+  }
+
   // 3b. Budget ceiling — enforced on the RESOLVED total (worker + all fee
   //     legs), before any irreversible broadcast. The relay's price is the
   //     truth being checked, so client-side listing math can't under-guard.
@@ -1325,7 +1393,7 @@ export async function resolveAndSubmitP2pDelegation(
   }
 
   // 5. Submit the pre-built proof (retry-safe; never re-broadcasts).
-  return submitP2pDelegation({
+  const submitted = await submitP2pDelegation({
     motebitId: params.motebitId,
     syncUrl: params.syncUrl,
     authToken: params.authToken,
@@ -1342,6 +1410,24 @@ export async function resolveAndSubmitP2pDelegation(
     logger: params.logger,
     ...(params.signal ? { signal: params.signal } : {}),
   });
+
+  // 6. Ledger write — a settled-but-unretrieved payment arms the interlock so
+  //    the NEXT delegation to this worker+capability refuses pre-broadcast.
+  //    Recorded only from the settledPayment fact (money verifiably moved),
+  //    never from an intent.
+  if (params.paidIntentLedger != null && !submitted.ok && submitted.error.settledPayment != null) {
+    const sp = submitted.error.settledPayment;
+    params.paidIntentLedger.recordSettledUnretrieved({
+      workerMotebitId: resolved.workerMotebitId,
+      capability: params.capability,
+      taskId: sp.taskId,
+      txHash: sp.txHash,
+      paidMicro: sp.paidMicro,
+      feeMicro: sp.feeMicro,
+      recordedAt: Date.now(),
+    });
+  }
+  return submitted;
 }
 
 export interface SelectDelegationParams {
@@ -1351,6 +1437,8 @@ export interface SelectDelegationParams {
    * the enforcement). Threaded to BOTH submit paths.
    */
   grantId?: string;
+  /** Session paid-intent ledger — threaded to the P2P path's interlock. */
+  paidIntentLedger?: PaidIntentLedger;
   /** The delegator's identity (submitter / owner of the task). */
   motebitId: string;
   /** Base URL of the relay. */
@@ -1461,6 +1549,7 @@ export async function selectAndRunDelegation(
       ...(params.acknowledgeNoHistoryRisk === true ? { acknowledgeNoHistoryRisk: true } : {}),
       ...(params.invocationOrigin ? { invocationOrigin: params.invocationOrigin } : {}),
       ...(params.grantId != null ? { grantId: params.grantId } : {}),
+      ...(params.paidIntentLedger != null ? { paidIntentLedger: params.paidIntentLedger } : {}),
       ...(params.timeoutMs != null ? { timeoutMs: params.timeoutMs } : {}),
       logger: params.logger,
       ...(params.signal ? { signal: params.signal } : {}),


### PR DESCRIPTION
Closes #435. Closes #436.

## The audit (#436)

Mapped the standing-grant auto-execute path against the #433 failure shape. Confirmed: every #434 mitigation is structurally unreachable there (no approval prompt ⇒ no denial ledger, no terminal refusal, nothing to suppress); `executeGrantedDelegation` flattened `settledPayment` into a bare code (the #433 shape verbatim, untested, human-absent); the only real double-spend brake was the tick-nonce replay gate — incidental, and blind to a next-slot re-hire; headroom was computed then discarded at the meter boundary, observable nowhere before the ceiling denial; the in-memory spend-store fallback silently re-arms the lifetime ceiling on restart.

## The fixes

1. **`PaidIntentLedger`** (#435's unretrieved-payment lock, made mandatory everywhere): session-scoped, seeded ONLY by verified settled-payment facts. One outstanding settled-unretrieved payment locks its worker+capability pair; two suspend ALL paid delegation. Typed `intent_already_paid`, fail-closed, refused BEFORE the payment is built, carrying the prior task+tx. Enforced inside `resolveAndSubmitP2pDelegation` — the shared chokepoint — so the loop path and the granted path cannot diverge (composition-preserves-enforcement).
2. **`settledPayment` propagation on the granted path** — paid-but-undelivered is no longer byte-identical to never-hired, in the result and the operator log.
3. **Owner legibility**: `grant show`/`list` render lifetime spent + remaining from the durable spend store (`GrantSpendStore.peek` promoted to the interface); the session-start preflight gains a headroom check and refuses arming on an exhausted ceiling.
4. **Durability honesty**: metering real money against the volatile in-memory store warns once that the lifetime ceiling re-arms on restart.

Deliberately unchanged: the tick-nonce replay gate, `maxCallsPerTurn`, and the consecutive-same-tool brake — the interlock now stops the money shape those were never built for.

## Proof

- The headline test replays the live incident on the human-absent path: payment settles, delivery fails, the retry arrives with a fresh tick the meter would admit — refused, with exactly one broadcast across both attempts and `buildP2pPayment` never called on the re-hire.
- 9 ledger unit tests; interlock refusal at both entry points; granted-path `settledPayment` propagation (previously uncovered); 1244 runtime / 482 policy / 195 persistence / 298 CLI tests green; `check-money-authority` + `check-ceiling-from-grant` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)