### PR TITLE
feat(cli): motebit keychain — opt-in passphrase enrollment in the macOS login Keychain

### DIFF
--- a/.changeset/keychain-enrollment.md
+++ b/.changeset/keychain-enrollment.md
@@ -1,0 +1,9 @@
+---
+"motebit": minor
+---
+
+`motebit keychain enroll` — opt-in passphrase enrollment in the macOS login Keychain (the third leg of the recovery arc: "remember a passphrase" stops being a single point of identity loss, with zero operator involvement).
+
+Once enrolled, commands unlock silently: the resolution chain is `MOTEBIT_PASSPHRASE` → session cache → enrolled keychain (validated against the encrypted key; a stale enrollment falls through to the prompt with a re-enroll hint, never a lockout) → interactive prompt. `motebit keychain` shows status; `motebit keychain remove` undoes it.
+
+Honest by design: the item is protected by your macOS account, not biometrics (v1 uses `/usr/bin/security` — no native modules, no gyp builds); any process running as your user can read it, which is why enrollment is opt-in and never a default; it does not replace the recovery seed (keychain and disk die with the machine — the seed nudge stays until a backup is acknowledged); and `motebit seed reveal` always asks interactively, enrolled or not. Other platforms report unsupported honestly.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -72,6 +72,9 @@ motebit verify motebit.md            # Verify an identity file signature
 motebit rotate --reason "scheduled"  # Rotate keypair with succession chain
 motebit seed                         # Recovery-seed backup status
 motebit seed reveal                  # Print the seed once (passphrase-gated) for paper
+motebit keychain enroll              # Opt-in: store the passphrase in the macOS login
+                                     #   Keychain (your macOS account is the protection —
+                                     #   not biometrics; never replaces the seed backup)
 motebit restore [motebit.md]         # Recover an identity — full-bundle from a motebit.md,
                                      #   or seed-only (re-derives a sovereign id); also
                                      #   resets a forgotten passphrase when the seed

--- a/apps/cli/etc/cli-surface.json
+++ b/apps/cli/etc/cli-surface.json
@@ -32,6 +32,7 @@
     "grant": [],
     "id": [],
     "init": [],
+    "keychain": [],
     "ledger": [],
     "logs": [],
     "lsp": [],

--- a/apps/cli/src/__tests__/keychain-enrollment.test.ts
+++ b/apps/cli/src/__tests__/keychain-enrollment.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Keychain adapter (#438): never touches a real keychain — the exec seam
+ * is injected. Platform honesty and fail-open-to-prompt are the contract.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  isKeychainSupported,
+  readKeychainPassphrase,
+  writeKeychainPassphrase,
+  deleteKeychainPassphrase,
+  keychainEnrollmentStatus,
+  type RunSecurity,
+} from "../keychain.js";
+
+describe("keychain adapter (injected exec — no real keychain)", () => {
+  it("unsupported off macOS: every operation is an honest no-op", () => {
+    expect(isKeychainSupported("linux")).toBe(false);
+    const run: RunSecurity = () => {
+      throw new Error("must not be called");
+    };
+    expect(readKeychainPassphrase("id", run, "linux")).toBeNull();
+    expect(writeKeychainPassphrase("id", "pw", run, "linux")).toBe(false);
+    expect(deleteKeychainPassphrase("id", run, "linux")).toBe(false);
+    expect(keychainEnrollmentStatus("id", run, "linux")).toBe("unsupported");
+  });
+
+  it("read: strips the trailing newline `security -w` emits", () => {
+    const run: RunSecurity = (args) => {
+      expect(args).toContain("find-generic-password");
+      expect(args).toContain("motebit-cli");
+      return { status: 0, stdout: "hunter2\n" };
+    };
+    expect(readKeychainPassphrase("mid-1", run, "darwin")).toBe("hunter2");
+  });
+
+  it("read: non-zero exit (item absent, keychain locked) → null, never a throw", () => {
+    const run: RunSecurity = () => ({ status: 44, stdout: "" });
+    expect(readKeychainPassphrase("mid-1", run, "darwin")).toBeNull();
+    expect(keychainEnrollmentStatus("mid-1", run, "darwin")).toBe("not_enrolled");
+  });
+
+  it("read: exec throwing → null (fail-open to the interactive prompt)", () => {
+    const run: RunSecurity = () => {
+      throw new Error("spawn failed");
+    };
+    expect(readKeychainPassphrase("mid-1", run, "darwin")).toBeNull();
+  });
+
+  it("write uses -U (update in place) and the account it was given", () => {
+    let seen: string[] = [];
+    const run: RunSecurity = (args) => {
+      seen = args;
+      return { status: 0, stdout: "" };
+    };
+    expect(writeKeychainPassphrase("mid-1", "pw", run, "darwin")).toBe(true);
+    expect(seen).toContain("-U");
+    expect(seen).toContain("mid-1");
+  });
+
+  it("enrolled status when a value reads back", () => {
+    const run: RunSecurity = () => ({ status: 0, stdout: "pw\n" });
+    expect(keychainEnrollmentStatus("mid-1", run, "darwin")).toBe("enrolled");
+  });
+});

--- a/apps/cli/src/__tests__/resolve-unlock-chain.test.ts
+++ b/apps/cli/src/__tests__/resolve-unlock-chain.test.ts
@@ -1,0 +1,126 @@
+/**
+ * The unlock-passphrase resolution chain (#438): env → session cache →
+ * enrolled keychain (validated) → interactive prompt. The keychain module
+ * is mocked wholesale; MOTEBIT_CONFIG_DIR is pinned BEFORE any import so
+ * the config module can never bind to a real ~/.motebit.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Pin the config dir before identity.js (→ config.js) can load — CONFIG_DIR
+// is computed at module load, so this MUST precede the dynamic imports.
+const tmpRoot = mkdtempSync(join(tmpdir(), "motebit-unlock-chain-test-"));
+process.env["MOTEBIT_CONFIG_DIR"] = tmpRoot;
+
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+
+vi.mock("../keychain.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../keychain.js")>();
+  return { ...original, readKeychainPassphrase: vi.fn(() => null) };
+});
+
+const { readKeychainPassphrase: mockedRead } = await import("../keychain.js");
+const {
+  encryptPrivateKey,
+  resolveUnlockPassphrase,
+  clearSessionPassphrase,
+  resetKeychainResolutionForTest,
+  rememberSessionPassphrase,
+} = await import("../identity.js");
+
+const PRIV_HEX = "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60";
+const savedEnv = process.env["MOTEBIT_PASSPHRASE"];
+
+describe("resolveUnlockPassphrase chain (env → session → keychain → prompt)", () => {
+  beforeEach(() => {
+    writeFileSync(
+      join(tmpRoot, "config.json"),
+      JSON.stringify({ motebit_id: "mid-test" }),
+      "utf-8",
+    );
+    delete process.env["MOTEBIT_PASSPHRASE"];
+    clearSessionPassphrase();
+    resetKeychainResolutionForTest();
+    vi.mocked(mockedRead).mockReset().mockReturnValue(null);
+  });
+
+  afterAll(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+    delete process.env["MOTEBIT_CONFIG_DIR"];
+    if (savedEnv == null) delete process.env["MOTEBIT_PASSPHRASE"];
+    else process.env["MOTEBIT_PASSPHRASE"] = savedEnv;
+    clearSessionPassphrase();
+    resetKeychainResolutionForTest();
+  });
+
+  it("env wins over an enrolled keychain", async () => {
+    process.env["MOTEBIT_PASSPHRASE"] = "from-env";
+    vi.mocked(mockedRead).mockReturnValue("from-keychain");
+    expect(await resolveUnlockPassphrase("p: ")).toBe("from-env");
+    expect(mockedRead).not.toHaveBeenCalled();
+  });
+
+  it("session cache wins over the keychain (one read per invocation)", async () => {
+    rememberSessionPassphrase("from-session");
+    vi.mocked(mockedRead).mockReturnValue("from-keychain");
+    expect(await resolveUnlockPassphrase("p: ")).toBe("from-session");
+    expect(mockedRead).not.toHaveBeenCalled();
+  });
+
+  it("an enrolled keychain resolves without a prompt, keyed on this identity's motebit_id", async () => {
+    vi.mocked(mockedRead).mockReturnValue("from-keychain");
+    expect(await resolveUnlockPassphrase("p: ")).toBe("from-keychain");
+    expect(mockedRead).toHaveBeenCalledWith("mid-test");
+  });
+
+  it("a VALID enrolled passphrase passes encryptedKey validation and seeds the session", async () => {
+    const enc = await encryptPrivateKey(PRIV_HEX, "correct-pw");
+    clearSessionPassphrase(); // encrypt seeded it — isolate the keychain leg
+    vi.mocked(mockedRead).mockReturnValue("correct-pw");
+    expect(await resolveUnlockPassphrase("p: ", { encryptedKey: enc })).toBe("correct-pw");
+    // The validating decrypt seeded the session — the next unlock is silent
+    // without another keychain read.
+    vi.mocked(mockedRead).mockClear();
+    expect(await resolveUnlockPassphrase("p: ")).toBe("correct-pw");
+    expect(mockedRead).not.toHaveBeenCalled();
+  });
+
+  it("a STALE enrolled passphrase falls through to the prompt — and is never consulted again this process", async () => {
+    const enc = await encryptPrivateKey(PRIV_HEX, "new-pw");
+    clearSessionPassphrase();
+    vi.mocked(mockedRead).mockReturnValue("old-stale-pw");
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const prompted = vi.fn(async () => "typed-pw");
+    const resolved = await resolveUnlockPassphrase("p: ", {
+      encryptedKey: enc,
+      promptOverrideForTest: prompted,
+    });
+    // Stale value refused; the user was asked instead of hard-failed.
+    expect(resolved).toBe("typed-pw");
+    expect(prompted).toHaveBeenCalledTimes(1);
+    // The stale-keychain note taught the remedy (assert BEFORE restore —
+    // mockRestore clears call history).
+    expect(errSpy.mock.calls.flat().join(" ")).toContain("keychain entry is stale");
+    errSpy.mockRestore();
+    // The keychain is disabled for the rest of the process: a later resolve
+    // (session empty) goes STRAIGHT to the prompt without a keychain read.
+    clearSessionPassphrase();
+    vi.mocked(mockedRead).mockClear();
+    const prompted2 = vi.fn(async () => "typed-again");
+    expect(await resolveUnlockPassphrase("p: ", { promptOverrideForTest: prompted2 })).toBe(
+      "typed-again",
+    );
+    expect(mockedRead).not.toHaveBeenCalled();
+  });
+
+  it("no identity in config ⇒ keychain leg is skipped entirely", async () => {
+    writeFileSync(join(tmpRoot, "config.json"), JSON.stringify({}), "utf-8");
+    vi.mocked(mockedRead).mockReturnValue("from-keychain");
+    const prompted = vi.fn(async () => "typed-pw");
+    expect(await resolveUnlockPassphrase("p: ", { promptOverrideForTest: prompted })).toBe(
+      "typed-pw",
+    );
+    expect(mockedRead).not.toHaveBeenCalled();
+  });
+});

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -418,6 +418,9 @@ Commands:
   doctor                    Check system readiness (Node, SQLite, config)
   seed [reveal]             Recovery-seed backup status; reveal prints it once
                             (passphrase-gated) for transcription to paper
+  keychain [enroll|remove]  Store the passphrase in the macOS login Keychain
+                            (opt-in; your macOS account is the protection —
+                            not biometrics; never replaces the seed backup)
   restore [motebit.md]      Recover an identity from its recovery seed —
                             with a motebit.md for full-bundle restore, or
                             seed-only (re-derives a sovereign id). Also resets

--- a/apps/cli/src/identity.ts
+++ b/apps/cli/src/identity.ts
@@ -17,7 +17,8 @@ import {
 } from "@motebit/core-identity";
 import type { MotebitDatabase } from "@motebit/persistence";
 import type { FullConfig } from "./config.js";
-import { saveFullConfig } from "./config.js";
+import { saveFullConfig, loadFullConfig } from "./config.js";
+import { readKeychainPassphrase } from "./keychain.js";
 
 export function toHex(bytes: Uint8Array): string {
   return Array.from(bytes)
@@ -379,15 +380,93 @@ const DEFAULT_PASSPHRASE_GETTER = async (label: string): Promise<string> => {
   const env = process.env["MOTEBIT_PASSPHRASE"];
   if (env != null && env !== "") {
     lastResolutionFromSession = false;
+    lastResolutionFromKeychain = false;
     return env;
   }
   if (sessionPassphrase != null) {
     lastResolutionFromSession = true;
+    lastResolutionFromKeychain = false;
     return sessionPassphrase;
   }
+  const fromKeychain = tryEnrolledKeychainPassphrase();
+  if (fromKeychain != null) {
+    lastResolutionFromSession = false;
+    lastResolutionFromKeychain = true;
+    return fromKeychain;
+  }
   lastResolutionFromSession = false;
+  lastResolutionFromKeychain = false;
   return promptPassphrase(label);
 };
+
+/**
+ * Keychain leg of the resolution chain (#438): the passphrase enrolled in
+ * the macOS login Keychain, unless a stale read already failed a decrypt
+ * this process (then the keychain is ignored for the rest of the run —
+ * fail-open to the interactive prompt, never a lockout).
+ */
+let keychainDisabledThisProcess = false;
+let lastResolutionFromKeychain = false;
+
+function tryEnrolledKeychainPassphrase(): string | null {
+  if (keychainDisabledThisProcess) return null;
+  try {
+    const motebitId = loadFullConfig().motebit_id;
+    if (motebitId == null || motebitId === "") return null;
+    return readKeychainPassphrase(motebitId);
+  } catch {
+    return null;
+  }
+}
+
+/** Test-only: reset keychain resolution state between cases. */
+export function resetKeychainResolutionForTest(): void {
+  keychainDisabledThisProcess = false;
+  lastResolutionFromKeychain = false;
+}
+
+/** A keychain-sourced passphrase failed to decrypt — stop consulting it this run. */
+function disableKeychainThisProcess(): void {
+  keychainDisabledThisProcess = true;
+  lastResolutionFromKeychain = false;
+  console.error(
+    "  (keychain entry is stale — ignoring it this run; re-enroll with `motebit keychain enroll`)",
+  );
+}
+
+/**
+ * The unlock-passphrase resolution chain for DIRECT prompt sites (export,
+ * attest, rotate, seed, …): env → session cache → enrolled keychain →
+ * interactive prompt. When `encryptedKey` is provided the keychain leg is
+ * VALIDATED here (a stale enrollment falls through to the prompt instead
+ * of surfacing as the caller's "incorrect passphrase" hard-exit — the
+ * user typed nothing, so the failure must not read as their typo).
+ */
+export async function resolveUnlockPassphrase(
+  promptText: string,
+  opts?: {
+    rl?: readline.Interface;
+    encryptedKey?: FullConfig["cli_encrypted_key"];
+    /** Test-only prompt seam — never set in product code. */
+    promptOverrideForTest?: (label: string) => Promise<string>;
+  },
+): Promise<string> {
+  const env = process.env["MOTEBIT_PASSPHRASE"];
+  if (env != null && env !== "") return env;
+  if (sessionPassphrase != null) return sessionPassphrase;
+  const fromKeychain = tryEnrolledKeychainPassphrase();
+  if (fromKeychain != null) {
+    if (opts?.encryptedKey == null) return fromKeychain;
+    try {
+      await decryptPrivateKey(opts.encryptedKey, fromKeychain);
+      return fromKeychain; // validated (and now session-cached by the decrypt)
+    } catch {
+      disableKeychainThisProcess();
+    }
+  }
+  if (opts?.promptOverrideForTest != null) return opts.promptOverrideForTest(promptText);
+  return opts?.rl != null ? promptPassphrase(opts.rl, promptText) : promptPassphrase(promptText);
+}
 
 /**
  * Decrypt the CLI's active Ed25519 signing key from config and verify
@@ -430,7 +509,11 @@ export async function loadActiveSigningKey(
       // Self-heal a stale session cache: if the failed passphrase came
       // from the cache (not env, not a live prompt), the key must have
       // changed since it was proven — drop the cache and ask for real.
-      if (lastResolutionFromSession) {
+      if (lastResolutionFromSession || lastResolutionFromKeychain) {
+        // A cached/enrolled value went stale (key replaced, passphrase
+        // reset) — drop the failing source and resolve for real. Never a
+        // lockout: the retry reaches the interactive prompt.
+        if (lastResolutionFromKeychain) disableKeychainThisProcess();
         clearSessionPassphrase();
         const fresh = await getPassphrase(promptLabel);
         try {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -11,6 +11,7 @@ import type { CliConfig } from "./args.js";
 import { loadFullConfig, extractPersonality, persistMotebitPublicKeys } from "./config.js";
 import {
   promptPassphrase,
+  resolveUnlockPassphrase,
   encryptPrivateKey,
   decryptPrivateKey,
   bootstrapIdentity,
@@ -81,6 +82,7 @@ import {
   handleRestore,
   handleRotate,
   handleSeed,
+  handleKeychain,
   seedBackupStatus,
   handleFederationStatus,
   handleFederationPeers,
@@ -224,6 +226,11 @@ async function main(): Promise<void> {
 
   if (subcommand === "seed") {
     await handleSeed(config);
+    return;
+  }
+
+  if (subcommand === "keychain") {
+    await handleKeychain(config);
     return;
   }
 
@@ -562,7 +569,11 @@ async function main(): Promise<void> {
     let unlocked = false;
     passphrase = "";
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      passphrase = envPassphrase ?? (await promptPassphrase("  Passphrase: "));
+      // env → session → enrolled keychain (validated; stale falls to the
+      // prompt) → interactive. A keychain-enrolled machine unlocks silently.
+      passphrase = await resolveUnlockPassphrase("  Passphrase: ", {
+        encryptedKey: fullConfig.cli_encrypted_key,
+      });
       try {
         await decryptPrivateKey(fullConfig.cli_encrypted_key, passphrase);
         unlocked = true;

--- a/apps/cli/src/keychain.ts
+++ b/apps/cli/src/keychain.ts
@@ -1,0 +1,116 @@
+/**
+ * macOS login-Keychain passphrase enrollment (#438) — the third leg of
+ * the recovery-UX arc (#428): "remember a passphrase" stops being a
+ * single point of identity loss, with zero operator involvement.
+ *
+ * v1 is DELIBERATELY macOS-only via `/usr/bin/security` (the
+ * native-module route — keytar lineage — adds a gyp build to the
+ * published CLI, the exact failure class the README's troubleshooting
+ * section exists for). Other platforms report `unsupported` honestly.
+ *
+ * Honest security framing (load-bearing — repeat it at every surface):
+ * - The item lives in the LOGIN KEYCHAIN, unlocked when the user logs
+ *   in. This is NOT per-use Touch-ID gating (that needs Secure Enclave
+ *   ACLs `/usr/bin/security` cannot create). Never promise biometrics.
+ * - Any process running as the user can read the item (the `security`
+ *   binary is on the item's ACL because it created it). Surface-authority
+ *   decision (#438, recorded in docs/doctrine/surface-authority-model.md):
+ *   ACCEPTED as an OPT-IN convenience — the CLI already trusts the user
+ *   account (config.json, the encrypted key, and the process's memory all
+ *   live under it), but enrollment DOES weaken "passphrase in your head"
+ *   to "passphrase on this machine", so it is never a default.
+ * - Enrollment does NOT replace the recovery seed: keychain + disk die
+ *   with the machine. The seed nudge is structurally independent
+ *   (`seedBackupStatus` never reads enrollment state) and must stay so.
+ *
+ * The passphrase passes to `security` as an argv element — briefly
+ * visible in the process table to the SAME user (and root). That is the
+ * same principal who can read the finished keychain item without a
+ * prompt, so it widens nothing; noted for honesty.
+ */
+
+import { spawnSync } from "node:child_process";
+
+const SERVICE = "motebit-cli";
+
+/** Injectable exec seam so tests never touch a real keychain. */
+export type RunSecurity = (args: string[]) => { status: number | null; stdout: string };
+
+const defaultRunSecurity: RunSecurity = (args) => {
+  const res = spawnSync("/usr/bin/security", args, { encoding: "utf8" });
+  return { status: res.status, stdout: res.stdout ?? "" };
+};
+
+export function isKeychainSupported(platform: NodeJS.Platform = process.platform): boolean {
+  return platform === "darwin";
+}
+
+/** Read the enrolled passphrase; null = not enrolled / locked / any failure (fail-open to prompt). */
+export function readKeychainPassphrase(
+  account: string,
+  run: RunSecurity = defaultRunSecurity,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  if (!isKeychainSupported(platform)) return null;
+  try {
+    const res = run(["find-generic-password", "-s", SERVICE, "-a", account, "-w"]);
+    if (res.status !== 0) return null;
+    // `security -w` prints the secret followed by a newline.
+    const value = res.stdout.replace(/\n$/, "");
+    return value === "" ? null : value;
+  } catch {
+    return null;
+  }
+}
+
+/** Create or update the enrollment item (`-U` = update in place). */
+export function writeKeychainPassphrase(
+  account: string,
+  passphrase: string,
+  run: RunSecurity = defaultRunSecurity,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (!isKeychainSupported(platform)) return false;
+  try {
+    const res = run([
+      "add-generic-password",
+      "-U",
+      "-s",
+      SERVICE,
+      "-a",
+      account,
+      "-l",
+      "motebit identity passphrase",
+      "-w",
+      passphrase,
+    ]);
+    return res.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+export function deleteKeychainPassphrase(
+  account: string,
+  run: RunSecurity = defaultRunSecurity,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (!isKeychainSupported(platform)) return false;
+  try {
+    const res = run(["delete-generic-password", "-s", SERVICE, "-a", account]);
+    return res.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+export type KeychainEnrollment = "enrolled" | "not_enrolled" | "unsupported";
+
+export function keychainEnrollmentStatus(
+  account: string,
+  run: RunSecurity = defaultRunSecurity,
+  platform: NodeJS.Platform = process.platform,
+): KeychainEnrollment {
+  if (!isKeychainSupported(platform)) return "unsupported";
+  return readKeychainPassphrase(account, run, platform) != null ? "enrolled" : "not_enrolled";
+}

--- a/apps/cli/src/subcommands/attest.ts
+++ b/apps/cli/src/subcommands/attest.ts
@@ -47,6 +47,7 @@ import {
   decryptPrivateKey,
   encryptPrivateKey,
   promptPassphrase,
+  resolveUnlockPassphrase,
 } from "../identity.js";
 import { getDbPath } from "../runtime-factory.js";
 
@@ -94,7 +95,12 @@ export async function handleAttest(config: CliConfig): Promise<void> {
   let passphrase: string;
 
   if (fullConfig.cli_encrypted_key) {
-    passphrase = envPassphrase ?? (await promptPassphrase(rl, "Passphrase: "));
+    passphrase =
+      envPassphrase ??
+      (await resolveUnlockPassphrase("Passphrase: ", {
+        rl,
+        encryptedKey: fullConfig.cli_encrypted_key,
+      }));
     try {
       await decryptPrivateKey(fullConfig.cli_encrypted_key, passphrase);
     } catch {

--- a/apps/cli/src/subcommands/delegate.ts
+++ b/apps/cli/src/subcommands/delegate.ts
@@ -68,13 +68,15 @@ async function handleDelegatePlan(
   let solanaConfig: { rpcUrl: string } | undefined;
   if (config.sovereign) {
     const fullConfig = loadFullConfig();
-    const { fromHex, promptPassphrase, decryptPrivateKey } = await import("../identity.js");
+    const { fromHex, resolveUnlockPassphrase, decryptPrivateKey } = await import("../identity.js");
 
     let privateKey: Uint8Array | null = null;
     if (fullConfig.cli_private_key) {
       privateKey = fromHex(fullConfig.cli_private_key);
     } else if (fullConfig.cli_encrypted_key) {
-      const passphrase = await promptPassphrase("Passphrase (for sovereign wallet): ");
+      const passphrase = await resolveUnlockPassphrase("Passphrase (for sovereign wallet): ", {
+        encryptedKey: fullConfig.cli_encrypted_key,
+      });
       const keyHex = await decryptPrivateKey(fullConfig.cli_encrypted_key, passphrase);
       privateKey = fromHex(keyHex);
     }

--- a/apps/cli/src/subcommands/export.ts
+++ b/apps/cli/src/subcommands/export.ts
@@ -21,6 +21,7 @@ import { CONFIG_DIR, loadFullConfig, saveFullConfig } from "../config.js";
 import {
   fromHex,
   promptPassphrase,
+  resolveUnlockPassphrase,
   encryptPrivateKey,
   decryptPrivateKey,
   bootstrapIdentity,
@@ -41,7 +42,12 @@ export async function handleExport(config: CliConfig): Promise<void> {
   let passphrase: string;
 
   if (fullConfig.cli_encrypted_key) {
-    passphrase = envPassphrase ?? (await promptPassphrase(rl, "Passphrase: "));
+    passphrase =
+      envPassphrase ??
+      (await resolveUnlockPassphrase("Passphrase: ", {
+        rl,
+        encryptedKey: fullConfig.cli_encrypted_key,
+      }));
     try {
       await decryptPrivateKey(fullConfig.cli_encrypted_key, passphrase);
     } catch {

--- a/apps/cli/src/subcommands/index.ts
+++ b/apps/cli/src/subcommands/index.ts
@@ -60,6 +60,7 @@ export { handleBalance, handleFund, handleWithdraw } from "./market.js";
 export { handleRegister } from "./register.js";
 export { handleRestore } from "./restore.js";
 export { handleSeed, seedBackupStatus } from "./seed.js";
+export { handleKeychain } from "./keychain.js";
 export { handleRelayUp } from "./relay.js";
 export { handleRotate } from "./rotate.js";
 export { handleSchema } from "./schema.js";

--- a/apps/cli/src/subcommands/keychain.ts
+++ b/apps/cli/src/subcommands/keychain.ts
@@ -1,0 +1,107 @@
+/**
+ * `motebit keychain` — opt-in passphrase enrollment in the macOS login
+ * Keychain (#438, the third leg of the recovery-UX arc #428).
+ *
+ *   motebit keychain           — enrollment status + what it does/doesn't do
+ *   motebit keychain enroll    — validate the passphrase, store it
+ *   motebit keychain remove    — delete the enrollment
+ *
+ * Honesty rules (the copy below is load-bearing — see keychain.ts):
+ * - "login Keychain, protected by your macOS account" — never "Touch ID".
+ * - Enrollment weakens "passphrase in your head" to "passphrase on this
+ *   machine": any process running as your user can read it. Opt-in only.
+ * - It does NOT replace the recovery seed (keychain and disk die with the
+ *   machine) — the seed nudge stays visible until a seed backup is
+ *   acknowledged, enrolled or not.
+ * - `motebit seed reveal` ALWAYS asks interactively — enrollment must not
+ *   turn a reveal-once secret into a zero-interaction dump for whoever is
+ *   at an unlocked terminal.
+ */
+
+import type { CliConfig } from "../args.js";
+import { loadFullConfig } from "../config.js";
+import { decryptPrivateKey, promptPassphrase } from "../identity.js";
+import {
+  isKeychainSupported,
+  keychainEnrollmentStatus,
+  readKeychainPassphrase,
+  writeKeychainPassphrase,
+  deleteKeychainPassphrase,
+} from "../keychain.js";
+import { seedBackupStatus } from "./seed.js";
+import { bold, dim, success, warn } from "../colors.js";
+
+export async function handleKeychain(config: CliConfig): Promise<void> {
+  const sub = config.positionals[1];
+  const full = loadFullConfig();
+
+  if (!isKeychainSupported()) {
+    console.log("\n  Keychain enrollment is macOS-only in v1 (login Keychain via `security`).");
+    console.log(dim("  On this platform, use MOTEBIT_PASSPHRASE or the interactive prompt."));
+    process.exit(sub === "enroll" ? 1 : 0);
+  }
+
+  if (full.motebit_id == null || full.cli_encrypted_key == null) {
+    console.log("\n  No identity on this machine. Run `motebit init` or `motebit restore`.");
+    process.exit(1);
+  }
+  const motebitId = full.motebit_id;
+
+  if (sub === "enroll") {
+    const passphrase = await promptPassphrase("  Passphrase: ");
+    try {
+      await decryptPrivateKey(full.cli_encrypted_key, passphrase);
+    } catch {
+      console.error("\n  Incorrect passphrase — nothing was stored.");
+      process.exit(1);
+    }
+    if (!writeKeychainPassphrase(motebitId, passphrase)) {
+      console.error("\n  Keychain write failed — nothing was stored.");
+      process.exit(1);
+    }
+    console.log(`\n  ${success("Enrolled.")} Commands unlock without a prompt on this machine.`);
+    console.log(dim("  Stored in your macOS login Keychain, protected by your macOS account —"));
+    console.log(dim("  this is convenience, not biometrics: any process running as your user"));
+    console.log(dim("  can read it. Undo anytime: motebit keychain remove"));
+    console.log(dim("  `motebit seed reveal` still always asks for the passphrase."));
+    if (seedBackupStatus(full) === "not_backed_up") {
+      console.log(
+        `\n  ${warn("Your recovery seed is still not backed up.")} The keychain dies with`,
+      );
+      console.log(
+        `  this machine — the seed is the recovery that survives it: ${bold("motebit seed reveal")}`,
+      );
+    }
+    process.exit(0);
+  }
+
+  if (sub === "remove") {
+    if (readKeychainPassphrase(motebitId) == null) {
+      console.log("\n  Nothing enrolled.");
+      process.exit(0);
+    }
+    if (!deleteKeychainPassphrase(motebitId)) {
+      console.error("\n  Keychain delete failed.");
+      process.exit(1);
+    }
+    console.log(`\n  ${success("Removed.")} Commands prompt for the passphrase again.`);
+    process.exit(0);
+  }
+
+  // ── Status ──
+  const status = keychainEnrollmentStatus(motebitId);
+  console.log(`\n  Identity   ${motebitId}`);
+  console.log(
+    `  Keychain   ${status === "enrolled" ? success("enrolled (login Keychain)") : "not enrolled"}`,
+  );
+  if (status === "enrolled") {
+    console.log(dim("  Commands unlock without a prompt; `motebit seed reveal` always asks."));
+    console.log(dim("  Undo: motebit keychain remove"));
+  } else {
+    console.log(dim("  Enroll to stop typing the passphrase on this machine:"));
+    console.log(`  ${bold("motebit keychain enroll")}`);
+    console.log(dim("  Stored in your login Keychain (your macOS account is the protection —"));
+    console.log(dim("  not biometrics). It does not replace your recovery seed."));
+  }
+  process.exit(0);
+}

--- a/apps/cli/src/subcommands/migrate.ts
+++ b/apps/cli/src/subcommands/migrate.ts
@@ -18,7 +18,7 @@ import { fromMicro } from "@motebit/sdk";
 import { createInterface } from "node:readline";
 import type { CliConfig } from "../args.js";
 import { loadFullConfig } from "../config.js";
-import { fromHex, promptPassphrase, decryptPrivateKey } from "../identity.js";
+import { fromHex, resolveUnlockPassphrase, decryptPrivateKey } from "../identity.js";
 import { getRelayUrl, getRelayAuthHeaders, requireMotebitId } from "./_helpers.js";
 
 async function loadIdentityPrivateKey(): Promise<Uint8Array | null> {
@@ -27,7 +27,9 @@ async function loadIdentityPrivateKey(): Promise<Uint8Array | null> {
     return fromHex(config.cli_private_key);
   }
   if (config.cli_encrypted_key) {
-    const passphrase = await promptPassphrase("Passphrase (to sign balance waiver): ");
+    const passphrase = await resolveUnlockPassphrase("Passphrase (to sign balance waiver): ", {
+      encryptedKey: config.cli_encrypted_key,
+    });
     const privateKeyHex = await decryptPrivateKey(config.cli_encrypted_key, passphrase);
     return fromHex(privateKeyHex);
   }

--- a/apps/cli/src/subcommands/rotate.ts
+++ b/apps/cli/src/subcommands/rotate.ts
@@ -23,7 +23,12 @@ import {
 } from "@motebit/encryption";
 import type { CliConfig } from "../args.js";
 import { CONFIG_DIR, loadFullConfig, saveFullConfig } from "../config.js";
-import { fromHex, promptPassphrase, encryptPrivateKey, decryptPrivateKey } from "../identity.js";
+import {
+  fromHex,
+  resolveUnlockPassphrase,
+  encryptPrivateKey,
+  decryptPrivateKey,
+} from "../identity.js";
 
 /**
  * Discover motebit.md by searching cwd, parent directories, and ~/.motebit/identity.md.
@@ -104,7 +109,10 @@ export async function handleRotate(config: CliConfig): Promise<void> {
   if (envPassphrase != null && envPassphrase !== "") {
     passphrase = envPassphrase;
   } else {
-    passphrase = await promptPassphrase(rl, "Passphrase: ");
+    passphrase = await resolveUnlockPassphrase("Passphrase: ", {
+      rl,
+      encryptedKey: fullConfig.cli_encrypted_key,
+    });
   }
 
   let oldPrivKeyHex: string;

--- a/apps/cli/src/subcommands/skills.ts
+++ b/apps/cli/src/subcommands/skills.ts
@@ -52,7 +52,7 @@ import type {
 
 import type { CliConfig } from "../args.js";
 import { CONFIG_DIR, loadFullConfig } from "../config.js";
-import { decryptPrivateKey, fromHex, promptPassphrase } from "../identity.js";
+import { decryptPrivateKey, fromHex, resolveUnlockPassphrase } from "../identity.js";
 import { bold, cyan, dim, error as errorColor, success, warn } from "../colors.js";
 
 const DEFAULT_RELAY_URL = "https://relay.motebit.com";
@@ -942,7 +942,10 @@ async function loadIdentityKey(): Promise<{ privateKey: Uint8Array; publicKey: U
       escapeCodeTimeout: 50,
     });
     try {
-      passphrase = await promptPassphrase(rl, "Passphrase: ");
+      passphrase = await resolveUnlockPassphrase("Passphrase: ", {
+        rl,
+        encryptedKey: fullConfig.cli_encrypted_key,
+      });
     } finally {
       rl.close();
     }

--- a/docs/doctrine/surface-authority-model.md
+++ b/docs/doctrine/surface-authority-model.md
@@ -81,6 +81,15 @@ This is a required deliverable of the unification arc, not doctrine poetry: an e
 - **Remote-trigger as an under-authenticated host-command path** → relay-mediated RCE. The channel is a capability and must be signed-authority-gated like every other.
 - **A frontend growing its own authority** — web/vscode/spatial deciding policy locally instead of invoking a runtime capability. The vscode-on-CLI pattern is the antidote; deviating from it is the smell.
 
+## Decided: keychain-resident passphrase (CLI, opt-in)
+
+The #438 review, decided 2026-07-29: the CLI may store the identity passphrase in the **macOS login Keychain** as an opt-in enrollment (`motebit keychain enroll`). The decision, not the assumption:
+
+- **What changes:** enrollment weakens "passphrase in the owner's head" to "passphrase on this machine" — any process running as the user can read the item (plus the on-disk encrypted key beside it) and decrypt the identity without the human. That adversary already owns the account session, but pre-enrollment it still lacked the passphrase; post-enrollment it does not. This is the standard OS-keychain trade every credential-storing tool makes, and it is **accepted as an opt-in convenience, never a default** — the enrollment copy states it plainly.
+- **What does not change:** the trust class. The CLI runtime already holds authority on this machine; the keychain item adds no new _boundary_, only removes a human factor from an existing one. No operator involvement at any point — the keyring is the user's OS, not ours (sovereignty-preserving recovery, per the #428 framing).
+- **Honesty floor:** the item is login-keychain-protected ("your macOS account"), NOT per-use biometric-gated — `/usr/bin/security` cannot create Secure Enclave ACLs, and the copy must never promise Touch ID it doesn't deliver. A future native binding that adds true biometric gating is additive.
+- **Two structural carve-outs:** enrollment never silences the seed nudge (keychain and disk die with the machine; the seed is the recovery that survives it), and `motebit seed reveal` always prompts interactively (a reveal-once secret must not become a zero-interaction dump for whoever sits at an unlocked terminal).
+
 ## Doctrine check before adding a surface or a capability boundary
 
 1. **Render axis or execution axis?** If it shows what the agent does, it's the slab's job. If it decides what the agent may do, it's the runtime's. Don't merge them.


### PR DESCRIPTION
Closes #438 — the third leg of the recovery-UX arc (#428).

## What ships

- **`motebit keychain [enroll|status|remove]`** — v1 deliberately via `/usr/bin/security` only (no native modules: the keytar route adds a gyp build to the published CLI, the exact failure class the README troubleshooting section exists for). Non-macOS reports unsupported honestly.
- **Resolution chain** in `identity.ts`: env → session cache (#448) → enrolled keychain → interactive prompt, wired at the REPL unlock and every direct-prompt subcommand. The keychain leg validates against the encrypted key where known: a stale enrollment falls through to the prompt with a re-enroll hint (never the caller's "incorrect passphrase" hard-exit — the user typed nothing) and is disabled for the rest of the process. Never a lockout.
- **Honesty floor** (copy is load-bearing at every surface): "your macOS account is the protection" — never Touch ID (`security` cannot create Secure Enclave ACLs); "any process running as your user can read it" — which is why enrollment is opt-in and never a default; "does not replace your recovery seed".
- **Two structural carve-outs**: the seed nudge is independent of enrollment (`seedBackupStatus` never reads keychain state), and `motebit seed reveal` ALWAYS prompts — a reveal-once secret must not become a zero-interaction dump for whoever sits at an unlocked terminal.
- **Surface-authority decision recorded** in `docs/doctrine/surface-authority-model.md` ("Decided: keychain-resident passphrase") — the trade (passphrase in your head → passphrase on this machine) named and accepted as opt-in, per the issue's requirement that this be decided, not assumed.

## Proof

- 13 new tests: adapter with an injected exec seam (no test touches a real keychain; config dir pinned before module load so tests can never read a real `~/.motebit`) + full chain ordering including stale fall-through and process-wide disable
- 310 CLI tests green; doctrine gates green; `check-cli-surface` baseline 35→36 deliberate

🤖 Generated with [Claude Code](https://claude.com/claude-code)