### PR TITLE
fix(render): far plane covers the backdrop dome across the whole orbit envelope

### DIFF
--- a/packages/render-engine/src/__tests__/camera-envelope.test.ts
+++ b/packages/render-engine/src/__tests__/camera-envelope.test.ts
@@ -1,0 +1,46 @@
+/**
+ * The camera frustum and the orbit-zoom envelope are COUPLED through the
+ * backdrop dome (the visible sky is world geometry): every camera
+ * position the controls permit must keep the dome's far wall inside the
+ * far plane, or the sky clips into a screen-centered hole — witnessed
+ * live 2026-07-29 on motebit.com as a giant flat disc behind the creature
+ * (far=10, dome=8, maxDistance=3: clipping began at distance 2, INSIDE
+ * the sanctioned envelope). Definition and consumption live in different
+ * files, so this is a composition invariant — locked here, not assumed
+ * (docs/doctrine/composition-preserves-enforcement.md).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  CAMERA_NEAR_M,
+  CAMERA_FAR_M,
+  BACKDROP_DOME_RADIUS_M,
+  ORBIT_MIN_DISTANCE_M,
+  ORBIT_MAX_DISTANCE_M,
+  CANONICAL_CAMERA,
+} from "../spec.js";
+
+describe("camera envelope × backdrop dome", () => {
+  it("the far plane covers the dome's far wall from the deepest sanctioned zoom-out", () => {
+    // Worst case: camera at maxDistance from the target, dome centered at
+    // the origin — the far wall sits at (distance + radius) from the camera.
+    expect(CAMERA_FAR_M).toBeGreaterThan(ORBIT_MAX_DISTANCE_M + BACKDROP_DOME_RADIUS_M);
+  });
+
+  it("the camera can never exit the dome inside the sanctioned envelope", () => {
+    // Outside the dome, its BackSide shell vanishes and the sky with it.
+    expect(ORBIT_MAX_DISTANCE_M).toBeLessThan(BACKDROP_DOME_RADIUS_M);
+  });
+
+  it("every canonical pose sits inside the orbit envelope and the dome", () => {
+    for (const [name, pose] of Object.entries(CANONICAL_CAMERA)) {
+      const [x, y, z] = pose.position;
+      const dist = Math.hypot(x - pose.lookAt[0], y - pose.lookAt[1], z - pose.lookAt[2]);
+      expect(dist, `${name} pose distance`).toBeLessThanOrEqual(ORBIT_MAX_DISTANCE_M);
+      expect(dist + BACKDROP_DOME_RADIUS_M, `${name} far-wall reach`).toBeLessThan(CAMERA_FAR_M);
+    }
+  });
+
+  it("near plane clears the closest sanctioned zoom-in", () => {
+    expect(CAMERA_NEAR_M).toBeLessThan(ORBIT_MIN_DISTANCE_M);
+  });
+});

--- a/packages/render-engine/src/adapter.ts
+++ b/packages/render-engine/src/adapter.ts
@@ -1,7 +1,14 @@
 import * as THREE from "three";
 import { OrbitControls } from "three/addons/controls/OrbitControls.js";
 import { TrustMode, type RenderSpec } from "@motebit/sdk";
-import { CANONICAL_SPEC, CANONICAL_CAMERA } from "./spec.js";
+import {
+  CANONICAL_SPEC,
+  CANONICAL_CAMERA,
+  CAMERA_NEAR_M,
+  CAMERA_FAR_M,
+  ORBIT_MIN_DISTANCE_M,
+  ORBIT_MAX_DISTANCE_M,
+} from "./spec.js";
 import type {
   RenderAdapter,
   RenderFrame,
@@ -133,11 +140,14 @@ export class ThreeJSAdapter implements RenderAdapter {
     // Camera numbers live in one place — the creature canon
     // (docs/doctrine/creature-canon.md; check-creature-canon).
     const pose = CANONICAL_CAMERA.front;
+    // Far plane must cover the backdrop dome from EVERY position the
+    // orbit envelope permits (spec.ts §camera frustum) — a far plane the
+    // dome outruns clips the sky into a screen-centered hole.
     this.camera = new THREE.PerspectiveCamera(
       pose.fov,
       canvas.clientWidth / canvas.clientHeight,
-      0.1,
-      10,
+      CAMERA_NEAR_M,
+      CAMERA_FAR_M,
     );
     this.camera.position.set(...pose.position);
     this.camera.lookAt(...pose.lookAt);
@@ -450,8 +460,8 @@ export class ThreeJSAdapter implements RenderAdapter {
     this.controls.dampingFactor = 0.08;
     const target = CANONICAL_CAMERA.front.lookAt;
     this.controls.target.set(...target);
-    this.controls.minDistance = 0.3;
-    this.controls.maxDistance = 3.0;
+    this.controls.minDistance = ORBIT_MIN_DISTANCE_M;
+    this.controls.maxDistance = ORBIT_MAX_DISTANCE_M;
     this.controls.update();
   }
 

--- a/packages/render-engine/src/creature.ts
+++ b/packages/render-engine/src/creature.ts
@@ -11,7 +11,7 @@
 
 import * as THREE from "three";
 import { TrustMode, type BehaviorCues } from "@motebit/sdk";
-import { CANONICAL_MATERIAL, smoothDelta } from "./spec.js";
+import { CANONICAL_MATERIAL, BACKDROP_DOME_RADIUS_M, smoothDelta } from "./spec.js";
 import type { RenderFrame, InteriorColor, AudioReactivity } from "./spec.js";
 
 // === Constants ===
@@ -277,7 +277,7 @@ function createSkyMaterial(
  * the light that illuminates the body.
  */
 export function createBackdropDome(preset: EnvironmentPreset = ENV_DEFAULT): THREE.Mesh {
-  const geo = new THREE.SphereGeometry(8, 64, 32);
+  const geo = new THREE.SphereGeometry(BACKDROP_DOME_RADIUS_M, 64, 32);
   const mat = createSkyMaterial(preset, { forDisplay: true });
   const mesh = new THREE.Mesh(geo, mat);
   mesh.name = "backdrop-dome";

--- a/packages/render-engine/src/spec.ts
+++ b/packages/render-engine/src/spec.ts
@@ -57,6 +57,23 @@ export const CANONICAL_SPEC: RenderSpec = {
 // divergence), and the golden-frame harness renders the pose ×
 // performance matrix deterministically. Enforced by check-creature-canon.
 
+// === Camera frustum + zoom envelope — one source, two consumers ===
+//
+// The visible sky is WORLD GEOMETRY (the backdrop dome), so the camera's
+// far plane and the orbit-zoom envelope are COUPLED: every camera
+// position the controls permit must keep the dome's far wall
+// (distance-to-target + dome radius) inside the far plane. Violating it
+// clips the sky along the far plane's screen-centered circle — witnessed
+// live 2026-07-29 on motebit.com as a giant flat disc behind the creature
+// (the transparent canvas showing the page background through the hole).
+// The invariant `CAMERA_FAR_M > ORBIT_MAX_DISTANCE_M +
+// BACKDROP_DOME_RADIUS_M` is locked by camera-envelope.test.ts.
+export const CAMERA_NEAR_M = 0.1;
+export const CAMERA_FAR_M = 20;
+export const BACKDROP_DOME_RADIUS_M = 8;
+export const ORBIT_MIN_DISTANCE_M = 0.3;
+export const ORBIT_MAX_DISTANCE_M = 3.0;
+
 export type CanonicalCameraName =
   "front" | "three_quarter" | "oblique" | "profile" | "back" | "hero";
 


### PR DESCRIPTION
## The bug (witnessed live on motebit.com, 2026-07-29)

Zooming out revealed a giant flat faceted disc behind the creature. The visible sky is WORLD GEOMETRY (the radius-8 backdrop dome), but the camera far plane was 10 and the orbit envelope allows dolly to 3 — from any distance past ~2 the dome's far wall (distance + 8) crossed the far plane, which clips the sphere along a screen-centered circle: sky at the periphery, a hole in the middle showing the page background through the transparent canvas. **Inside the sanctioned envelope** — the designed edge was broken, not an out-of-bounds camera.

Reproduced deterministically on the golden harness (distance 2.4 = the exact witnessed frame), fixed, re-captured clean.

## The fix

The canon fix, not the local one: the five coupled numbers move into `spec.ts` (creature-canon: numbers live in one place) — `CAMERA_NEAR_M`/`CAMERA_FAR_M` (10→20), `BACKDROP_DOME_RADIUS_M`, `ORBIT_MIN/MAX_DISTANCE_M` — consumed by the adapter and `createBackdropDome`, with `camera-envelope.test.ts` locking the coupling (far > maxDistance + dome radius; the camera never exits the dome; every canonical pose inside both). Definition and consumption live in different files, so the invariant is a composition test (composition-preserves-enforcement).

Canonical poses sit at ~0.9 where nothing was ever clipped — golden frames unaffected. 472 render-engine tests green; `check-creature-canon` green.

Merging auto-triggers `deploy-web.yml` (paths: `packages/**`) — motebit.com picks this up on the merge push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)