### PR TITLE
fix(relay): device-auth rejections name their reason — a 401 is never silent again

### DIFF
--- a/services/relay/src/__tests__/auth.test.ts
+++ b/services/relay/src/__tests__/auth.test.ts
@@ -238,3 +238,99 @@ describe("verifySignedTokenForDevice — agent-registry sibling fallback", () =>
     expect(ok).toBe(true);
   });
 });
+
+describe("verifySignedTokenForDevice — rejection legibility (#460)", () => {
+  const mid = "motebit-legibility-1";
+  const did = "device-legibility-1";
+
+  const noDeviceIM = {
+    loadDeviceById: async () => null,
+  } as unknown as IdentityManager;
+
+  function deviceIM(publicKeyHex: string): IdentityManager {
+    return {
+      loadDeviceById: async () => ({ public_key: publicKeyHex }),
+    } as unknown as IdentityManager;
+  }
+
+  async function mintToken(privateKey: Uint8Array, aud: TokenAudience = "account:balance") {
+    const now = Date.now();
+    return createSignedToken(
+      { mid, did, iat: now, exp: now + 300_000, jti: "jti-legibility-1", aud },
+      privateKey,
+    );
+  }
+
+  it("names no_key_for_device_or_agent when neither device row nor registry fallback resolves — the silent-401 shape witnessed live", async () => {
+    const kp = await generateKeypair();
+    const token = await mintToken(kp.privateKey);
+    const reasons: string[] = [];
+    const ok = await verifySignedTokenForDevice(
+      token,
+      mid,
+      noDeviceIM,
+      "account:balance",
+      undefined,
+      undefined,
+      undefined,
+      (r) => reasons.push(r),
+    );
+    expect(ok).toBe(false);
+    expect(reasons).toEqual(["no_key_for_device_or_agent"]);
+  });
+
+  it("names the audience mismatch with got + expected", async () => {
+    const kp = await generateKeypair();
+    const token = await mintToken(kp.privateKey, "task:submit");
+    const reasons: string[] = [];
+    const ok = await verifySignedTokenForDevice(
+      token,
+      mid,
+      deviceIM(bytesToHex(kp.publicKey)),
+      "account:balance",
+      undefined,
+      undefined,
+      undefined,
+      (r) => reasons.push(r),
+    );
+    expect(ok).toBe(false);
+    expect(reasons).toEqual(["audience_mismatch:got=task:submit:expected=account:balance"]);
+  });
+
+  it("names a signature failure (token signed by a DIFFERENT key)", async () => {
+    const signer = await generateKeypair();
+    const registered = await generateKeypair();
+    const token = await mintToken(signer.privateKey);
+    const reasons: string[] = [];
+    const ok = await verifySignedTokenForDevice(
+      token,
+      mid,
+      deviceIM(bytesToHex(registered.publicKey)),
+      "account:balance",
+      undefined,
+      undefined,
+      undefined,
+      (r) => reasons.push(r),
+    );
+    expect(ok).toBe(false);
+    expect(reasons).toEqual(["signature_or_expiry_invalid"]);
+  });
+
+  it("a VALID token triggers no rejection callback", async () => {
+    const kp = await generateKeypair();
+    const token = await mintToken(kp.privateKey);
+    const reasons: string[] = [];
+    const ok = await verifySignedTokenForDevice(
+      token,
+      mid,
+      deviceIM(bytesToHex(kp.publicKey)),
+      "account:balance",
+      undefined,
+      undefined,
+      undefined,
+      (r) => reasons.push(r),
+    );
+    expect(ok).toBe(true);
+    expect(reasons).toEqual([]);
+  });
+});

--- a/services/relay/src/auth.ts
+++ b/services/relay/src/auth.ts
@@ -109,15 +109,32 @@ export async function verifySignedTokenForDevice(
   blacklistCheck?: (jti: string, motebitId: string) => boolean,
   agentRevokedCheck?: (motebitId: string) => boolean,
   agentKeyLookup?: (motebitId: string) => string | null,
+  onReject?: (reason: string) => void,
 ): Promise<boolean> {
+  // Rejection legibility (#460): every `return false` names its reason via
+  // the optional callback so the enforcement site can LOG why — witnessed
+  // 2026-07-29: a live 401 left zero server-side trace, making device-auth
+  // failures undiagnosable from the operator seat. The reason never
+  // includes the token; the boolean contract is unchanged (additive).
   const claims = parseTokenPayloadUnsafe(token);
-  if (!claims || claims.mid !== motebitId || !claims.did) return false;
+  if (!claims || claims.mid !== motebitId || !claims.did) {
+    onReject?.(
+      !claims ? "token_unparseable" : claims.mid !== motebitId ? "mid_mismatch" : "did_missing",
+    );
+    return false;
+  }
 
   // Check if the agent's identity has been revoked
-  if (agentRevokedCheck && agentRevokedCheck(motebitId)) return false;
+  if (agentRevokedCheck && agentRevokedCheck(motebitId)) {
+    onReject?.("agent_revoked");
+    return false;
+  }
 
   // Check if this specific token's jti has been blacklisted
-  if (blacklistCheck && claims.jti && blacklistCheck(claims.jti, motebitId)) return false;
+  if (blacklistCheck && claims.jti && blacklistCheck(claims.jti, motebitId)) {
+    onReject?.("jti_blacklisted");
+    return false;
+  }
 
   // Resolve the verifying public key. Device-mode motebits (web/mobile/desktop)
   // have a device row keyed by `did`. Service-mode motebits (molecules) register
@@ -133,14 +150,25 @@ export async function verifySignedTokenForDevice(
   if (pubKeyHex === null && agentKeyLookup) {
     pubKeyHex = agentKeyLookup(motebitId);
   }
-  if (pubKeyHex === null) return false;
+  if (pubKeyHex === null) {
+    onReject?.("no_key_for_device_or_agent");
+    return false;
+  }
 
   const pubKeyBytes = hexToBytes(pubKeyHex);
   const payload = await verifySignedToken(token, pubKeyBytes);
-  if (payload === null || payload.mid !== motebitId) return false;
+  if (payload === null || payload.mid !== motebitId) {
+    onReject?.(payload === null ? "signature_or_expiry_invalid" : "payload_mid_mismatch");
+    return false;
+  }
 
   // Audience binding: reject tokens missing aud or scoped to a different endpoint
-  if (payload.aud !== expectedAudience) return false;
+  if (payload.aud !== expectedAudience) {
+    onReject?.(
+      `audience_mismatch:got=${String(payload.aud ?? "absent")}:expected=${expectedAudience}`,
+    );
+    return false;
+  }
 
   return true;
 }

--- a/services/relay/src/middleware.ts
+++ b/services/relay/src/middleware.ts
@@ -185,6 +185,18 @@ export function createDualAuth(deps: MiddlewareDeps) {
       expectedAudience,
       deps.isTokenBlacklisted,
       deps.isAgentRevoked,
+      undefined,
+      // Rejection legibility (#460): a device-auth 401 previously left ZERO
+      // server-side trace (witnessed live 2026-07-29 — undiagnosable from
+      // the operator seat). Log the structured reason; never the token.
+      (reason) =>
+        logger.warn("auth.device_token_rejected", {
+          correlationId: c.req.header("x-correlation-id") ?? "none",
+          reason,
+          expectedAudience,
+          mid: claims.mid,
+          path: new URL(c.req.url, "http://localhost").pathname,
+        }),
     );
     if (!valid) {
       throw new AuthenticationError("AUTH_INVALID_TOKEN", "Token verification failed");
@@ -446,6 +458,15 @@ export function registerMiddleware(deps: MiddlewareDeps): MiddlewareResult {
         "sync",
         deps.isTokenBlacklisted,
         deps.isAgentRevoked,
+        undefined,
+        (reason) =>
+          logger.warn("auth.device_token_rejected", {
+            correlationId: c.req.header("x-correlation-id") ?? "none",
+            reason,
+            expectedAudience: "sync",
+            mid: motebitId,
+            path: new URL(c.req.url, "http://localhost").pathname,
+          }),
       );
       if (!verified) {
         throw new AuthorizationError(


### PR DESCRIPTION
Progress on #460 (diagnosis infrastructure; root cause TBD by first logged repro).

A live REPL `/balance` 401 (2026-07-29 ~10:08 UTC) left zero server-side trace: `verifySignedTokenForDevice` has six rejection paths and reported none. `onReject(reason)` callback added (additive, boolean contract unchanged), both middleware sites log structured `auth.device_token_rejected` {reason, expectedAudience, mid, path} — never the token. Reasons: token_unparseable / mid_mismatch / did_missing / agent_revoked / jti_blacklisted / no_key_for_device_or_agent / signature_or_expiry_invalid / payload_mid_mismatch / audience_mismatch:got=X:expected=Y.

Prod evidence attached to #460: the identity's device row is healthy, so the next repro's logged reason pinpoints the failing check. 4 new tests; relay suite 1513 green.

Merging auto-deploys the relay (path-filtered, CI-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)