### PR TITLE
fix(runtime,cli): approval expiry is never silent — every approval answer renders a terminal outcome

### DIFF
--- a/.changeset/approval-expiry-legibility.md
+++ b/.changeset/approval-expiry-legibility.md
@@ -1,0 +1,7 @@
+---
+"motebit": patch
+---
+
+An approval that expires can never end in silence again.
+
+Approvals wait ten minutes; answering after the timer had voided one used to render nothing at all — an approved irreversible-money action ending with an empty prompt (witnessed live: the human approved, the runtime returned zero output, and only the blockchain could confirm no money moved). Now the expiry announces itself the moment the timer fires, a late answer renders a plain "this approval expired before your answer arrived — nothing was executed; no money moved," and the REPL prints an honest fallback if a resumed approval ever yields nothing. Every approval answer ends in a rendered terminal outcome.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -36,6 +36,7 @@ import {
   success,
   bold,
   cyan,
+  warn,
 } from "./colors.js";
 import {
   isSlashCommand,
@@ -756,6 +757,18 @@ async function main(): Promise<void> {
     solanaWallet,
   );
   runtimeRef.current = runtime;
+
+  // #457: when a pending approval times out (default 10 minutes), say so
+  // the MOMENT it happens — previously the expiry was structurally
+  // invisible (callback never registered anywhere, chunk never emitted),
+  // so a human answering an expired prompt got pure silence after an
+  // approved money action. The line may land mid-prompt; the redraw
+  // roughness belongs to the #456 rendering arc — silence does not.
+  runtime.onApprovalExpired(() => {
+    console.log(
+      `\n  ${warn("[the pending approval expired — nothing was executed]")}\n  ${dim("(approvals wait 10 minutes; ask again when ready)")}`,
+    );
+  });
 
   // Connect MCP servers
   let mcpAdapters: Awaited<ReturnType<typeof connectMcpServers>> = [];

--- a/apps/cli/src/stream.ts
+++ b/apps/cli/src/stream.ts
@@ -29,7 +29,7 @@ export async function consumeStream(
   stream: AsyncGenerator<StreamChunk>,
   runtime: MotebitRuntime,
   opts?: { voice?: VoiceController; budgetUsd?: number },
-): Promise<void> {
+): Promise<boolean> {
   let pendingApproval: {
     tool_call_id: string;
     name: string;
@@ -39,8 +39,13 @@ export async function consumeStream(
   } | null = null;
   let stopAnimation: (() => void) | null = null;
   let lastCompletedReceiptResult: string | null = null;
+  // #457: whether ANY chunk arrived — the caller uses this to guarantee an
+  // approval answer never ends in pure silence. Returns true once a chunk
+  // is observed (every chunk type renders or deliberately captures).
+  let sawAnyChunk = false;
 
   for await (const chunk of stream) {
+    sawAnyChunk = true;
     switch (chunk.type) {
       case "text":
         writeOutput(chunk.text);
@@ -125,6 +130,21 @@ export async function consumeStream(
         writeOutput(`\n  ${warn("⚠")} ${warn("suspicious content in " + chunk.tool_name)}\n`);
         break;
 
+      case "approval_expired":
+        // #457: an approval submitted after the timeout voided it used to
+        // end with NOTHING on screen — an approved money action with no
+        // rendered outcome. The runtime now emits this typed chunk; say
+        // plainly that nothing executed and how to proceed.
+        if (stopAnimation) {
+          stopAnimation();
+          stopAnimation = null;
+        }
+        writeOutput(
+          `\n  ${warn("[this approval expired before your answer arrived — nothing was executed]")}\n` +
+            `  ${dim(`(${chunk.tool_name} was never run; no money moved. Ask again when ready.)`)}\n`,
+        );
+        break;
+
       case "invoke_error":
         if (stopAnimation) {
           stopAnimation();
@@ -179,7 +199,21 @@ export async function consumeStream(
 
     const approved = answer.trim().toLowerCase() === "y";
     writeOutput("\n" + promptColor("mote>") + " ");
-    await consumeStream(runtime.resolveApprovalVote(approved, runtime.motebitId), runtime, opts);
+    const resumedRendered = await consumeStream(
+      runtime.resolveApprovalVote(approved, runtime.motebitId),
+      runtime,
+      opts,
+    );
+    // #457 backstop: an approval answer must never end with a bare orphaned
+    // `mote>`. The runtime now emits approval_expired on every late-resume
+    // path, so a zero-chunk resume should be impossible — but if a new one
+    // appears, say so instead of silence. Terminal-outcome-always is the
+    // contract for money surfaces.
+    if (!resumedRendered) {
+      writeOutput(
+        `${warn("[nothing came back for this approval — it may have expired or been resolved elsewhere; nothing was executed]")}\n`,
+      );
+    }
   }
 
   // Speak the delegated task's result on completion, but only if voice is
@@ -188,4 +222,6 @@ export async function consumeStream(
   if (opts?.voice && lastCompletedReceiptResult) {
     void opts.voice.speakIfEnabled(lastCompletedReceiptResult);
   }
+
+  return sawAnyChunk;
 }

--- a/packages/runtime/src/__tests__/streaming.test.ts
+++ b/packages/runtime/src/__tests__/streaming.test.ts
@@ -1133,15 +1133,44 @@ describe("resumeAfterApproval", () => {
     );
   });
 
-  it("returns silently without pending approval (timeout may have fired)", async () => {
-    // When no pending approval exists (e.g. timeout already fired and cleared it),
-    // resumeAfterApproval returns silently instead of throwing — prevents the race
-    // where a user approves at the same moment the timeout fires.
-    const chunks: unknown[] = [];
+  it("emits approval_expired (never silence) when resumed without a pending approval — #457", async () => {
+    // When no pending approval exists (timeout already fired and cleared it),
+    // resumeAfterApproval must not throw (the approve-vs-timeout race) — but it
+    // must NOT be silent either: witnessed live 2026-07-29, a human approved an
+    // R4 money action after the 10-minute timer voided it and got ZERO rendered
+    // outcome. The typed expiry chunk is the terminal outcome every surface
+    // renders.
+    const chunks: Array<{ type: string; tool_name?: string }> = [];
     for await (const chunk of runtime.resumeAfterApproval(true)) {
-      chunks.push(chunk);
+      chunks.push(chunk as { type: string; tool_name?: string });
     }
-    expect(chunks).toHaveLength(0);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]!.type).toBe("approval_expired");
+  });
+
+  it("resolveApprovalVote after expiry emits approval_expired too — same #457 contract", async () => {
+    const chunks: Array<{ type: string }> = [];
+    for await (const chunk of runtime.resolveApprovalVote(true, "approval-test")) {
+      chunks.push(chunk as { type: string });
+    }
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]!.type).toBe("approval_expired");
+  });
+
+  it("the expiry chunk NAMES the tool when the timeout handler recorded it", async () => {
+    const streaming = (
+      runtime as unknown as {
+        streaming: {
+          _lastExpiredToolName: string | null;
+        };
+      }
+    ).streaming;
+    streaming._lastExpiredToolName = "delegate_to_agent";
+    const chunks: Array<{ type: string; tool_name?: string }> = [];
+    for await (const chunk of runtime.resumeAfterApproval(true)) {
+      chunks.push(chunk as { type: string; tool_name?: string });
+    }
+    expect(chunks[0]).toEqual({ type: "approval_expired", tool_name: "delegate_to_agent" });
   });
 
   it("throws without AI provider", async () => {

--- a/packages/runtime/src/streaming.ts
+++ b/packages/runtime/src/streaming.ts
@@ -237,6 +237,8 @@ interface PendingApproval {
 
 export class StreamingManager {
   private _pendingApproval: PendingApproval | null = null;
+  /** Tool name of the most recently EXPIRED approval — lets a late resume name it (#457). */
+  private _lastExpiredToolName: string | null = null;
   private approvalTimer: ReturnType<typeof setTimeout> | null = null;
   /**
    * Intents the human has REFUSED this session, keyed by tool + exact args
@@ -578,7 +580,17 @@ export class StreamingManager {
 
     if (!this._pendingApproval) {
       // Timeout already fired — approval came too late. The timeout handler
-      // already injected a denial into conversation history, so this is a no-op.
+      // already injected a denial into conversation history. This MUST NOT
+      // be a silent no-op (#457, witnessed live 2026-07-29: a human approved
+      // an R4 money action ~12 minutes after the prompt, the 10-minute timer
+      // had voided it, and the resume returned zero chunks — an approved
+      // irreversible-money action ended with NOTHING rendered). Emit the
+      // typed expiry chunk (declared since the beginning; zero producers
+      // until now) so every surface can say what happened.
+      yield {
+        type: "approval_expired" as const,
+        tool_name: this._lastExpiredToolName ?? "unknown",
+      };
       return;
     }
     // Resume after tool approval IS a bytes-leave moment — fire the
@@ -751,7 +763,12 @@ export class StreamingManager {
     this.clearApprovalTimeout();
 
     if (!this._pendingApproval) {
-      // Timeout already fired — approval came too late.
+      // Timeout already fired — approval came too late. Same #457 contract
+      // as resumeAfterApproval: never a silent zero-chunk return.
+      yield {
+        type: "approval_expired" as const,
+        tool_name: this._lastExpiredToolName ?? "unknown",
+      };
       return;
     }
 
@@ -804,6 +821,9 @@ export class StreamingManager {
       if (!this._pendingApproval) return;
       const expired = this._pendingApproval;
       this._pendingApproval = null;
+      // Remembered so a late resume can NAME the tool in its
+      // approval_expired chunk (#457) — the pending record is gone by then.
+      this._lastExpiredToolName = expired.toolName;
       // Push denial into conversation history so LLM sees it on next turn
       this.deps.injectIntermediateMessages(
         {


### PR DESCRIPTION
Closes #457 (the expiry-silence half; the concurrent-actor hazards split to #462).

## Root cause (full map on #457)

The witnessed silent evaporation: the user approved an R4 money action ~12 minutes after the prompt; the 10-minute approval timer had voided it; `resumeAfterApproval`'s no-pending path returned **zero chunks by design** (a test codified the silence), the `approval_expired` chunk type had **zero producers**, and the expiry callback had **zero registrations**. Expiry was structurally unrenderable at every layer — an approved irreversible-money action ended with nothing on screen. Every other suspect was ruled out with evidence (the tool registry converts throws to `{ok:false}`; every executed path renders).

## The fix — layered so no single miss restores the silence

1. **Runtime**: the timeout handler records the expired tool's name; `resumeAfterApproval` and `resolveApprovalVote` late paths emit `{type: approval_expired, tool_name}` — the chunk's first producers.
2. **CLI render**: `approval_expired` renders plainly — *this approval expired before your answer arrived — nothing was executed; no money moved*.
3. **CLI moment-of-expiry**: `onApprovalExpired` registered (first registration anywhere) — the timer announces itself when it fires, not only when the user answers into the void.
4. **Backstop**: `consumeStream` returns whether any chunk arrived; the approval-answer site prints an honest fallback if a zero-chunk resume ever reappears.

## Proof

1247 runtime + 310 CLI tests green (3 new: expiry chunk on both resume paths + tool-name carrying; the codified-silence test inverted); tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)