### PR TITLE
fix(relay): kill the settlement-amplification loop at its four relay-side enablers

### DIFF
--- a/services/relay/fly.toml
+++ b/services/relay/fly.toml
@@ -39,11 +39,16 @@ kill_timeout = 5
 
   [[http_service.checks]]
     interval = "15s"
-    grace_period = "5s"
+    # 2s was the tightest health budget in the fleet — during the 2026-07-29
+    # amplification incident (#459) a starved event loop blew past it and the
+    # Fly proxy pulled the relay from rotation, 503ing every unrelated
+    # endpoint while the process was still alive. 5s tolerates a busy loop
+    # without masking a genuinely dead one.
+    grace_period = "15s"
     method = "GET"
     path = "/health"
     protocol = "http"
-    timeout = "2s"
+    timeout = "5s"
 
 [mounts]
   source = "motebit_data"

--- a/services/relay/src/__tests__/settlement-amplification-459.test.ts
+++ b/services/relay/src/__tests__/settlement-amplification-459.test.ts
@@ -1,0 +1,242 @@
+/**
+ * #459 — the settlement-amplification incident's three relay-side fixes,
+ * each asserted over live routes:
+ *
+ * 1. Routing self-exclusion: capability routing must never select the
+ *    SUBMITTER as its own worker (the distributed loop closed exactly
+ *    there — web-search's read_url sub-task routed back to web-search).
+ * 2. Receipt-time pricing honesty: a task with no price snapshot and no
+ *    allocation settles at gross 0 (a real $0 settlement row) — never at
+ *    a gross invented from the EXECUTING agent's listing (the constant
+ *    gross=6316 signature of the incident).
+ * 3. Idempotency claim release: a submission that fails AFTER claiming
+ *    its Idempotency-Key releases the claim — an honest same-key retry
+ *    proceeds instead of 409ing until the 24h sweep (the defect that
+ *    trains clients to mint fresh keys per attempt, defeating
+ *    idempotency).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { SyncRelay } from "../index.js";
+// eslint-disable-next-line no-restricted-imports -- tests need direct keypair generation
+import { generateKeypair, bytesToHex } from "@motebit/encryption";
+import { signExecutionReceipt, hash as sha256 } from "@motebit/crypto";
+import type { MotebitId, DeviceId } from "@motebit/sdk";
+import {
+  createTestRelay,
+  createAgent,
+  JSON_AUTH,
+  jsonAuthWithIdempotency,
+} from "./test-helpers.js";
+
+const WORKER_ADDR = "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgHkv";
+
+/** Ephemeral counting HTTP server — records every request it receives. */
+function countingServer(): Promise<{ server: Server; url: string; hits: () => number }> {
+  return new Promise((resolve) => {
+    let count = 0;
+    const server = createServer((_req, res) => {
+      count++;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end("{}");
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ server, url: `http://127.0.0.1:${port}/mcp`, hits: () => count });
+    });
+  });
+}
+
+async function registerAgentWithEndpoint(
+  relay: SyncRelay,
+  motebitId: string,
+  endpointUrl: string,
+  capabilities: string[],
+): Promise<void> {
+  await relay.app.request("/api/v1/agents/register", {
+    method: "POST",
+    headers: JSON_AUTH,
+    body: JSON.stringify({
+      motebit_id: motebitId,
+      endpoint_url: endpointUrl,
+      capabilities,
+      settlement_address: WORKER_ADDR,
+      settlement_modes: "relay,p2p",
+    }),
+  });
+}
+
+describe("#459 — settlement-amplification relay fixes", () => {
+  let relay: SyncRelay;
+
+  beforeEach(async () => {
+    relay = await createTestRelay({ enableDeviceAuth: false });
+  });
+
+  afterEach(async () => {
+    await relay.close();
+  });
+
+  it("capability routing never forwards a task back to its own submitter (the loop's closing edge)", async () => {
+    const submitterHits = await countingServer();
+    const otherHits = await countingServer();
+    try {
+      const subKp = await generateKeypair();
+      const submitter = await createAgent(relay, bytesToHex(subKp.publicKey));
+      const otherKp = await generateKeypair();
+      const other = await createAgent(relay, bytesToHex(otherKp.publicKey));
+
+      // BOTH advertise read_url; the submitter must never be chosen.
+      await registerAgentWithEndpoint(relay, submitter.motebitId, submitterHits.url, ["read_url"]);
+      await registerAgentWithEndpoint(relay, other.motebitId, otherHits.url, ["read_url"]);
+
+      const res = await relay.app.request(`/agent/${submitter.motebitId}/task`, {
+        method: "POST",
+        headers: jsonAuthWithIdempotency(),
+        body: JSON.stringify({
+          prompt: "read https://example.com",
+          submitted_by: submitter.motebitId,
+          required_capabilities: ["read_url"],
+        }),
+      });
+      expect(res.status).toBe(201);
+
+      // The forward is fire-and-forget — give it a beat to land.
+      await new Promise((r) => setTimeout(r, 400));
+
+      // The incident's mechanism: pre-fix, the submitter (advertising the
+      // capability) could be selected as its own worker. Post-fix: never.
+      expect(submitterHits.hits()).toBe(0);
+      // Routing still works — the OTHER capable agent received the dispatch.
+      expect(otherHits.hits()).toBeGreaterThan(0);
+    } finally {
+      submitterHits.server.close();
+      otherHits.server.close();
+    }
+  });
+
+  it("a task with no snapshot and no allocation settles at gross 0 — never at the executing agent's listing price", async () => {
+    const workerKp = await generateKeypair();
+    const worker = await createAgent(relay, bytesToHex(workerKp.publicKey));
+    // Register with a NON-zero listing — the incident's invented gross came
+    // from exactly this listing being consulted at receipt time.
+    await registerAgentWithEndpoint(relay, worker.motebitId, "http://localhost:9999/mcp", [
+      "web_search",
+    ]);
+    await relay.app.request(`/api/v1/agents/${worker.motebitId}/listing`, {
+      method: "POST",
+      headers: JSON_AUTH,
+      body: JSON.stringify({
+        capabilities: ["web_search", "read_url"],
+        pricing: [
+          { capability: "web_search", unit_cost: 0.003, currency: "USD", per: "task" },
+          { capability: "read_url", unit_cost: 0.003, currency: "USD", per: "task" },
+        ],
+        sla: { max_latency_ms: 5000, availability_guarantee: 0.99 },
+        description: "459 pricing-honesty worker",
+      }),
+    });
+
+    // Self-delegation (Arc 3 carve-out) at ZERO submission cost: pricingAgent
+    // is the URL agent whose listing IS priced — but submit as a free task by
+    // targeting a capability-less prompt... Simplest zero-cost shape: the
+    // SUBMITTER is the worker itself (self-delegation carve-out) and the URL
+    // agent's listing prices it >0, so price_snapshot IS set. To reproduce
+    // the incident's no-snapshot state we submit to a DIFFERENT, unlisted
+    // agent id (zero listing → unitCostAtSubmission 0 → no snapshot, no
+    // allocation) and then deliver the LISTED worker's receipt for it.
+    const targetKp = await generateKeypair();
+    const target = await createAgent(relay, bytesToHex(targetKp.publicKey));
+    const submit = await relay.app.request(`/agent/${target.motebitId}/task`, {
+      method: "POST",
+      headers: jsonAuthWithIdempotency(),
+      body: JSON.stringify({ prompt: "search for something" }),
+    });
+    expect(submit.status).toBe(201);
+    const { task_id: taskId } = (await submit.json()) as { task_id: string };
+
+    // The LISTED worker signs and delivers the receipt (the incident shape:
+    // the executing agent's listing was then used to invent gross=6316).
+    const enc = new TextEncoder();
+    const receipt = await signExecutionReceipt(
+      {
+        task_id: taskId,
+        relay_task_id: taskId,
+        motebit_id: worker.motebitId as unknown as MotebitId,
+        device_id: "svc" as unknown as DeviceId,
+        submitted_at: Date.now() - 1000,
+        completed_at: Date.now(),
+        status: "completed" as const,
+        result: "done",
+        tools_used: ["web_search"],
+        memories_formed: 0,
+        prompt_hash: await sha256(enc.encode("search for something")),
+        result_hash: await sha256(enc.encode("done")),
+      },
+      workerKp.privateKey,
+    );
+    const resultRes = await relay.app.request(`/agent/${target.motebitId}/task/${taskId}/result`, {
+      method: "POST",
+      headers: JSON_AUTH,
+      body: JSON.stringify(receipt),
+    });
+    expect(resultRes.status).toBe(200);
+
+    // The honest outcome: a REAL $0 settlement row (funded via gross 0) —
+    // not an unfunded skip of an invented listing-priced gross.
+    const row = relay.moteDb.db
+      .prepare("SELECT amount_settled, platform_fee FROM relay_settlements WHERE task_id = ?")
+      .get(taskId) as { amount_settled: number; platform_fee: number } | undefined;
+    expect(row).toBeDefined();
+    expect(row!.amount_settled).toBe(0);
+    expect(row!.platform_fee).toBe(0);
+  });
+
+  it("a failed submission releases its idempotency claim — an honest same-key retry proceeds", async () => {
+    const paidKp = await generateKeypair();
+    const paidWorker = await createAgent(relay, bytesToHex(paidKp.publicKey));
+    await registerAgentWithEndpoint(relay, paidWorker.motebitId, "http://localhost:9999/mcp", [
+      "web_search",
+    ]);
+    await relay.app.request(`/api/v1/agents/${paidWorker.motebitId}/listing`, {
+      method: "POST",
+      headers: JSON_AUTH,
+      body: JSON.stringify({
+        capabilities: ["web_search"],
+        pricing: [{ capability: "web_search", unit_cost: 1.0, currency: "USD", per: "task" }],
+        sla: { max_latency_ms: 5000, availability_guarantee: 0.99 },
+        description: "459 idempotency worker",
+      }),
+    });
+    const delegatorKp = await generateKeypair();
+    const delegator = await createAgent(relay, bytesToHex(delegatorKp.publicKey));
+
+    const key = `459-retry-${crypto.randomUUID()}`;
+    const headers = { ...JSON_AUTH, "Idempotency-Key": key };
+
+    // Attempt 1: paid direct delegation without a P2P proof → the Arc 3.5
+    // gate throws 402 AFTER checkIdempotency claimed the key.
+    const first = await relay.app.request(`/agent/${paidWorker.motebitId}/task`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        prompt: "paid work",
+        submitted_by: delegator.motebitId,
+      }),
+    });
+    expect(first.status).toBe(402);
+
+    // Attempt 2, SAME key (the honest retry, here as a free self-submission
+    // that passes the gate): pre-fix this 409'd forever ("already being
+    // processed") because the claim was stranded; post-fix it proceeds.
+    const freeKp = await generateKeypair();
+    const freeTarget = await createAgent(relay, bytesToHex(freeKp.publicKey));
+    const second = await relay.app.request(`/agent/${freeTarget.motebitId}/task`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ prompt: "retry after failure" }),
+    });
+    expect(second.status).toBe(201);
+  });
+});

--- a/services/relay/src/idempotency.ts
+++ b/services/relay/src/idempotency.ts
@@ -129,6 +129,23 @@ export function completeIdempotency(
 }
 
 /**
+ * Release a claimed-but-never-completed idempotency key (#459 secondary
+ * defect): a submit handler that throws AFTER `checkIdempotency` claimed
+ * the row used to strand it in 'processing' forever — an honest retry
+ * with the SAME key then got 409 until the 24h sweep, which trains
+ * clients to mint a fresh key per attempt (defeating idempotency
+ * entirely; both storm-implicated submitters did exactly this). Deletes
+ * ONLY a still-'processing' row — a completed row (cached response) is
+ * never touched. Call from the error boundary of the request that made
+ * the claim, never for a conflict observed on someone else's claim.
+ */
+export function releaseIdempotency(db: DatabaseDriver, key: string, motebitId: string): void {
+  db.prepare(
+    "DELETE FROM relay_idempotency_keys WHERE idempotency_key = ? AND motebit_id = ? AND status = 'processing'",
+  ).run(key, motebitId);
+}
+
+/**
  * Delete idempotency records older than 24 hours.
  * Called from the existing cleanup interval in index.ts.
  * Returns the number of records deleted.

--- a/services/relay/src/index.ts
+++ b/services/relay/src/index.ts
@@ -82,7 +82,11 @@ import { registerWebSocketRoutes } from "./websocket.js";
 import type { ConnectedDevice } from "./websocket.js";
 import { registerSyncRoutes, redactSensitiveEvents } from "./sync-routes.js";
 import { registerIntakeRoutes } from "./intake-routes.js";
-import { createIdempotencyTable, cleanupIdempotencyKeys } from "./idempotency.js";
+import {
+  createIdempotencyTable,
+  cleanupIdempotencyKeys,
+  releaseIdempotency,
+} from "./idempotency.js";
 import {
   createFederationTables,
   initRelayIdentity,
@@ -684,6 +688,7 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
     isAgentRevoked,
     verifySignedTokenForDevice: verifySignedTokenForDeviceWithFallback,
     parseTokenPayloadUnsafe,
+    releaseIdempotencyClaim: (key, motebitId) => releaseIdempotency(moteDb.db, key, motebitId),
     getShuttingDown: config.getShuttingDown,
     getConnectionCount: () => getConnectionCount(),
     isDraining: () => draining,

--- a/services/relay/src/middleware.ts
+++ b/services/relay/src/middleware.ts
@@ -72,6 +72,14 @@ export interface MiddlewareDeps {
   verifySignedTokenForDevice: typeof verifySignedTokenForDevice;
   parseTokenPayloadUnsafe: typeof parseTokenPayloadUnsafe;
   healthCheckDeps?: HealthCheckDeps;
+  /**
+   * Release a claimed-but-uncompleted idempotency key when a handler
+   * throws after claiming it (#459) — wired by index.ts to
+   * `releaseIdempotency`. The claiming handler stamps ownership via
+   * `c.set("idempotencyClaim", …)`; the error boundary calls this so a
+   * failed submission never strands its key in 'processing'.
+   */
+  releaseIdempotencyClaim?: (key: string, motebitId: string) => void;
 }
 
 export interface MiddlewareResult {
@@ -559,6 +567,20 @@ export function registerMiddleware(deps: MiddlewareDeps): MiddlewareResult {
 
   // --- Error handler ---
   app.onError((err, c) => {
+    // #459: if THIS request claimed an idempotency key and then failed
+    // before completing it, release the claim — else the key is stranded
+    // in 'processing' and an honest same-key retry gets 409 until the 24h
+    // sweep. Ownership is stamped only by the claiming request, so a 409
+    // conflict on someone else's live claim never reaches here with a stamp.
+    const claim = c.get("idempotencyClaim" as never) as
+      { key: string; motebitId: string } | undefined;
+    if (claim != null && deps.releaseIdempotencyClaim != null) {
+      try {
+        deps.releaseIdempotencyClaim(claim.key, claim.motebitId);
+      } catch {
+        // Release is best-effort — the 24h sweep remains the backstop.
+      }
+    }
     if (err instanceof RelayError) {
       const status = err.statusCode as 400;
       if (err instanceof RateLimitError) {

--- a/services/relay/src/tasks.ts
+++ b/services/relay/src/tasks.ts
@@ -174,7 +174,15 @@ export interface TasksDeps {
   eventStore: EventStore;
   relayIdentity: RelayIdentity;
   connections: Map<string, ConnectedDevice[]>;
-  taskQueue: Map<string, TaskQueueEntry>;
+  /**
+   * The production queue is `TaskQueue` (SQLite-backed) whose indexed
+   * `countBySubmitter` the fairness check uses (#459 — the Map-iteration
+   * fallback is a full-table scan there). Tests may inject a plain Map;
+   * the check falls back to iteration, which is fine at test scale.
+   */
+  taskQueue: Map<string, TaskQueueEntry> & {
+    countBySubmitter?: (submitterId: string) => number;
+  };
   taskRouter: TaskRouter;
   issueCredentials: boolean;
   apiToken?: string;
@@ -1165,11 +1173,19 @@ export async function handleReceiptIngestion(
             .get(taskId) as
             { allocation_id: string; amount_locked: number; motebit_id: string } | undefined);
 
-      const fallbackUnitCost = isP2pTask ? 0 : getListingUnitCost(moteDb, receipt.motebit_id);
-      const grossAmount =
-        entry.price_snapshot ??
-        persistentAlloc?.amount_locked ??
-        (fallbackUnitCost > 0 ? toMicro(computeGrossAmount(fallbackUnitCost, platformFeeRate)) : 0);
+      // Receipt-time pricing honesty (#459): gross comes from what was
+      // actually HELD — the submission price snapshot or the locked
+      // allocation — never from the EXECUTING agent's listing. The removed
+      // fallback (getListingUnitCost over the receipt's signer) fired
+      // exactly when a task had NO snapshot and NO allocation (a zero-cost
+      // submission that never booked funds) and invented a gross that was
+      // never held: guaranteed `settlement.unfunded_skipped`, plus a full
+      // Ed25519 settlement-signing cost per attempt to produce an object
+      // that was then discarded (the constant gross=6316 in the 2026-07-29
+      // incident was web-search's summed listing, not any funded amount).
+      // No snapshot and no allocation ⇒ gross 0 — the honest free-task
+      // settlement.
+      const grossAmount = entry.price_snapshot ?? persistentAlloc?.amount_locked ?? 0;
 
       const settlementId = asSettlementId(crypto.randomUUID());
       const allocationId = persistentAlloc
@@ -1485,7 +1501,15 @@ export async function handleReceiptIngestion(
             originRelay: entry.origin_relay,
             note: "settlement driven by originating relay via /federation/v1/settlement/forward",
           });
-        } else {
+        } else if (settlementFunded) {
+          // Log honesty (#459): `settlement.created` fires ONLY when a
+          // settlement was actually recorded. During the 2026-07-29 incident
+          // this line sat outside the funded guard and reported the same
+          // in-memory gross that `settlement.unfunded_skipped` had just
+          // refused — the log stream claimed money movement that never
+          // happened, dozens of times per second. The multihop sibling
+          // (`multihop.settlement.created`) always had it right; the
+          // unfunded case's record is the unfunded_skipped line alone.
           logger.info("settlement.created", {
             correlationId: taskId,
             gross: settlement.amount_settled + settlement.platform_fee,
@@ -1874,6 +1898,12 @@ export async function registerTaskRoutes(deps: TasksDeps): Promise<void> {
         409,
       );
     }
+    // This request now OWNS the 'processing' claim. Stamp ownership so the
+    // error boundary can release it if the handler throws before
+    // completeIdempotency — else the key is stranded and an honest
+    // same-key retry gets 409 until the 24h sweep (#459). Set only on the
+    // claiming request; a conflict above never reaches this line.
+    c.set("idempotencyClaim" as never, { key: idempotencyKey, motebitId } as never);
 
     const body = await c.req.json<{
       prompt: string;
@@ -2062,23 +2092,35 @@ export async function registerTaskRoutes(deps: TasksDeps): Promise<void> {
       throw new TaskError("TASK_QUEUE_FULL", "Task queue at capacity — try again later", 503);
     }
 
-    // Per-submitter fairness: prevent a single agent from monopolizing queue capacity
+    // Per-submitter fairness: prevent a single agent from monopolizing queue
+    // capacity. Uses the O(1) indexed COUNT — the previous implementation
+    // iterated taskQueue.values(), which is a FULL-TABLE `SELECT *` plus a
+    // per-row JSON.parse on every submission (#459: during the 2026-07-29
+    // amplification incident this scan, growing with the queue it was
+    // guarding, was the largest single event-loop cost and helped starve
+    // the relay past its 2s health budget).
     if (submittedBy) {
-      let submitterCount = 0;
-      for (const entry of taskQueue.values()) {
-        if (entry.submitted_by === submittedBy) submitterCount++;
-        if (submitterCount >= maxTasksPerSubmitter) {
-          logger.warn("task.per_submitter_limit", {
-            correlationId: taskId,
-            submittedBy,
-            limit: maxTasksPerSubmitter,
-          });
-          throw new TaskError(
-            "TASK_PER_SUBMITTER_LIMIT",
-            "Too many pending tasks for this agent",
-            429,
-          );
+      let submitterCount: number;
+      if (typeof taskQueue.countBySubmitter === "function") {
+        submitterCount = taskQueue.countBySubmitter(submittedBy);
+      } else {
+        // Plain-Map injection (tests) — iteration is fine at that scale.
+        submitterCount = 0;
+        for (const entry of taskQueue.values()) {
+          if (entry.submitted_by === submittedBy) submitterCount++;
         }
+      }
+      if (submitterCount >= maxTasksPerSubmitter) {
+        logger.warn("task.per_submitter_limit", {
+          correlationId: taskId,
+          submittedBy,
+          limit: maxTasksPerSubmitter,
+        });
+        throw new TaskError(
+          "TASK_PER_SUBMITTER_LIMIT",
+          "Too many pending tasks for this agent",
+          429,
+        );
       }
     }
 
@@ -2589,6 +2631,15 @@ export async function registerTaskRoutes(deps: TasksDeps): Promise<void> {
             ? body.exclude_agents.filter((a): a is string => typeof a === "string")
             : [],
         );
+        // Self-exclusion (#459): capability ranking must NEVER select the
+        // SUBMITTER as its own worker. The 2026-07-29 amplification loop
+        // closed exactly here — web-search sub-delegated a read_url task,
+        // the target atom was down, ranking picked the other agent
+        // advertising read_url (the submitter itself), and the task
+        // round-tripped forever (submit → route-to-self → execute →
+        // sub-delegate again). Deliberate self-delegation stays available
+        // via explicit target_agent pinning — that path never ranks.
+        if (submittedBy) excludeSet.add(submittedBy);
         const eligibleProfiles =
           excludeSet.size > 0
             ? multiCapProfiles.filter((p) => !excludeSet.has(p.motebit_id))
@@ -3094,14 +3145,20 @@ export async function registerTaskRoutes(deps: TasksDeps): Promise<void> {
     if (!pinnedLocalHandled && !routed && !federationAttempted && requiredCaps.length > 0) {
       const now = Date.now();
       const capFilter = requiredCaps[0]!;
+      // Self-exclusion (#459): same rule as the scored path — the fallback
+      // must never route a task back to its own submitter (the second half
+      // of the 2026-07-29 routing cycle). Pinned self-delegation never
+      // reaches this query.
       const httpCandidate = moteDb.db
         .prepare(
           `SELECT r.motebit_id, r.endpoint_url FROM agent_registry r
            WHERE r.expires_at > ? AND r.endpoint_url != ''
+             AND r.motebit_id != ?
              AND EXISTS (SELECT 1 FROM json_each(r.capabilities) WHERE value = ?)
            LIMIT 1`,
         )
-        .get(now, capFilter) as { motebit_id: string; endpoint_url: string } | undefined;
+        .get(now, submittedBy ?? "", capFilter) as
+        { motebit_id: string; endpoint_url: string } | undefined;
       if (httpCandidate?.endpoint_url?.trim()) {
         void forwardTaskViaMcp(
           httpCandidate.endpoint_url,


### PR DESCRIPTION
Relay half of #459 (worker-side backoff/watchdog follows in the sibling PR). Full byte-level mechanics map on the issue — the loop was distributed: capability routing selected the SUBMITTER as its own worker, zero-cost submissions guaranteed the unfunded-skip signature, and the fairness check's full-table scan grew with the queue it guarded.

1. **Routing self-exclusion** — scored ranking + HTTP-MCP fallback can never select the task's own submitter (pinned self-delegation untouched; it never ranks). Severs the loop's closing edge.
2. **Receipt-time pricing honesty** — gross comes from what was HELD (snapshot or locked allocation); the listing fallback that priced never-allocated tasks from the EXECUTING agent's listing (the invented gross=6316) is removed. No snapshot + no allocation = honest $0 settlement.
3. **`settlement.created` gated on funded** — it reported money movement that never happened, dozens/sec (the multihop sibling always had it right).
4. **O(1) fairness count** — `countBySubmitter` (existed, indexed, never called) replaces the per-submission full-table `SELECT *` + JSON.parse scan, the storm's largest single event-loop cost.
5. **Idempotency claim release on failure** — a submission failing after claiming its key releases it via the error boundary (ownership stamped by the claiming request only); honest same-key retries proceed instead of 409ing for 24h.
6. **Health-check headroom** — 2s→5s timeout, 5s→15s grace; the fleet's tightest budget is what flapped the whole relay out of rotation.

**Proof**: 3 live-route tests shaped like the incident (self-exclusion with counting endpoints; $0-settlement honesty — fails pre-fix; same-key retry after a 402). Relay suite 1516 green. Merging auto-deploys the relay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)