### PR TITLE
fix(workers,ops): backoff, intent-stable idempotency, and self-restarting atoms — the worker half of #459

### DIFF
--- a/packages/mcp-server/src/__tests__/self-watchdog.test.ts
+++ b/packages/mcp-server/src/__tests__/self-watchdog.test.ts
@@ -1,0 +1,63 @@
+/**
+ * #459 ops leg: the self-watchdog turns "wedged-but-alive for 25 minutes
+ * until a human noticed" into "exits non-zero, platform restarts it".
+ * All seams injected — no real server, no real exit, no real timers
+ * (checkOnce is driven directly).
+ */
+import { describe, it, expect } from "vitest";
+import { startSelfWatchdog } from "../self-watchdog.js";
+
+function harness(responses: Array<"ok" | "fail" | "throw">) {
+  let i = 0;
+  const exits: number[] = [];
+  const logs: string[] = [];
+  const handle = startSelfWatchdog({
+    healthUrl: "http://127.0.0.1:9/health",
+    intervalMs: 1_000_000, // interval never fires in tests — checkOnce drives
+    maxConsecutiveFailures: 3,
+    fetchFn: (async () => {
+      const r = responses[Math.min(i++, responses.length - 1)]!;
+      if (r === "throw") throw new Error("ECONNREFUSED");
+      return { ok: r === "ok" } as Response;
+    }) as typeof fetch,
+    exitFn: (code) => exits.push(code),
+    log: (m) => logs.push(m),
+  });
+  return { handle, exits, logs };
+}
+
+describe("startSelfWatchdog", () => {
+  it("healthy checks never exit and reset the failure count", async () => {
+    const { handle, exits } = harness(["ok", "fail", "ok", "fail", "fail"]);
+    for (let n = 0; n < 5; n++) await handle.checkOnce();
+    expect(exits).toEqual([]);
+    expect(handle.consecutiveFailures).toBe(2); // fail,fail after the reset
+    handle.stop();
+  });
+
+  it("exits non-zero after maxConsecutiveFailures — the wedge becomes a restart", async () => {
+    const { handle, exits, logs } = harness(["throw", "throw", "throw"]);
+    await handle.checkOnce();
+    await handle.checkOnce();
+    expect(exits).toEqual([]);
+    await handle.checkOnce();
+    expect(exits).toEqual([1]);
+    expect(logs.join(" ")).toContain("self-watchdog");
+  });
+
+  it("a non-2xx self-response counts as a failure (unservable, not just unreachable)", async () => {
+    const { handle, exits } = harness(["fail", "fail", "fail"]);
+    for (let n = 0; n < 3; n++) await handle.checkOnce();
+    expect(exits).toEqual([1]);
+  });
+
+  it("stop() halts checking — no exit after shutdown", async () => {
+    const { handle, exits } = harness(["throw", "throw", "throw", "throw"]);
+    await handle.checkOnce();
+    handle.stop();
+    await handle.checkOnce();
+    await handle.checkOnce();
+    await handle.checkOnce();
+    expect(exits).toEqual([]);
+  });
+});

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -19,6 +19,7 @@ import {
   parseScopeSet,
 } from "@motebit/encryption";
 import type { DelegationToken } from "@motebit/encryption";
+import { startSelfWatchdog } from "./self-watchdog.js";
 
 // Re-export for consumers
 export type { MotebitServerDeps, McpServerConfig, InboundCredentialVerifier };
@@ -27,6 +28,7 @@ export { StaticTokenVerifier };
 
 // Service scaffold — eliminates boilerplate for service motebits
 export { wireServerDeps, startServiceServer } from "./service.js";
+export { startSelfWatchdog, type SelfWatchdogHandle } from "./self-watchdog.js";
 export { buildServiceReceipt } from "./build-receipt.js";
 export type { BuildServiceReceiptInput } from "./build-receipt.js";
 export { bootstrapAndEmitIdentity } from "./bootstrap-service.js";
@@ -308,6 +310,8 @@ export class McpServerAdapter {
   private config: McpServerConfig;
   private deps: MotebitServerDeps;
   private httpServer?: import("node:http").Server;
+  /** #459: loopback self-check that exits the process when unservable. */
+  private selfWatchdog?: import("./self-watchdog.js").SelfWatchdogHandle;
   private lastVerifiedCaller: CallerIdentity | null = null;
 
   /**
@@ -354,6 +358,8 @@ export class McpServerAdapter {
   }
 
   async stop(): Promise<void> {
+    this.selfWatchdog?.stop();
+    this.selfWatchdog = undefined;
     if (this.server !== null) await this.server.close();
     if (this.httpServer) {
       await new Promise<void>((resolve, reject) => {
@@ -1289,5 +1295,16 @@ export class McpServerAdapter {
         resolve();
       });
     });
+
+    // #459 ops leg: a wedged-but-alive atom sat unservable for ~25 minutes
+    // because Fly restarts on process EXIT, not on failing health checks.
+    // The watchdog self-checks over loopback and exits non-zero after
+    // repeated failures so the platform restart policy revives a healthy
+    // process. Opt-out via MOTEBIT_SELF_WATCHDOG=off (local dev/tests).
+    if (process.env["MOTEBIT_SELF_WATCHDOG"] !== "off") {
+      this.selfWatchdog = startSelfWatchdog({
+        healthUrl: `http://127.0.0.1:${port}/health`,
+      });
+    }
   }
 }

--- a/packages/mcp-server/src/self-watchdog.ts
+++ b/packages/mcp-server/src/self-watchdog.ts
@@ -1,0 +1,96 @@
+/**
+ * Atom self-watchdog (#459 — the ops leg of the settlement-amplification
+ * incident): `motebit-read-url` wedged post-deploy with its port
+ * unresponsive for ~25 minutes. Fly restarts a machine when the PROCESS
+ * exits — it does not restart on failing HTTP health checks — so a
+ * process that is alive-but-unservable sits wedged until a human
+ * intervenes, while downstream workers hammer it and the network degrades
+ * around the hole.
+ *
+ * The watchdog closes the loop from inside: it periodically fetches the
+ * server's OWN /health over loopback; after `maxConsecutiveFailures` the
+ * process exits non-zero, and the platform's restart policy revives it.
+ * A self-check over the real listening socket exercises the same accept
+ * path external traffic uses — if we cannot reach ourselves, neither can
+ * anyone else.
+ *
+ * Injectable seams (`fetchFn`, `exitFn`, timers via `intervalMs`) keep it
+ * fully testable without a real server or a real exit.
+ */
+
+export interface SelfWatchdogOptions {
+  /** The server's own health URL over loopback, e.g. http://127.0.0.1:3200/health */
+  healthUrl: string;
+  /** Check cadence. Default 60s. */
+  intervalMs?: number;
+  /** Per-check timeout. Default 5s. */
+  timeoutMs?: number;
+  /** Consecutive failures before exiting. Default 3. */
+  maxConsecutiveFailures?: number;
+  /** Injectable fetch (tests). */
+  fetchFn?: typeof fetch;
+  /** Injectable exit (tests). */
+  exitFn?: (code: number) => void;
+  /** Structured-ish logger. Default console.error. */
+  log?: (message: string) => void;
+}
+
+export interface SelfWatchdogHandle {
+  stop(): void;
+  /** Run one check now (exported for tests; the interval calls this). */
+  checkOnce(): Promise<void>;
+  readonly consecutiveFailures: number;
+}
+
+export function startSelfWatchdog(options: SelfWatchdogOptions): SelfWatchdogHandle {
+  const intervalMs = options.intervalMs ?? 60_000;
+  const timeoutMs = options.timeoutMs ?? 5_000;
+  const maxFailures = options.maxConsecutiveFailures ?? 3;
+  const fetchFn = options.fetchFn ?? fetch;
+  const exitFn = options.exitFn ?? ((code: number) => process.exit(code));
+  const log = options.log ?? ((m: string) => console.error(m));
+
+  let failures = 0;
+  let stopped = false;
+
+  const checkOnce = async (): Promise<void> => {
+    if (stopped) return;
+    try {
+      const res = await fetchFn(options.healthUrl, {
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (res.ok) {
+        failures = 0;
+        return;
+      }
+      failures++;
+    } catch {
+      failures++;
+    }
+    if (failures >= maxFailures) {
+      log(
+        `[motebit/mcp-server] self-watchdog: ${failures} consecutive failed self-checks on ${options.healthUrl} — exiting so the platform restart policy can revive a healthy process (#459)`,
+      );
+      stopped = true;
+      clearInterval(timer);
+      exitFn(1);
+    }
+  };
+
+  const timer = setInterval(() => {
+    void checkOnce();
+  }, intervalMs);
+  // Never keep the process alive solely for the watchdog.
+  timer.unref?.();
+
+  return {
+    stop() {
+      stopped = true;
+      clearInterval(timer);
+    },
+    checkOnce,
+    get consecutiveFailures() {
+      return failures;
+    },
+  };
+}

--- a/services/auditor/fly.toml
+++ b/services/auditor/fly.toml
@@ -40,3 +40,9 @@ kill_timeout = 5
   memory = "512mb"
   cpu_kind = "shared"
   cpus = 1
+
+# #459: a wedged-but-alive process exits via the mcp-server self-watchdog;
+# this policy makes Fly revive it instead of leaving the machine dead.
+[[restart]]
+  policy = "on-failure"
+  retries = 10

--- a/services/browser-sandbox/fly.toml
+++ b/services/browser-sandbox/fly.toml
@@ -56,3 +56,9 @@ kill_timeout = 10
   memory = "1024mb"
   cpu_kind = "shared"
   cpus = 1
+
+# #459: a wedged-but-alive process exits via the mcp-server self-watchdog;
+# this policy makes Fly revive it instead of leaving the machine dead.
+[[restart]]
+  policy = "on-failure"
+  retries = 10

--- a/services/clerk/fly.toml
+++ b/services/clerk/fly.toml
@@ -40,3 +40,9 @@ kill_timeout = 5
   memory = "512mb"
   cpu_kind = "shared"
   cpus = 1
+
+# #459: a wedged-but-alive process exits via the mcp-server self-watchdog;
+# this policy makes Fly revive it instead of leaving the machine dead.
+[[restart]]
+  policy = "on-failure"
+  retries = 10

--- a/services/code-review/fly.toml
+++ b/services/code-review/fly.toml
@@ -40,3 +40,9 @@ kill_timeout = 5
   memory = "512mb"
   cpu_kind = "shared"
   cpus = 1
+
+# #459: a wedged-but-alive process exits via the mcp-server self-watchdog;
+# this policy makes Fly revive it instead of leaving the machine dead.
+[[restart]]
+  policy = "on-failure"
+  retries = 10

--- a/services/embed/fly.toml
+++ b/services/embed/fly.toml
@@ -34,3 +34,9 @@ kill_timeout = 5
     path = "/health"
     protocol = "http"
     timeout = "2s"
+
+# #459: a wedged-but-alive process exits via the mcp-server self-watchdog;
+# this policy makes Fly revive it instead of leaving the machine dead.
+[[restart]]
+  policy = "on-failure"
+  retries = 10

--- a/services/read-url/fly.toml
+++ b/services/read-url/fly.toml
@@ -38,3 +38,9 @@ kill_timeout = 5
 [mounts]
   source = "read_url_data"
   destination = "/data"
+
+# #459: a wedged-but-alive process exits via the mcp-server self-watchdog;
+# this policy makes Fly revive it instead of leaving the machine dead.
+[[restart]]
+  policy = "on-failure"
+  retries = 10

--- a/services/research/fly.toml
+++ b/services/research/fly.toml
@@ -40,3 +40,9 @@ kill_timeout = 5
   memory = "512mb"
   cpu_kind = "shared"
   cpus = 1
+
+# #459: a wedged-but-alive process exits via the mcp-server self-watchdog;
+# this policy makes Fly revive it instead of leaving the machine dead.
+[[restart]]
+  policy = "on-failure"
+  retries = 10

--- a/services/research/src/research.ts
+++ b/services/research/src/research.ts
@@ -23,6 +23,7 @@
  * primitive; they should not reinvent the transport.
  */
 
+import { createHash } from "node:crypto";
 import Anthropic from "@anthropic-ai/sdk";
 import { McpClientAdapter } from "@motebit/mcp-client";
 import type { Citation, ExecutionReceipt } from "@motebit/sdk";
@@ -322,7 +323,15 @@ async function bindRelayBudget(
       headers: {
         Authorization: `Bearer ${config.apiToken}`,
         "Content-Type": "application/json",
-        "Idempotency-Key": crypto.randomUUID(),
+        // Intent-stable, not per-attempt (#459): the same logical sub-hop
+        // (caller × target × prompt) presents the same key, so a retry
+        // REPLAYS the relay's cached response instead of minting a new
+        // task per attempt (the fresh-UUID pattern defeated relay
+        // idempotency during the 2026-07-29 amplification incident).
+        "Idempotency-Key": `sub-${createHash("sha256")
+          .update(`${config.callerMotebitId}\n${targetMotebitId}\n${prompt}`)
+          .digest("hex")
+          .slice(0, 32)}`,
       },
       body: JSON.stringify({
         prompt,

--- a/services/summarize/fly.toml
+++ b/services/summarize/fly.toml
@@ -40,3 +40,9 @@ kill_timeout = 5
   memory = "512mb"
   cpu_kind = "shared"
   cpus = 1
+
+# #459: a wedged-but-alive process exits via the mcp-server self-watchdog;
+# this policy makes Fly revive it instead of leaving the machine dead.
+[[restart]]
+  policy = "on-failure"
+  retries = 10

--- a/services/web-search/fly.toml
+++ b/services/web-search/fly.toml
@@ -35,3 +35,9 @@ kill_timeout = 5
 [mounts]
   source = "web_search_data"
   destination = "/data"
+
+# #459: a wedged-but-alive process exits via the mcp-server self-watchdog;
+# this policy makes Fly revive it instead of leaving the machine dead.
+[[restart]]
+  policy = "on-failure"
+  retries = 10

--- a/services/web-search/src/__tests__/sub-delegate-circuit.test.ts
+++ b/services/web-search/src/__tests__/sub-delegate-circuit.test.ts
@@ -1,0 +1,59 @@
+/**
+ * #459: the sub-delegation failure circuit and the intent-stable
+ * idempotency key — the two client-side halves of the amplification fix.
+ * During the incident this service retried a down peer as fast as each
+ * handler turn completed, minting a fresh relay task per attempt.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  recordSubDelegateOutcome,
+  resetSubDelegateCircuitForTest,
+  subDelegateCircuitState,
+  stableSubmissionKey,
+  SUB_DELEGATE_MAX_CONSECUTIVE_FAILURES,
+  SUB_DELEGATE_COOLDOWN_MS,
+} from "../index.js";
+
+describe("sub-delegation failure circuit", () => {
+  beforeEach(() => {
+    resetSubDelegateCircuitForTest();
+  });
+
+  it("opens the cooldown at the consecutive-failure ceiling", () => {
+    const now = 1_000_000;
+    for (let i = 0; i < SUB_DELEGATE_MAX_CONSECUTIVE_FAILURES - 1; i++) {
+      recordSubDelegateOutcome(false, now);
+      expect(subDelegateCircuitState().cooldownUntil).toBe(0);
+    }
+    recordSubDelegateOutcome(false, now);
+    expect(subDelegateCircuitState().cooldownUntil).toBe(now + SUB_DELEGATE_COOLDOWN_MS);
+  });
+
+  it("one success closes the circuit and clears the count", () => {
+    recordSubDelegateOutcome(false, 1000);
+    recordSubDelegateOutcome(false, 1000);
+    recordSubDelegateOutcome(true, 2000);
+    expect(subDelegateCircuitState()).toEqual({ failures: 0, cooldownUntil: 0 });
+  });
+
+  it("failures below the ceiling never open the cooldown", () => {
+    recordSubDelegateOutcome(false, 1000);
+    expect(subDelegateCircuitState().cooldownUntil).toBe(0);
+  });
+});
+
+describe("stableSubmissionKey (#459 — retries replay, never mint new tasks)", () => {
+  it("identical intent → identical key (the anti-amplification property)", () => {
+    const a = stableSubmissionKey("caller-1", "target-1", "read https://example.com");
+    const b = stableSubmissionKey("caller-1", "target-1", "read https://example.com");
+    expect(a).toBe(b);
+    expect(a).toMatch(/^sub-[0-9a-f]{32}$/);
+  });
+
+  it("any component change → different key (no cross-intent replay)", () => {
+    const base = stableSubmissionKey("caller-1", "target-1", "read https://example.com");
+    expect(stableSubmissionKey("caller-2", "target-1", "read https://example.com")).not.toBe(base);
+    expect(stableSubmissionKey("caller-1", "target-2", "read https://example.com")).not.toBe(base);
+    expect(stableSubmissionKey("caller-1", "target-1", "read https://other.io")).not.toBe(base);
+  });
+});

--- a/services/web-search/src/index.ts
+++ b/services/web-search/src/index.ts
@@ -13,6 +13,7 @@
  * handleAgentTask that runs web_search and optionally sub-delegates
  * read_url to a downstream atom.
  */
+import { createHash } from "node:crypto";
 
 import {
   InMemoryToolRegistry,
@@ -54,6 +55,58 @@ function log(msg: string): void {
  * is reinvented — see CLAUDE.md "Protocol primitives belong in
  * packages, never inline in services" for the doctrine.
  */
+// #459: sub-delegation failure circuit. During the 2026-07-29 incident this
+// path retried a down read-url atom as fast as each handler turn completed —
+// no backoff, no ceiling — creating a fresh relay task per attempt and
+// feeding the settlement-amplification storm. The circuit is deliberately
+// simple: consecutive failures open a cooldown during which subDelegate
+// returns null IMMEDIATELY (before the relay-task POST, so no task is
+// created either); one success closes it. Exported for tests; `nowFn`
+// injectable so the cooldown is deterministic under test.
+export const SUB_DELEGATE_MAX_CONSECUTIVE_FAILURES = 3;
+export const SUB_DELEGATE_COOLDOWN_MS = 60_000;
+let subDelegateConsecutiveFailures = 0;
+let subDelegateCooldownUntil = 0;
+
+export function subDelegateCircuitState(): { failures: number; cooldownUntil: number } {
+  return { failures: subDelegateConsecutiveFailures, cooldownUntil: subDelegateCooldownUntil };
+}
+
+export function resetSubDelegateCircuitForTest(): void {
+  subDelegateConsecutiveFailures = 0;
+  subDelegateCooldownUntil = 0;
+}
+
+/**
+ * Stable intent-derived Idempotency-Key (#459): the same logical
+ * sub-delegation (caller × target × prompt) always presents the SAME key,
+ * so a retry REPLAYS the relay's cached response instead of minting a
+ * brand-new task per attempt — the fresh-UUID-per-attempt pattern is what
+ * made every retry a distinct task/allocation/settlement during the
+ * incident and defeated the relay's idempotency entirely. Safe now that a
+ * failed submission releases its claim relay-side (same arc).
+ */
+export function stableSubmissionKey(caller: string, target: string, prompt: string): string {
+  const digest = createHash("sha256").update(`${caller}\n${target}\n${prompt}`).digest("hex");
+  return `sub-${digest.slice(0, 32)}`;
+}
+
+/** Record one sub-delegation outcome; opens the cooldown at the ceiling. */
+export function recordSubDelegateOutcome(ok: boolean, nowMs: number): void {
+  if (ok) {
+    subDelegateConsecutiveFailures = 0;
+    subDelegateCooldownUntil = 0;
+    return;
+  }
+  subDelegateConsecutiveFailures++;
+  if (subDelegateConsecutiveFailures >= SUB_DELEGATE_MAX_CONSECUTIVE_FAILURES) {
+    subDelegateCooldownUntil = nowMs + SUB_DELEGATE_COOLDOWN_MS;
+    log(
+      `sub-delegation circuit OPEN — ${subDelegateConsecutiveFailures} consecutive failures; cooling down ${SUB_DELEGATE_COOLDOWN_MS / 1000}s`,
+    );
+  }
+}
+
 async function subDelegate(
   mcpUrl: string,
   prompt: string,
@@ -67,6 +120,13 @@ async function subDelegate(
   /** Target motebit ID for relay task submission. */
   targetMotebitId?: string,
 ): Promise<ExecutionReceipt | null> {
+  // Circuit check FIRST — during cooldown, no relay task is created and the
+  // down peer is left alone (#459).
+  if (Date.now() < subDelegateCooldownUntil) {
+    log("sub-delegation skipped — circuit cooling down after consecutive failures");
+    return null;
+  }
+
   // Optional relay budget binding — best-effort, failures don't block the chain
   let subRelayTaskId: string | undefined;
   if (syncUrl != null && syncUrl !== "" && apiToken != null && targetMotebitId != null) {
@@ -76,7 +136,9 @@ async function subDelegate(
         headers: {
           Authorization: `Bearer ${apiToken}`,
           "Content-Type": "application/json",
-          "Idempotency-Key": crypto.randomUUID(),
+          // Intent-stable, not per-attempt (#459) — retries replay, never
+          // mint a new task.
+          "Idempotency-Key": stableSubmissionKey(callerMotebitId, targetMotebitId, prompt),
         },
         body: JSON.stringify({
           prompt,
@@ -114,10 +176,12 @@ async function subDelegate(
     if (subRelayTaskId != null) args.relay_task_id = subRelayTaskId;
     await adapter.executeTool("read-url__motebit_task", args);
     const receipts = adapter.getAndResetDelegationReceipts();
+    recordSubDelegateOutcome(true, Date.now());
     return receipts[0] ?? null;
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     log(`sub-delegation failed: ${msg}`);
+    recordSubDelegateOutcome(false, Date.now());
     return null;
   } finally {
     await adapter.disconnect().catch(() => {


### PR DESCRIPTION
Worker+ops half of #459 (relay half: #464). Closes #459 when both land.

1. **web-search sub-delegation failure circuit** — 3 consecutive failures open a 60s cooldown during which `subDelegate` returns immediately, BEFORE the relay-task POST: a down peer costs zero tasks and zero hammering. One success closes it.
2. **Intent-stable Idempotency-Keys** (web-search + research) — the same logical sub-hop (caller × target × prompt) presents the SAME key, so retries REPLAY the relay's cached response instead of minting a new task per attempt. Safe now that #464 releases a failed submission's claim.
3. **mcp-server self-watchdog** (all atoms at once) — loopback self-check of the atom's own `/health`; 3 consecutive failures exit non-zero. Fly restarts on process EXIT, not failing health checks — read-url sat wedged-but-alive ~25 minutes. Opt-out `MOTEBIT_SELF_WATCHDOG=off`.
4. **`[[restart]] policy = on-failure`** in all nine atom fly.tomls — none declared any restart policy; the watchdog's exit now reliably becomes a revival.

**Proof**: 4 watchdog + 5 circuit/key tests; mcp-server 173 / web-search 20 / research 45 green (research at its 100%-branch bar); tsc clean. Merging auto-deploys the touched services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)