### PR TITLE
fix(relay): account-family routes name one audience across both auth layers (#460)

### DIFF
--- a/services/relay/src/__tests__/account-family-auth.test.ts
+++ b/services/relay/src/__tests__/account-family-auth.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Account-family route auth (#460) — the regression lock for the
+ * double-wrap audience conflict witnessed live 2026-07-29.
+ *
+ * Two auth layers wrap `/api/v1/agents/:id/{balance,withdraw,withdrawals,
+ * checkout,settlements}`: the early agent-family middleware (agents.ts)
+ * and the dedicated `dualAuth(account:*)` guards (middleware.ts). Before
+ * this fix the family middleware fell through to its `admin:query`
+ * default for the account routes, so the two layers demanded DIFFERENT
+ * audiences of the same bearer — no device token could satisfy the
+ * composition, and every sovereign `balance` read 401'd
+ * (composition-preserves-enforcement, inverse flavor: each layer
+ * individually correct, the composition severs the legitimate path).
+ *
+ * The audience fix also un-masks a second latent hole this suite locks:
+ * the account handlers had no first-person own-id check, so once
+ * account:* tokens could reach them, agent A could read agent B's
+ * balance or POST a withdraw against B's account with a self-supplied
+ * destination. Device tokens are now first-person; master token remains
+ * the operator bypass.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { SyncRelay } from "../index.js";
+// eslint-disable-next-line no-restricted-imports -- tests need direct crypto
+import { generateKeypair, bytesToHex, mintAudienceToken } from "@motebit/crypto";
+import type { TokenAudience } from "@motebit/protocol";
+import { createTestRelay, JSON_AUTH, AUTH_HEADER, seedBalance } from "./test-helpers.js";
+
+async function seedAgent(relay: SyncRelay): Promise<{
+  motebitId: string;
+  deviceId: string;
+  privateKey: Uint8Array;
+}> {
+  const kp = await generateKeypair();
+  const idRes = await relay.app.request("/identity", {
+    method: "POST",
+    headers: JSON_AUTH,
+    body: JSON.stringify({ owner_id: `owner-${crypto.randomUUID()}` }),
+  });
+  const { motebit_id } = (await idRes.json()) as { motebit_id: string };
+  const devRes = await relay.app.request("/device/register", {
+    method: "POST",
+    headers: JSON_AUTH,
+    body: JSON.stringify({ motebit_id, device_name: "T", public_key: bytesToHex(kp.publicKey) }),
+  });
+  const { device_id } = (await devRes.json()) as { device_id: string };
+  return { motebitId: motebit_id, deviceId: device_id, privateKey: kp.privateKey };
+}
+
+async function mint(
+  a: { motebitId: string; deviceId: string; privateKey: Uint8Array },
+  aud: TokenAudience,
+): Promise<string> {
+  const { token } = await mintAudienceToken(
+    { mid: a.motebitId, did: a.deviceId, aud },
+    a.privateKey,
+  );
+  return token;
+}
+
+describe("account-family route auth (#460 double-wrap regression lock)", () => {
+  let relay: SyncRelay;
+
+  beforeEach(async () => {
+    relay = await createTestRelay();
+  });
+
+  afterEach(async () => {
+    await relay.close();
+  });
+
+  it("GET /balance with the caller's own account:balance device token → 200 (the live #460 repro)", async () => {
+    const agent = await seedAgent(relay);
+    seedBalance(relay, agent.motebitId, 1);
+    const token = await mint(agent, "account:balance");
+    const res = await relay.app.request(`/api/v1/agents/${agent.motebitId}/balance`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { motebit_id: string; balance: number };
+    expect(body.motebit_id).toBe(agent.motebitId);
+    expect(body.balance).toBe(1);
+  });
+
+  it("GET /balance with an admin:query token → 401 (audience binding still enforced)", async () => {
+    const agent = await seedAgent(relay);
+    const token = await mint(agent, "admin:query");
+    const res = await relay.app.request(`/api/v1/agents/${agent.motebitId}/balance`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /balance for ANOTHER agent with a valid account:balance token → 403 (first-person)", async () => {
+    const alice = await seedAgent(relay);
+    const bob = await seedAgent(relay);
+    seedBalance(relay, bob.motebitId, 5);
+    const token = await mint(alice, "account:balance");
+    const res = await relay.app.request(`/api/v1/agents/${bob.motebitId}/balance`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("POST /withdraw against ANOTHER agent's account → 403 (fund-drain lock)", async () => {
+    const alice = await seedAgent(relay);
+    const bob = await seedAgent(relay);
+    seedBalance(relay, bob.motebitId, 5);
+    const token = await mint(alice, "account:withdraw");
+    const res = await relay.app.request(`/api/v1/agents/${bob.motebitId}/withdraw`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "Idempotency-Key": crypto.randomUUID(),
+      },
+      body: JSON.stringify({
+        amount: 5,
+        destination: "AttackerAddr11111111111111111111111111111111",
+      }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("POST /withdraw with the caller's own account:withdraw token passes both auth layers", async () => {
+    const agent = await seedAgent(relay);
+    seedBalance(relay, agent.motebitId, 5);
+    const token = await mint(agent, "account:withdraw");
+    const res = await relay.app.request(`/api/v1/agents/${agent.motebitId}/withdraw`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "Idempotency-Key": crypto.randomUUID(),
+      },
+      body: JSON.stringify({ amount: 1 }),
+    });
+    // Not 401/403 — auth composed; outcome depends on withdrawal rails.
+    expect([200, 201, 402]).toContain(res.status);
+  });
+
+  it("GET /withdrawals own token → 200; other's → 403", async () => {
+    const alice = await seedAgent(relay);
+    const bob = await seedAgent(relay);
+    const own = await relay.app.request(`/api/v1/agents/${alice.motebitId}/withdrawals`, {
+      headers: { Authorization: `Bearer ${await mint(alice, "account:withdrawals")}` },
+    });
+    expect(own.status).toBe(200);
+    const cross = await relay.app.request(`/api/v1/agents/${bob.motebitId}/withdrawals`, {
+      headers: { Authorization: `Bearer ${await mint(alice, "account:withdrawals")}` },
+    });
+    expect(cross.status).toBe(403);
+  });
+
+  it("GET /settlements still requires auth after the carve-out removal", async () => {
+    const agent = await seedAgent(relay);
+    const anon = await relay.app.request(`/api/v1/agents/${agent.motebitId}/settlements`);
+    expect(anon.status).toBe(401);
+    const authed = await relay.app.request(`/api/v1/agents/${agent.motebitId}/settlements`, {
+      headers: { Authorization: `Bearer ${await mint(agent, "account:balance")}` },
+    });
+    expect(authed.status).toBe(200);
+  });
+
+  it("master token still reads any balance (operator console bypass)", async () => {
+    const agent = await seedAgent(relay);
+    seedBalance(relay, agent.motebitId, 2);
+    const res = await relay.app.request(`/api/v1/agents/${agent.motebitId}/balance`, {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/services/relay/src/agents.ts
+++ b/services/relay/src/agents.ts
@@ -394,6 +394,8 @@ export interface AgentsDeps {
     expectedAudience: TokenAudience,
     blacklistCheck?: (jti: string, motebitId: string) => boolean,
     agentRevokedCheck?: (motebitId: string) => boolean,
+    agentKeyLookup?: (motebitId: string) => string | null,
+    onReject?: (reason: string) => void,
   ) => Promise<boolean>;
   isTokenBlacklisted: (jti: string, motebitId: string) => boolean;
   isAgentRevoked: (motebitId: string) => boolean;
@@ -467,16 +469,17 @@ export const PUBLIC_AGENT_ROUTES: ReadonlyArray<{
       "counterparty checks an agent can cover an amount BEFORE transacting, " +
       "which requires no pre-existing auth (sibling of succession).",
   },
-  {
-    match: (p, m) => p.endsWith("/settlements") && m === "GET",
-    reason:
-      "settlements (GET): owner-private financial history, but enforced by " +
-      "its OWN dedicated dualAuth(account:balance) in middleware.ts (same " +
-      "class as /balance) + the handler's first-person own-id check. This " +
-      "agent-middleware carve-out DEFERS to that dualAuth — removing it would " +
-      "double-wrap the route (admin:query here vs account:balance there) and " +
-      "conflict. Not public: account:balance-authed, caller===:motebitId.",
-  },
+  // NOTE (#460): /settlements previously sat here as a carve-out DEFERRING to
+  // its dedicated dualAuth(account:balance) in middleware.ts. That shape had
+  // two flaws: (1) on a deploy with no apiToken configured, registerAuthMiddleware
+  // registers NOTHING, so the carve-out made owner-private financial history
+  // public; (2) its siblings (/balance, /withdraw, /withdrawals, /checkout)
+  // never got the carve-out, so this middleware's admin:query default and
+  // middleware.ts's account:* dualAuth demanded two different audiences of the
+  // same bearer — no device token could satisfy both, and every sovereign
+  // balance read 401'd (witnessed live 2026-07-29). The account family is now
+  // a route-family branch below: both layers agree on the audience, and auth
+  // holds even when the dedicated dualAuth layer is absent.
 ];
 
 /**
@@ -525,7 +528,13 @@ export function registerAgentAuthMiddleware(deps: AgentAuthMiddlewareDeps): void
       throw new HTTPException(401, { message: "Invalid token" });
     }
 
-    // Expected audience by route family.
+    // Expected audience by route family. The account family (balance /
+    // settlements / withdraw / withdrawals / checkout) MUST name the same
+    // audience middleware.ts's dedicated dualAuth expects — the two layers
+    // both wrap these routes, and a disagreement means no device token can
+    // ever satisfy the composition (#460: the admin:query default here vs
+    // account:balance there 401'd every sovereign balance read). Terminal
+    // segments use endsWith — `/withdrawals` contains `/withdraw`.
     let agentAudience: TokenAudience;
     if (path.includes("/p2p-eligibility")) {
       agentAudience = "market:listing";
@@ -539,6 +548,14 @@ export function registerAgentAuthMiddleware(deps: AgentAuthMiddlewareDeps): void
       agentAudience = "proxy:token";
     } else if (path.includes("/receipts")) {
       agentAudience = "receipts:read";
+    } else if (path.endsWith("/balance") || path.endsWith("/settlements")) {
+      agentAudience = "account:balance";
+    } else if (path.endsWith("/withdrawals")) {
+      agentAudience = "account:withdrawals";
+    } else if (path.endsWith("/withdraw")) {
+      agentAudience = "account:withdraw";
+    } else if (path.endsWith("/checkout")) {
+      agentAudience = "account:checkout";
     } else {
       agentAudience = "admin:query";
     }
@@ -550,6 +567,17 @@ export function registerAgentAuthMiddleware(deps: AgentAuthMiddlewareDeps): void
       agentAudience,
       isTokenBlacklisted,
       isAgentRevoked,
+      undefined,
+      // Rejection legibility (#460): this second auth layer rejecting
+      // silently is exactly what made the balance 401 undiagnosable — the
+      // dedicated dualAuth logged nothing because it never rejected.
+      (reason) =>
+        logger.warn("auth.agent_token_rejected", {
+          reason,
+          expectedAudience: agentAudience,
+          mid: claims.mid,
+          path,
+        }),
     );
     if (!valid) {
       throw new HTTPException(401, { message: "Token verification failed" });

--- a/services/relay/src/budget.ts
+++ b/services/relay/src/budget.ts
@@ -182,10 +182,28 @@ export function registerBudgetRoutes(deps: BudgetDeps): void {
   // detector and the Stripe webhook, both via `creditAccount` server-side.
   // Tests seed via `seedBalance` (test-helpers), not an HTTP money route.
 
+  // First-person own-id check for the account family (#460). The account:*
+  // audiences prove the caller controls SOME registered device key — they
+  // bind the token to the caller's own mid, not to the :motebitId in the
+  // path. Without this check, any authenticated agent could read another
+  // agent's balance/transactions or, worse, POST a withdraw against another
+  // agent's account with a self-supplied destination. A master token
+  // (callerMotebitId unset) bypasses for the operator console — the same
+  // shape as the /settlements handler in state-export.ts.
+  const requireFirstPerson = (c: Context, motebitId: string, what: string): void => {
+    const callerMotebitId = c.get("callerMotebitId" as never) as string | undefined;
+    if (callerMotebitId != null && callerMotebitId !== "" && callerMotebitId !== motebitId) {
+      throw new HTTPException(403, {
+        message: `${what} is first-person: a device token may act only on its own motebit's account`,
+      });
+    }
+  };
+
   // --- Balance ---
   /** @internal */
   app.get("/api/v1/agents/:motebitId/balance", (c) => {
     const motebitId = c.req.param("motebitId");
+    requireFirstPerson(c, motebitId, "balance");
     const account = getAccountBalance(moteDb.db, motebitId);
     if (!account)
       return c.json({
@@ -228,6 +246,7 @@ export function registerBudgetRoutes(deps: BudgetDeps): void {
   /** @internal */
   app.post("/api/v1/agents/:motebitId/withdraw", async (c) => {
     const motebitId = c.req.param("motebitId");
+    requireFirstPerson(c, motebitId, "withdraw");
     const correlationId = c.get("correlationId" as never) as string;
 
     // Idempotency key required for financial operations
@@ -514,6 +533,7 @@ export function registerBudgetRoutes(deps: BudgetDeps): void {
   /** @internal */
   app.get("/api/v1/agents/:motebitId/withdrawals", (c) => {
     const motebitId = c.req.param("motebitId");
+    requireFirstPerson(c, motebitId, "withdrawal history");
     const withdrawals = getWithdrawals(moteDb.db, motebitId, 50).map((w) =>
       toWithdrawalRecord(w, relayIdentity.relayMotebitId),
     );
@@ -712,6 +732,7 @@ export function registerBudgetRoutes(deps: BudgetDeps): void {
       throw new HTTPException(501, { message: "Stripe is not configured on this relay" });
 
     const motebitId = c.req.param("motebitId");
+    requireFirstPerson(c, motebitId, "checkout");
     const correlationId = c.get("correlationId" as never) as string;
     const body = await c.req.json<{ amount: number; return_url?: string }>();
     if (typeof body.amount !== "number" || body.amount <= 0)


### PR DESCRIPTION
## The live bug (#460)

Every sovereign `balance` read in the REPL returned 401 — with **zero server-side trace**. Diagnosed live 2026-07-29 via a controlled repro (minted the exact `account:balance` device token the REPL mints; same 401; relay silent).

## Root cause: double-wrap audience conflict

Two auth layers wrap `/api/v1/agents/:id/{balance,withdraw,withdrawals,checkout}`:
1. the early agent-family middleware (`agents.ts`) — fell through to its `admin:query` **default** for these paths,
2. the dedicated `dualAuth(account:*)` guards (`middleware.ts`) — demanding `account:balance` etc.

No single device token can carry two audiences, so the composition rejected every legitimate call — the account family was accidentally master-only. `/settlements` dodged this via a carve-out that was itself a latent hole: on a deploy with no `apiToken`, `registerAuthMiddleware` registers nothing and the carve-out made owner-private financial history public. A composition-preserves-enforcement instance in the inverse flavor: each layer individually correct, the composition severs the legitimate path.

## Fix

- **agents.ts** — the account family becomes a route-family branch (`/balance`+`/settlements` → `account:balance`, `/withdrawals` → `account:withdrawals`, `/withdraw` → `account:withdraw`, `/checkout` → `account:checkout`; `endsWith` because `/withdrawals` contains `/withdraw`). The `/settlements` carve-out is removed — auth now holds even when the dedicated dualAuth layer is absent. The second layer's verify gains the #461 `onReject` logging (`auth.agent_token_rejected`) — its silence is exactly what made this undiagnosable.
- **budget.ts** — first-person own-id checks on all four handlers. The audience fix un-masks handlers that never compared caller to path: without this, any authenticated agent could read another agent's balance/transactions or POST a withdraw against another agent's account with a self-supplied destination. Master token (`callerMotebitId` unset) stays the operator bypass, mirroring `state-export.ts`.

## Tests

`account-family-auth.test.ts` drives the real app: the live #460 repro (own `account:balance` token → 200), audience binding still enforced (`admin:query` → 401), cross-agent 403s on balance/withdraw/withdrawals (the fund-drain lock), settlements still authed post-carve-out-removal, master-token bypass intact. Full relay suite: 1524 passed. Gates `check-agent-route-auth` + `check-audience-canonical` green.

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)