### PR TITLE
fix(runtime,cli): approval lifecycle is single-writer and every transition renders (#462)

### DIFF
--- a/.changeset/approval-lifecycle-single-writer.md
+++ b/.changeset/approval-lifecycle-single-writer.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+Pending approvals can no longer be voided or resolved by other actors invisibly. A new user turn that sets aside a pending approval now renders the void on both surfaces (typed `approval_voided` chunk + `onApprovalVoided` callback) and is never recorded as a refusal; proactive turns refuse to start instead of voiding human consent; resume/vote hold the single-writer turn lock; and the goals scheduler resolves only the approval it owns (bound by the gate's `tool_call_id`), never whatever happens to be pending.

--- a/apps/cli/src/__tests__/scheduler-approvals.test.ts
+++ b/apps/cli/src/__tests__/scheduler-approvals.test.ts
@@ -41,6 +41,10 @@ interface MockRuntimeResult {
   runtime: MotebitRuntime;
   registeredTools: Map<string, ToolHandler>;
   eventsAppended: Array<{ event_type: string; payload: Record<string, unknown> }>;
+  /** Every resumeAfterApproval invocation's `approved` argument (#462 binding assertions). */
+  resumeCalls: boolean[];
+  /** Simulate the runtime's pending approval being REPLACED by another actor's (#462). */
+  setPendingToolCallId: (id: string) => void;
 }
 
 function createMockRuntime(
@@ -52,6 +56,8 @@ function createMockRuntime(
   } = {},
 ): MockRuntimeResult {
   let _hasPending = false;
+  let _pendingToolCallId = "tc-1";
+  const resumeCalls: boolean[] = [];
   const registeredTools = new Map<string, ToolHandler>();
   const eventsAppended: Array<{ event_type: string; payload: Record<string, unknown> }> = [];
 
@@ -61,7 +67,11 @@ function createMockRuntime(
     },
     get pendingApprovalInfo() {
       return _hasPending
-        ? { toolName: opts.approvalToolName ?? "shell_exec", args: opts.approvalArgs ?? {} }
+        ? {
+            toolName: opts.approvalToolName ?? "shell_exec",
+            args: opts.approvalArgs ?? {},
+            toolCallId: _pendingToolCallId,
+          }
         : null;
     },
     async *sendMessageStreaming(_text: string): AsyncGenerator<StreamChunk> {
@@ -83,6 +93,7 @@ function createMockRuntime(
       yield { type: "result" as const, result: makeMockTurnResult() };
     },
     async *resumeAfterApproval(approved: boolean): AsyncGenerator<StreamChunk> {
+      resumeCalls.push(approved);
       _hasPending = false;
       if (approved) {
         yield { type: "tool_status" as const, name: "shell_exec", status: "calling" as const };
@@ -135,7 +146,15 @@ function createMockRuntime(
     consolidationCycle: vi.fn().mockResolvedValue(undefined),
   } as unknown as MotebitRuntime;
 
-  return { runtime, registeredTools, eventsAppended };
+  return {
+    runtime,
+    registeredTools,
+    eventsAppended,
+    resumeCalls,
+    setPendingToolCallId: (id: string) => {
+      _pendingToolCallId = id;
+    },
+  };
 }
 
 function makeGoal(overrides: Partial<Goal> = {}): Goal {
@@ -469,5 +488,98 @@ describe("GoalScheduler — orphan approval cleanup on start", () => {
 
     const a = moteDb.approvalStore.get("resolved-1");
     expect(a!.status).toBe("approved");
+  });
+});
+
+describe("GoalScheduler — approval resolution is bound to the owned toolCallId (#462)", () => {
+  let moteDb: MotebitDatabase;
+
+  beforeEach(() => {
+    moteDb = createMotebitDatabase(":memory:");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  function makeScheduler(runtime: MotebitRuntime): GoalScheduler {
+    const scheduler = new GoalScheduler(
+      runtime,
+      moteDb.goalStore,
+      moteDb.approvalStore,
+      moteDb.goalOutcomeStore,
+      "mote-test",
+      RiskLevel.R3_EXECUTE,
+    );
+    scheduler.registerGoalTools();
+    return scheduler;
+  }
+
+  it("drains a resolved approval by resuming the runtime it OWNS", async () => {
+    const mock = createMockRuntime({ yieldApproval: true });
+    moteDb.goalStore.add(makeGoal());
+    const scheduler = makeScheduler(mock.runtime);
+    await scheduler.tickOnce();
+
+    const approvalId = moteDb.approvalStore.listAll("mote-test")[0]!.approval_id;
+    moteDb.approvalStore.resolve(approvalId, "approved");
+
+    await scheduler.tickOnce();
+    // The suspended turn's toolCallId (tc-1, from the approval_request chunk)
+    // matches the runtime's pending — resume happened, with the verdict.
+    // (hasPendingApproval is not asserted: the always-due goal re-runs in the
+    // same tick and suspends anew — the resumeCalls record is the contract.)
+    expect(mock.resumeCalls).toEqual([true]);
+  });
+
+  it("NEVER resumes when the runtime's pending approval belongs to another actor", async () => {
+    const mock = createMockRuntime({ yieldApproval: true });
+    moteDb.goalStore.add(makeGoal());
+    const scheduler = makeScheduler(mock.runtime);
+    await scheduler.tickOnce();
+
+    const approvalId = moteDb.approvalStore.listAll("mote-test")[0]!.approval_id;
+    moteDb.approvalStore.resolve(approvalId, "approved");
+
+    // Another actor's approval is now pending in the runtime — in a
+    // daemon-coordinated setup this can be a HUMAN's live money prompt.
+    mock.setPendingToolCallId("someone-elses-approval");
+
+    await scheduler.tickOnce();
+    // The stored verdict must NOT be applied to the foreign approval.
+    expect(mock.resumeCalls).toEqual([]);
+    expect(mock.runtime.hasPendingApproval).toBe(true);
+  });
+
+  it("expiry deny-release also skips a foreign pending approval", async () => {
+    const mock = createMockRuntime({ yieldApproval: true });
+    moteDb.goalStore.add(makeGoal());
+    const scheduler = makeScheduler(mock.runtime);
+    await scheduler.tickOnce();
+
+    // Force the stored approval past its TTL, and replace the runtime's
+    // pending with another actor's.
+    const approvalId = moteDb.approvalStore.listAll("mote-test")[0]!.approval_id;
+    moteDb.approvalStore.expireStale(Date.now() + 100 * 3_600_000);
+    mock.setPendingToolCallId("someone-elses-approval");
+
+    await scheduler.tickOnce();
+    // The scheduler's record is expired and cleaned up…
+    expect(moteDb.approvalStore.get(approvalId)!.status).toBe("expired");
+    // …but the foreign pending approval was NOT denied to "release" it.
+    expect(mock.resumeCalls).toEqual([]);
+    expect(mock.runtime.hasPendingApproval).toBe(true);
+  });
+
+  it("expiry deny-release DOES release the runtime when the pending approval is its own", async () => {
+    const mock = createMockRuntime({ yieldApproval: true });
+    moteDb.goalStore.add(makeGoal());
+    const scheduler = makeScheduler(mock.runtime);
+    await scheduler.tickOnce();
+
+    moteDb.approvalStore.expireStale(Date.now() + 100 * 3_600_000);
+
+    await scheduler.tickOnce();
+    expect(mock.resumeCalls).toEqual([false]);
   });
 });

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -770,6 +770,16 @@ async function main(): Promise<void> {
     );
   });
 
+  // #462: when another actor's new turn voids a pending approval (an
+  // attached frontend chatting through the runtime-host coordinator, or a
+  // new message on this surface), the surface that OWNS the voided prompt
+  // must hear it — the voiding turn's stream renders elsewhere.
+  runtime.onApprovalVoided((toolName) => {
+    console.log(
+      `\n  ${warn(`[a new message set aside the pending approval for ${toolName} — nothing was executed]`)}\n  ${dim("(not a refusal; it can be proposed again)")}`,
+    );
+  });
+
   // Connect MCP servers
   let mcpAdapters: Awaited<ReturnType<typeof connectMcpServers>> = [];
   if (mcpServers.length > 0) {

--- a/apps/cli/src/scheduler.ts
+++ b/apps/cli/src/scheduler.ts
@@ -24,6 +24,12 @@ interface SuspendedTurn {
   approvalId: string;
   goalId: string;
   createdAt: number;
+  /** The runtime gate's tool_call_id for the approval this turn suspended on.
+   *  Resume/deny is BOUND to it (#462): the scheduler may only resolve the
+   *  pending approval it owns, never whatever happens to be pending — in
+   *  daemon-coordinated setups "whatever is pending" can be a HUMAN's money
+   *  prompt from an attached surface. */
+  toolCallId: string;
 }
 
 export interface GoalStreamResult {
@@ -624,7 +630,12 @@ export class GoalScheduler {
           });
 
           // Track in-memory (runtime holds the actual suspended state)
-          this.suspended.set(approvalId, { approvalId, goalId, createdAt: now });
+          this.suspended.set(approvalId, {
+            approvalId,
+            goalId,
+            createdAt: now,
+            toolCallId: chunk.tool_call_id,
+          });
 
           console.log(
             `\n  [approval-pending] ${chunk.name} — approval_id: ${approvalId.slice(0, 8)}`,
@@ -801,7 +812,12 @@ export class GoalScheduler {
             denied_reason: null,
           });
 
-          this.suspended.set(approvalId, { approvalId, goalId, createdAt: now });
+          this.suspended.set(approvalId, {
+            approvalId,
+            goalId,
+            createdAt: now,
+            toolCallId: innerChunk.tool_call_id,
+          });
           console.log(
             `\n  [approval-pending] ${innerChunk.name} — approval_id: ${approvalId.slice(0, 8)}`,
           );
@@ -857,10 +873,22 @@ export class GoalScheduler {
       if (!item || item.status === "expired") {
         this.suspended.delete(id);
         void this.logApprovalEvent(EventType.ApprovalExpired, turn.goalId, id, "", {});
-        // If runtime is holding this suspended turn, deny to release
-        if (this.runtime.hasPendingApproval) {
+        // Deny-release the runtime ONLY when the pending approval is the one
+        // this suspended turn owns (#462): guarding on bare
+        // `hasPendingApproval` would let the scheduler deny a HUMAN's pending
+        // money prompt in daemon-coordinated setups. And never silently — the
+        // old path discarded the resume stream with zero output.
+        const pending = this.runtime.pendingApprovalInfo;
+        if (pending != null && pending.toolCallId === turn.toolCallId) {
+          console.log(
+            `[approval] expired → denying suspended turn ${id.slice(0, 8)} (${pending.toolName}) to release the runtime`,
+          );
           const resumeStream = this.runtime.resumeAfterApproval(false);
           void this.consumeAndDiscard(resumeStream);
+        } else if (pending != null) {
+          console.log(
+            `[approval] expired ${id.slice(0, 8)} but the runtime's pending approval belongs to another actor (${pending.toolName}) — leaving it untouched`,
+          );
         }
       }
     }
@@ -877,7 +905,13 @@ export class GoalScheduler {
         `[approval] draining ${approved ? "approved" : "denied"}: ${approvalId.slice(0, 8)}`,
       );
 
-      if (this.runtime.hasPendingApproval) {
+      // Resume ONLY the approval this suspended turn owns (#462). If the
+      // runtime's pending approval is a different one (another actor's — in
+      // daemon-coordinated setups possibly a human's live money prompt), the
+      // scheduler's suspended turn was already voided; resuming would
+      // approve/deny SOMEONE ELSE's decision with the stored verdict.
+      const pending = this.runtime.pendingApprovalInfo;
+      if (pending != null && pending.toolCallId === turn.toolCallId) {
         this.currentGoalId = turn.goalId;
         const resumeStream = this.runtime.resumeAfterApproval(approved);
         const result = await this.consumeDaemonStream(resumeStream, turn.goalId);
@@ -885,6 +919,14 @@ export class GoalScheduler {
         if (approved && !result.suspended) {
           this.goalStore.updateLastRun(turn.goalId, Date.now());
         }
+      } else if (pending != null) {
+        console.log(
+          `[approval] ${approvalId.slice(0, 8)} resolved, but the runtime's pending approval belongs to another actor (${pending.toolName}) — this turn was already voided; not resuming`,
+        );
+      } else {
+        console.log(
+          `[approval] ${approvalId.slice(0, 8)} resolved, but its suspended turn is gone (voided or expired) — nothing to resume`,
+        );
       }
 
       this.suspended.delete(approvalId);

--- a/apps/cli/src/stream.ts
+++ b/apps/cli/src/stream.ts
@@ -145,6 +145,20 @@ export async function consumeStream(
         );
         break;
 
+      case "approval_voided":
+        // #462: this turn's message set aside a pending approval before the
+        // human answered. Not a refusal, not an expiry — say what happened
+        // and that nothing ran.
+        if (stopAnimation) {
+          stopAnimation();
+          stopAnimation = null;
+        }
+        writeOutput(
+          `\n  ${warn("[your new message set aside the pending approval — nothing was executed]")}\n` +
+            `  ${dim(`(${chunk.tool_name} was never run; no money moved. It can be proposed again.)`)}\n`,
+        );
+        break;
+
       case "invoke_error":
         if (stopAnimation) {
           stopAnimation();

--- a/packages/runtime/src/__tests__/streaming.test.ts
+++ b/packages/runtime/src/__tests__/streaming.test.ts
@@ -920,6 +920,8 @@ describe("processStream side effects", () => {
     expect(runtime.pendingApprovalInfo).toEqual({
       toolName: "delete_file",
       args: { path: "/tmp/x" },
+      quorum: undefined,
+      toolCallId: "tc-1",
     });
   });
 
@@ -3045,5 +3047,122 @@ describe("MotebitRuntime — [Now] block stale pixel-omission (typed-truth-perce
     (rt as unknown as { _sessionStartedAt: number })._sessionStartedAt = 0;
     rt.resetConversation();
     expect((rt as unknown as { _sessionStartedAt: number })._sessionStartedAt).toBeGreaterThan(0);
+  });
+});
+
+describe("approval lifecycle single-writer (#462)", () => {
+  let runtime: MotebitRuntime;
+
+  const injectPending = (
+    rt: MotebitRuntime,
+    toolCallId = "tc-462",
+    toolName = "delegate_to_agent",
+  ) => {
+    (rt as unknown as { streaming: { _pendingApproval: unknown } }).streaming._pendingApproval = {
+      toolCallId,
+      toolName,
+      args: { target: "worker-1" },
+      userMessage: "hire someone",
+      requestedAt: Date.now(),
+    };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runtime = new MotebitRuntime(
+      { motebitId: "single-writer-test", tickRateHz: 0 },
+      createAdapters(createMockProvider()),
+    );
+  });
+
+  it("a new user turn voids a pending approval VISIBLY — approval_voided is the first chunk, callback fires, nothing recorded as denied", async () => {
+    injectPending(runtime);
+    const voidedTools: string[] = [];
+    runtime.onApprovalVoided((toolName) => voidedTools.push(toolName));
+
+    const result = makeTurnResult("continuing");
+    mockRunTurnStreaming.mockReturnValue(
+      yieldChunks({ type: "text", text: "ok" }, { type: "result", result }),
+    );
+
+    const chunks = await collectChunks(runtime.sendMessageStreaming("something else"));
+
+    expect(chunks[0]).toEqual({ type: "approval_voided", tool_name: "delegate_to_agent" });
+    expect(runtime.hasPendingApproval).toBe(false);
+    expect(voidedTools).toEqual(["delegate_to_agent"]);
+    // A void is NOT a refusal — the #433 denied-intents brake must not engage,
+    // so a re-proposal re-prompts the human instead of auto-denying.
+    const denied = (runtime as unknown as { streaming: { deniedIntents: Map<string, number> } })
+      .streaming.deniedIntents;
+    expect(denied.size).toBe(0);
+  });
+
+  it("turns without a pending approval emit no approval_voided chunk", async () => {
+    const result = makeTurnResult("plain");
+    mockRunTurnStreaming.mockReturnValue(
+      yieldChunks({ type: "text", text: "ok" }, { type: "result", result }),
+    );
+    const chunks = await collectChunks(runtime.sendMessageStreaming("hello"));
+    expect(chunks.some((c) => c.type === "approval_voided")).toBe(false);
+  });
+
+  it("generateActivation refuses while an approval is pending — proactive turns never void human consent", async () => {
+    injectPending(runtime);
+    await expect(async () => {
+      for await (const _chunk of runtime.generateActivation("wake up")) {
+        /* consume */
+      }
+    }).rejects.toThrow(/pending approval/);
+    // The pending approval survives untouched.
+    expect(runtime.hasPendingApproval).toBe(true);
+  });
+
+  it("resumeAfterApproval holds the single-writer lock — refuses while another turn is processing", async () => {
+    (runtime as unknown as { _isProcessing: boolean })._isProcessing = true;
+    injectPending(runtime);
+    await expect(async () => {
+      for await (const _chunk of runtime.resumeAfterApproval(true)) {
+        /* consume */
+      }
+    }).rejects.toThrow("Already processing");
+    // Still pending — the refused resume consumed nothing.
+    expect(runtime.hasPendingApproval).toBe(true);
+  });
+
+  it("resolveApprovalVote holds the same lock", async () => {
+    (runtime as unknown as { _isProcessing: boolean })._isProcessing = true;
+    injectPending(runtime);
+    await expect(async () => {
+      for await (const _chunk of runtime.resolveApprovalVote(true, "someone")) {
+        /* consume */
+      }
+    }).rejects.toThrow("Already processing");
+  });
+
+  it("a new turn cannot start while a resume is mid-flight (the interleave the hold prevents)", async () => {
+    injectPending(runtime);
+    const result = makeTurnResult("resumed");
+    mockRunTurnStreaming.mockReturnValue(
+      yieldChunks({ type: "text", text: "after denial" }, { type: "result", result }),
+    );
+
+    const resumeGen = runtime.resumeAfterApproval(false);
+    await resumeGen.next(); // resume is now mid-flight
+
+    await expect(async () => {
+      for await (const _chunk of runtime.sendMessageStreaming("interleaved")) {
+        /* consume */
+      }
+    }).rejects.toThrow("Already processing");
+
+    for await (const _chunk of resumeGen) {
+      /* drain */
+    }
+  });
+
+  it("pendingApprovalInfo exposes the gate's toolCallId for external-arbiter binding", () => {
+    injectPending(runtime, "tc-binding-99", "send_payment");
+    expect(runtime.pendingApprovalInfo?.toolCallId).toBe("tc-binding-99");
+    expect(runtime.pendingApprovalInfo?.toolName).toBe("send_payment");
   });
 });

--- a/packages/runtime/src/activity.ts
+++ b/packages/runtime/src/activity.ts
@@ -46,6 +46,8 @@ export function deriveStreamActivity(chunk: StreamChunk): ActivityLabel | undefi
       return `approval: ${chunk.name}`;
     case "approval_expired":
       return "thinking";
+    case "approval_voided":
+      return "thinking";
     case "task_step_narration":
       // Spatial chrome render: the slab's
       // `motebit × virtual_browser` register IS the activity label

--- a/packages/runtime/src/motebit-runtime.ts
+++ b/packages/runtime/src/motebit-runtime.ts
@@ -2424,7 +2424,12 @@ export class MotebitRuntime {
     // system-triggered and should not reset the quiet window.
     this._lastUserMessageAt = Date.now();
     this._currentTypedIntent = options?.userActionAttestation ?? null;
-    this.streaming.clearPendingApproval();
+    // A new user turn sets aside any pending approval — but never silently
+    // (#462): the void renders on THIS stream via the typed chunk below, and
+    // the owning surface hears it through the onApprovalVoided callback. A
+    // void is not a refusal — nothing executes, nothing is recorded as
+    // denied, and re-proposal re-prompts the human.
+    const voidedApproval = this.streaming.voidPendingApproval();
     this.state.pushUpdate({ processing: 0.9, attention: 0.8 });
     this.behavior.setSpeaking(true);
 
@@ -2437,6 +2442,12 @@ export class MotebitRuntime {
     const turnStartedAt = Date.now();
 
     try {
+      // Render the void FIRST — before any model output — so the surface
+      // that started this turn sees what its message displaced (#462).
+      if (voidedApproval != null) {
+        yield { type: "approval_voided" as const, tool_name: voidedApproval.toolName };
+      }
+
       const trimmed = this.conversation.trimmed();
       const { knownAgents, agentCapabilities } = await withStageTimeout(
         "build_agent_context",
@@ -2589,9 +2600,18 @@ export class MotebitRuntime {
     const clearedLoopDeps = this.assertSensitivityPermitsAiCall("generateActivation");
 
     if (this._isProcessing) throw new Error("Already processing a message");
+    // A system-triggered turn must NEVER void a human's pending approval —
+    // the pending decision is authority-in-flight, and only a user-initiated
+    // turn may set it aside (and then only visibly). Refuse instead; callers
+    // (idle-tick, goals) treat this as a failed activation and retry later
+    // (#462).
+    if (this.streaming.hasPendingApproval) {
+      throw new Error(
+        "A pending approval is awaiting the user's decision — proactive turns do not void it",
+      );
+    }
 
     this._isProcessing = true;
-    this.streaming.clearPendingApproval();
     this.state.pushUpdate({ processing: 0.9, attention: 0.8 });
     this.behavior.setSpeaking(true);
 
@@ -2638,7 +2658,16 @@ export class MotebitRuntime {
   }
 
   async *resumeAfterApproval(approved: boolean): AsyncGenerator<StreamChunk> {
-    yield* this.streaming.resumeAfterApproval(approved);
+    // Single-writer arbitration (#462): the resume IS a turn. Without this
+    // hold, a concurrent `sendMessageStreaming` could start mid-resume and
+    // run a second provider stream interleaved with the continuation.
+    if (this._isProcessing) throw new Error("Already processing a message");
+    this._isProcessing = true;
+    try {
+      yield* this.streaming.resumeAfterApproval(approved);
+    } finally {
+      this._isProcessing = false;
+    }
   }
 
   get hasPendingApproval(): boolean {
@@ -2649,16 +2678,32 @@ export class MotebitRuntime {
     toolName: string;
     args: Record<string, unknown>;
     quorum?: { required: number; approvers: string[]; collected: string[] };
+    /** Gate's tool_call_id — lets an external arbiter (goals scheduler) verify
+     *  the pending approval is the one it OWNS before resolving it (#462). */
+    toolCallId: string;
   } | null {
     return this.streaming.pendingApprovalInfo;
   }
 
   async *resolveApprovalVote(approved: boolean, approverId: string): AsyncGenerator<StreamChunk> {
-    yield* this.streaming.resolveApprovalVote(approved, approverId);
+    // Same single-writer hold as resumeAfterApproval (#462).
+    if (this._isProcessing) throw new Error("Already processing a message");
+    this._isProcessing = true;
+    try {
+      yield* this.streaming.resolveApprovalVote(approved, approverId);
+    } finally {
+      this._isProcessing = false;
+    }
   }
 
   onApprovalExpired(cb: () => void): void {
     this.streaming.onApprovalExpired(cb);
+  }
+
+  /** Register a callback fired when a new turn voids a pending approval (#462) —
+   *  the surface owning the voided prompt renders the void the moment it happens. */
+  onApprovalVoided(cb: (toolName: string) => void): void {
+    this.streaming.onApprovalVoided(cb);
   }
 
   resetConversation(): void {

--- a/packages/runtime/src/runtime-config.ts
+++ b/packages/runtime/src/runtime-config.ts
@@ -393,6 +393,18 @@ export type StreamChunk =
   | { type: "approval_expired"; tool_name: string }
   | {
       /**
+       * A new user turn set aside a pending approval before the human
+       * answered (#462). NOT a refusal and NOT an expiry: nothing executed,
+       * nothing was recorded as denied, and the model may re-propose (which
+       * re-prompts the human). Emitted as the FIRST chunk of the turn that
+       * did the voiding; the surface owning the voided prompt hears it via
+       * `runtime.onApprovalVoided`.
+       */
+      type: "approval_voided";
+      tool_name: string;
+    }
+  | {
+      /**
        * Task-step narration — what motebit is currently doing at the
        * supervisor-cares-about granularity. The slab's chrome consumes
        * this in the `motebit × virtual_browser` register; voice

--- a/packages/runtime/src/streaming.ts
+++ b/packages/runtime/src/streaming.ts
@@ -259,6 +259,8 @@ export class StreamingManager {
    */
   private readonly deniedIntents = new Map<string, number>();
   private approvalExpiredCallback: (() => void) | null = null;
+  /** Fired when a NEW turn voids a pending approval (#462) — the owning surface renders the void. */
+  private approvalVoidedCallback: ((toolName: string) => void) | null = null;
   private _isProcessing = false;
 
   constructor(private readonly deps: StreamingDeps) {}
@@ -279,18 +281,58 @@ export class StreamingManager {
     toolName: string;
     args: Record<string, unknown>;
     quorum?: { required: number; approvers: string[]; collected: string[] };
+    /** The gate's tool_call_id (= approval_request chunk's id). Lets an external
+     *  arbiter (goals scheduler) prove the approval it resolves is the one it
+     *  OWNS, instead of resuming whatever happens to be pending (#462). */
+    toolCallId: string;
   } | null {
     if (!this._pendingApproval) return null;
     return {
       toolName: this._pendingApproval.toolName,
       args: this._pendingApproval.args,
       quorum: this._pendingApproval.quorum,
+      toolCallId: this._pendingApproval.toolCallId,
     };
   }
 
-  /** Clear pending approval state (called when starting a new message). */
-  clearPendingApproval(): void {
+  /**
+   * Void pending approval state at the start of a NEW user turn.
+   *
+   * A pending approval is authority-in-flight — the human's undelivered
+   * decision — and nothing may consume or discard it invisibly (#462; the
+   * memory-never-confers-authority posture applied to consent). Voiding:
+   * - never executes and never records a refusal (a void is not a "no" —
+   *   the model may re-propose, and re-proposal re-prompts the human);
+   * - clears the expiry timer (the void supersedes the expiry message);
+   * - injects the outcome into conversation history so the model knows the
+   *   proposal was neither run nor denied (mirror of the timeout handler);
+   * - fires the voided callback so the OWNING surface renders the void
+   *   (the new turn's surface gets the `approval_voided` chunk instead).
+   *
+   * Returns the voided approval so the caller can emit the typed chunk.
+   */
+  voidPendingApproval(): { toolName: string } | null {
+    const voided = this._pendingApproval;
+    if (!voided) return null;
     this._pendingApproval = null;
+    this.clearApprovalTimeout();
+    this.deps.injectIntermediateMessages(
+      {
+        role: "assistant" as const,
+        content: `[tool_use: ${voided.toolName}(${JSON.stringify(voided.args)})]`,
+      },
+      {
+        role: "user" as const,
+        content: `[tool_result: {"ok":false,"error":"A new message set this pending approval aside before the user answered. The tool was NEVER executed and the user did NOT refuse it — if it is still needed, propose it again."}]`,
+      },
+    );
+    this.approvalVoidedCallback?.(voided.toolName);
+    return { toolName: voided.toolName };
+  }
+
+  /** Register a callback invoked when a new turn voids a pending approval (#462). */
+  onApprovalVoided(cb: (toolName: string) => void): void {
+    this.approvalVoidedCallback = cb;
   }
 
   /** Shared stream processing — extracts state tags, handles tool/approval/injection chunks. */


### PR DESCRIPTION
## The hazard class (#462, split from #457's root-cause map)

A pending approval is **authority-in-flight** — the human's undelivered decision. Two paths mutated it invisibly:

1. **Concurrent turn voids the pause.** `sendMessageStreaming` and `generateActivation` called `clearPendingApproval()` unconditionally, and the `_isProcessing` guard covered neither the approval pause (the paused stream's finally already reset it) nor the resume itself. Live-reachable through the runtime-host coordinator seam: an attached frontend (desktop, `motebit serve`, a second terminal) chatting during a money-approval pause silently discarded the human's pending decision.
2. **Scheduler resumes by ambient state.** `expireStaleApprovals`/`drainResolvedApprovals` called `resumeAfterApproval` guarded only by `hasPendingApproval` — no binding to the approval the scheduler owns. In daemon-coordinated setups the stored verdict could approve/deny a **human's** live money prompt; the expiry path did so with zero console output (`consumeAndDiscard`).

## Fix — single-writer + every transition renders

- **Void is visible, and is not a refusal**: `voidPendingApproval` clears the expiry timer, injects the outcome into conversation history (mirror of the timeout handler — the model knows the proposal neither ran nor was denied), fires the new `onApprovalVoided` callback (the owning surface renders the void), and the voiding turn's stream opens with the new typed `approval_voided` chunk. The #433 denied-intents brake does not engage — re-proposal re-prompts the human.
- **Proactive turns never void human consent**: `generateActivation` refuses (throws) while an approval is pending; idle-tick/goals treat it as a failed activation and retry later.
- **The resume IS a turn**: `resumeAfterApproval` and `resolveApprovalVote` hold `_isProcessing` for their duration — a concurrent turn can no longer interleave a second provider stream mid-resume.
- **Scheduler resolution is bound to ownership**: each suspended turn records its `approval_request` chunk's `tool_call_id`; expire/drain resolve only on a `toolCallId` match against `pendingApprovalInfo` (newly exposed), and every skip/release logs.

Doctrine: memory-never-confers-authority posture applied to consent — nothing may consume or discard the human's pending decision invisibly.

## Tests

7 new runtime tests (void visibility + first-chunk ordering, no-denial-recorded, activation refusal, both single-writer holds, mid-resume interleave, `toolCallId` exposure) and 4 new scheduler binding tests (owned resume, foreign-pending skip on drain and on expiry, owned expiry release). Full suites: runtime 1253, cli 314, monorepo typecheck green.

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)