### PR TITLE
fix(runtime,cli): the delegation route is part of consent — a P2P→relay degrade is named everywhere it can be read (#458)

### DIFF
--- a/.changeset/route-degrade-honesty.md
+++ b/.changeset/route-degrade-honesty.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+Consent describes what actually happens: the money-approval band now states that the payment route is late-bound (if peer payment is unavailable, the task reroutes through the relay with no wallet payment), the route switch renders and is stated in the delegation result when it occurs, and the relay-mode settlement note no longer overclaims a payment. Also: attached surfaces render approval expiry/void outcomes, and the goals daemon contains drain errors instead of leaking unhandled rejections.

--- a/apps/cli/src/__tests__/approval-render.test.ts
+++ b/apps/cli/src/__tests__/approval-render.test.ts
@@ -26,6 +26,22 @@ describe("renderApprovalRequest", () => {
     expect(out).toMatch(/sovereign wallet/i);
   });
 
+  it("states the route is late-bound — the relay-reroute possibility is part of consent (#458)", () => {
+    const out = plain(
+      renderApprovalRequest({
+        name: "delegate_to_agent",
+        args: { prompt: "do research" },
+        riskLevel: 4,
+      }),
+    );
+    // Witnessed live 2026-07-29: approval framed as sovereign-wallet payment,
+    // the P2P pre-flight failed closed, and the task ran relay-routed under
+    // that consent. The band must describe what can actually happen — the
+    // route, like the amount, is late-bound.
+    expect(out).toMatch(/If peer payment is unavailable/);
+    expect(out).toMatch(/no wallet payment/);
+  });
+
   it("states the pricing RULE instead of inventing an amount (late-bound spend)", () => {
     const out = plain(
       renderApprovalRequest({

--- a/apps/cli/src/approval-render.ts
+++ b/apps/cli/src/approval-render.ts
@@ -102,6 +102,13 @@ export function renderApprovalRequest(req: ApprovalRequestView): string[] {
         : // No ceiling set: say so plainly rather than implying one exists.
           `  ${dim("Amount: set by the worker's listing at hire time (no --budget ceiling set).")}`,
     );
+    // Route honesty (#458): the route is LATE-BOUND, like the amount. The
+    // 2026-07-29 validation run approved under the sovereign-wallet framing
+    // and the delegation then degraded to relay routing with nothing said.
+    // Consent must describe what can actually happen.
+    lines.push(
+      `  ${dim("If peer payment is unavailable, this reroutes through the relay with no wallet payment — the switch is named in the result.")}`,
+    );
   }
 
   if (req.quorum && req.quorum.required > 1) {

--- a/apps/cli/src/attached-repl.ts
+++ b/apps/cli/src/attached-repl.ts
@@ -69,6 +69,21 @@ async function renderStream(
         case "injection_warning":
           writeOutput(`\n${warn("⚠")} suspicious content in ${chunk.tool_name ?? "tool"} output\n`);
           break;
+        case "approval_expired":
+          // #457 sibling: the coordinator-owned REPL renders this in
+          // stream.ts; an attached frontend must never get silence on an
+          // approval outcome either.
+          writeOutput(
+            `\n${warn("[this approval expired before your answer arrived — nothing was executed]")}\n${dim(`(${chunk.tool_name ?? "the tool"} was never run; no money moved. Ask again when ready.)`)}\n`,
+          );
+          break;
+        case "approval_voided":
+          // #462: this turn's message set aside a pending approval (possibly
+          // one prompted on another surface). Not a refusal, not an expiry.
+          writeOutput(
+            `\n${warn("[your new message set aside the pending approval — nothing was executed]")}\n${dim(`(${chunk.tool_name ?? "the tool"} was never run; no money moved. It can be proposed again.)`)}\n`,
+          );
+          break;
         case "invoke_error":
           writeOutput(
             `\n${warn(`[invoke failed${chunk.code != null ? ` · ${chunk.code}` : ""}]`)} ${chunk.message ?? ""}\n`,

--- a/apps/cli/src/scheduler.ts
+++ b/apps/cli/src/scheduler.ts
@@ -943,8 +943,17 @@ export class GoalScheduler {
   }
 
   private async consumeAndDiscard(stream: AsyncGenerator<StreamChunk>): Promise<void> {
-    for await (const _chunk of stream) {
-      // drain
+    // Never let a drain reject escape — callers fire-and-forget (`void ...`),
+    // so a throw here (e.g. resumeAfterApproval's single-writer "Already
+    // processing" guard, #462, when a human turn is mid-flight on the shared
+    // runtime) would be an unhandled rejection. Log and retry next tick.
+    try {
+      for await (const _chunk of stream) {
+        // drain
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[approval] release drain failed (will retry next tick): ${msg}`);
     }
   }
 

--- a/packages/runtime/src/__tests__/interactive-delegation.test.ts
+++ b/packages/runtime/src/__tests__/interactive-delegation.test.ts
@@ -434,6 +434,84 @@ describe("Interactive Delegation (delegate_to_agent tool)", () => {
     expect(result.data).toContain("tx-p2p-test");
   });
 
+  it("states the route switch in the tool result when P2P degrades to relay-mode (#458)", async () => {
+    // The live 2026-07-29 gap: consent framed as "pays from your sovereign
+    // wallet — onchain", the pre-flight failed closed, the delegation
+    // proceeded relay-mode, and NOTHING said the route changed. The tool
+    // result must state the switch so the model relays it.
+    const runtime = new MotebitRuntime(
+      { motebitId: "alice-001", tickRateHz: 0 },
+      createAdapters(createMockProvider()),
+    );
+    const buildP2pPayment = vi.fn(async (): Promise<P2pPaymentProof> => {
+      throw new Error("must never be called — pre-flight denied");
+    });
+    const receipt = fakeReceipt();
+
+    mockFetchHandler = async (url: string, init?: RequestInit) => {
+      if (url.includes("/api/v1/agents/discover")) {
+        return new Response(
+          JSON.stringify({
+            agents: [
+              {
+                motebit_id: "bob-worker",
+                settlement_address: "BobWorkerAddr1111111111111111111111111111111",
+                settlement_modes: "relay,p2p",
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("/p2p-eligibility")) {
+        // Fail closed pre-broadcast — the incident's exact shape.
+        return new Response(JSON.stringify({ allowed: false, reason: "relay drowning" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (url.includes("/agent/alice-001/task") && init?.method === "POST") {
+        const body = JSON.parse(init.body as string) as Record<string, unknown>;
+        // Degraded submission is relay-mode: no pinned target, no proof.
+        expect(body.target_agent).toBeUndefined();
+        expect(body.payment_proof).toBeUndefined();
+        return new Response(JSON.stringify({ task_id: "degraded-task-1" }), {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (url.includes("/agent/alice-001/task/degraded-task-1")) {
+        return new Response(JSON.stringify({ task: { status: "completed" }, receipt }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    runtime.enableInteractiveDelegation({
+      syncUrl: "https://mock-relay.test",
+      authToken: async () => "test-token",
+      relayPublicKey: "07".repeat(32),
+      buildP2pPayment,
+      acknowledgeNoHistoryRisk: true,
+    });
+
+    const result = await runtime.getToolRegistry().execute("delegate_to_agent", {
+      prompt: "search the web for motebit",
+      required_capabilities: ["web_search"],
+    });
+
+    expect(buildP2pPayment).not.toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    // The worker's answer stays primary…
+    expect(result.data).toContain("motebit is a sovereign AI agent framework");
+    // …and the route switch is stated, with the reason and the money truth.
+    expect(result.data).toContain("[route]");
+    expect(result.data).toContain("p2p_ineligible");
+    expect(result.data).toContain("NO onchain payment left the wallet");
+  });
+
   it("returns error on relay submission failure (402 insufficient budget)", async () => {
     const runtime = new MotebitRuntime(
       { motebitId: "alice-001", tickRateHz: 0 },

--- a/packages/runtime/src/__tests__/relay-delegation.test.ts
+++ b/packages/runtime/src/__tests__/relay-delegation.test.ts
@@ -1145,11 +1145,14 @@ describe("selectAndRunDelegation", () => {
       }),
     );
 
+    const base = baseSelect();
+    const degrades: Array<{ from: string; to: string; code: string }> = [];
     await selectAndRunDelegation({
-      ...baseSelect(),
+      ...base,
       requiredCapabilities: ["review_pr"],
       relayPublicKey: PINNED_HEX,
       buildP2pPayment,
+      onRouteDegrade: (d) => degrades.push(d),
     });
 
     // No broadcast (pre-flight blocked it), and the fallback is relay-mode — its
@@ -1157,6 +1160,42 @@ describe("selectAndRunDelegation", () => {
     expect(buildP2pPayment).not.toHaveBeenCalled();
     expect(submitBody!.target_agent).toBeUndefined();
     expect(submitBody!.payment_proof).toBeUndefined();
+
+    // #458: the route switch is NEVER silent — callback fired with the
+    // pre-broadcast reason, and the structured log line emitted for headless
+    // callers. Witnessed live 2026-07-29: consent framed as sovereign-wallet
+    // payment, route degraded to relay, nothing rendered.
+    expect(degrades).toEqual([
+      { from: "p2p", to: "relay", code: "p2p_ineligible", message: expect.any(String) },
+    ]);
+    expect(base.logger.warn).toHaveBeenCalledWith(
+      "delegation.route_degraded",
+      expect.objectContaining({ from: "p2p", to: "relay", code: "p2p_ineligible" }),
+    );
+  });
+
+  it("no degrade event when P2P is unconfigured (relay-mode was never a switch)", async () => {
+    let submitted = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (url.endsWith("/task") && init?.method === "POST") {
+          submitted = true;
+          return jsonResponse(400, { code: "BAD" }); // stop before the poll
+        }
+        return jsonResponse(404, {});
+      }),
+    );
+    const degrades: unknown[] = [];
+    await selectAndRunDelegation({
+      ...baseSelect(),
+      requiredCapabilities: ["review_pr"],
+      onRouteDegrade: (d) => degrades.push(d),
+    });
+    expect(submitted).toBe(true);
+    // Relay-mode by CONFIGURATION is not a route switch — no consent was
+    // framed around a sovereign payment that then didn't happen.
+    expect(degrades).toEqual([]);
   });
 
   it("uses relay-mode (no P2P, no discovery) when no rail is configured", async () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -331,6 +331,7 @@ export type {
   GrantedDelegationResult,
   DelegationError,
   DelegationErrorCode,
+  RouteDegrade,
 } from "./relay-delegation.js";
 // The session paid-intent interlock (#435/#436) — enforced inside the shared
 // submit chokepoint; exported for surfaces/tests that render or probe it.

--- a/packages/runtime/src/interactive-delegation.ts
+++ b/packages/runtime/src/interactive-delegation.ts
@@ -22,7 +22,11 @@ import type { P2pPaymentProof, SovereignP2pPaymentRequest } from "@motebit/proto
 function formatSettlementNote(settlement: DelegationSettlement | undefined): string {
   if (!settlement) return "";
   if (settlement.mode === "relay") {
-    return "[settlement] Paid via the relay ledger (instant settlement).";
+    // Route-honest (#458): relay-mode moves NO money from the delegator's
+    // wallet on this path (a paid direct delegation without a P2P proof is
+    // refused by the relay's Arc 3.5 gate) — "Paid via the relay ledger"
+    // overclaimed a payment on free-routed tasks.
+    return "[settlement] Routed relay-mode — no onchain payment left your wallet.";
   }
   // P2P — onchain, paid by the delegator's own atomic transaction.
   const paid =
@@ -267,6 +271,15 @@ export class InteractiveDelegationManager {
         // acceptance-time revocation fence keys on it.
         const grantId = config.getActiveGrantId?.() ?? null;
 
+        // Route-degrade capture (#458): if the sovereign P2P route fails
+        // pre-broadcast and the delegation proceeds relay-mode, the human's
+        // approval may have been framed as a wallet payment — the switch is
+        // stated in this tool's result so the model reports it, never
+        // narrates the sovereign route it didn't take.
+        const routeDegrade: { current: import("./relay-delegation.js").RouteDegrade | null } = {
+          current: null,
+        };
+
         const result = await selectAndRunDelegation({
           motebitId,
           syncUrl: config.syncUrl,
@@ -282,6 +295,9 @@ export class InteractiveDelegationManager {
           invocationOrigin: "ai-loop",
           ...(timeoutMs != null ? { timeoutMs } : {}),
           logger,
+          onRouteDegrade: (degrade) => {
+            routeDegrade.current = degrade;
+          },
         });
 
         if (!result.ok) {
@@ -323,7 +339,14 @@ export class InteractiveDelegationManager {
                 `and the result did not come back, and let them decide.`,
             };
           }
-          return { ok: false, error: `${result.error.code}: ${result.error.message}` };
+          return {
+            ok: false,
+            error:
+              `${result.error.code}: ${result.error.message}` +
+              (routeDegrade.current != null
+                ? ` (This failure happened AFTER the sovereign peer-payment route was unavailable (${routeDegrade.current.code}) and the task had rerouted through the relay — no onchain payment left the wallet at any point.)`
+                : ""),
+          };
         }
 
         // Bump trust (best-effort)
@@ -345,7 +368,18 @@ export class InteractiveDelegationManager {
         const workerResult = result.receipt.result ?? "Task completed (no result text)";
         const settlementNote = formatSettlementNote(result.settlement);
         const workerNote = `[delegated_to: ${result.receipt.motebit_id}]`;
-        const footnotes = [workerNote, ...(settlementNote ? [settlementNote] : [])].join("\n");
+        // Route honesty (#458): the approval may have been framed as a
+        // sovereign-wallet payment; if the route switched, the result says so
+        // explicitly so the model relays the switch to the user.
+        const degradeNote =
+          routeDegrade.current != null
+            ? `[route] The sovereign peer-payment route was unavailable (${routeDegrade.current.code}); this task ran relay-routed instead — NO onchain payment left the wallet. Tell the user the route changed from what the approval described.`
+            : "";
+        const footnotes = [
+          workerNote,
+          ...(settlementNote ? [settlementNote] : []),
+          ...(degradeNote ? [degradeNote] : []),
+        ].join("\n");
         return {
           ok: true,
           data: `${workerResult}\n\n${footnotes}`,

--- a/packages/runtime/src/relay-delegation.ts
+++ b/packages/runtime/src/relay-delegation.ts
@@ -1430,6 +1430,31 @@ export async function resolveAndSubmitP2pDelegation(
   return submitted;
 }
 
+/**
+ * A pre-broadcast route switch (#458): the sovereign P2P path was configured
+ * and attempted, failed BEFORE any payment could move, and the delegation is
+ * about to proceed relay-mode instead. Consent to a paid hire is framed
+ * around the sovereign route ("pays from your wallet, onchain"), so the
+ * switch to a different route must be NAMED, never silent — the surface
+ * renders it, the tool result states it, and headless callers get the
+ * structured `delegation.route_degraded` log line.
+ *
+ * Money safety note: the degraded relay-mode submission cannot spend the
+ * wallet (no rail is invoked on that path) and a PAID direct delegation
+ * without a P2P proof is refused by the relay's Arc 3.5 gate — the degrade
+ * changes the ROUTE, not the spend. The dishonesty this type closes is
+ * consent describing a mechanism that then didn't happen.
+ */
+export interface RouteDegrade {
+  /** The route the consent framing described. */
+  from: "p2p";
+  /** The route the delegation actually takes. */
+  to: "relay";
+  /** The pre-broadcast P2P failure that forced the switch. */
+  code: DelegationErrorCode;
+  message: string;
+}
+
 export interface SelectDelegationParams {
   /**
    * Standing-grant id the current turn executes under (advisory wire
@@ -1437,6 +1462,12 @@ export interface SelectDelegationParams {
    * the enforcement). Threaded to BOTH submit paths.
    */
   grantId?: string;
+  /**
+   * Fired when the P2P route degrades to relay-mode pre-broadcast (#458) —
+   * the caller renders/records the switch. Optional; the structured
+   * `delegation.route_degraded` log line fires regardless.
+   */
+  onRouteDegrade?: (degrade: RouteDegrade) => void;
   /** Session paid-intent ledger — threaded to the P2P path's interlock. */
   paidIntentLedger?: PaidIntentLedger;
   /** The delegator's identity (submitter / owner of the task). */
@@ -1572,6 +1603,26 @@ export async function selectAndRunDelegation(
     ) {
       return p2p;
     }
+    // The route is switching AFTER consent was (possibly) framed around the
+    // sovereign wallet — name it (#458). Witnessed live 2026-07-29: the
+    // approval band said "Pays from your sovereign wallet — onchain", the
+    // pre-flight failed closed against a drowning relay, and the delegation
+    // proceeded relay-mode under the differently-framed approval with
+    // nothing rendered. Never silent again: structured log always, callback
+    // for the surface/tool to render.
+    const degrade: RouteDegrade = {
+      from: "p2p",
+      to: "relay",
+      code: p2p.error.code,
+      message: p2p.error.message,
+    };
+    params.logger.warn("delegation.route_degraded", {
+      from: degrade.from,
+      to: degrade.to,
+      code: degrade.code,
+      message: degrade.message,
+    });
+    params.onRouteDegrade?.(degrade);
   }
 
   return submitAndPollDelegation({


### PR DESCRIPTION
## The live gap (#458, 2026-07-29 validation run)

The money-approval band said **'Pays from your sovereign wallet — onchain, not refundable'**, the user approved, the P2P eligibility pre-flight failed closed against a drowning relay (correct — never broadcast on an unconfirmable pre-flight), and `selectAndRunDelegation` degraded to relay-mode per the fallback set. The safer route executed under a differently-framed approval, and **nothing rendered the switch**.

## Why honesty, not blocking (the issue's shape (a), chosen deliberately)

The degraded relay path cannot spend the wallet — no rail is invoked on it, and a PAID direct delegation without a P2P proof is refused by the relay's Arc 3.5 gate (`TASK_P2P_PROOF_REQUIRED`). The degrade changes the **route**, not the spend. Blocking the fallback (shape (b)) would trade availability for a consent nuance the honest naming fully covers — and re-prompting would re-render the same band anyway. So: name the switch at every layer it can be read.

## The three layers

1. **The decision point** (`relay-delegation.ts`): typed `RouteDegrade` + optional `onRouteDegrade` callback fired at the pre-broadcast fall-through, plus an unconditional structured `delegation.route_degraded` log line (renders in the REPL today; headless callers get the record). Relay-by-configuration is *not* a degrade — no consent was framed around a route that then didn't happen.
2. **The tool result** (`delegate_to_agent`): success carries `[route] The sovereign peer-payment route was unavailable (…) — NO onchain payment left the wallet…` so the model relays the actual route; failures after a degrade are annotated too. `formatSettlementNote`'s relay branch no longer overclaims ('Paid via the relay ledger' on a free-routed task → 'Routed relay-mode — no onchain payment left your wallet').
3. **The consent band** (CLI `approval-render.ts`): the route is late-bound like the amount, and the band says so — *'If peer payment is unavailable, this reroutes through the relay with no wallet payment — the switch is named in the result.'*

## Also: principal-review follow-ups on merged #467

- `expireStaleApprovals`' fire-and-forget drain now contains the rejection the new single-writer guard can throw (was an unhandled rejection escaping the tick's try/catch).
- `attached-repl` renders `approval_expired` (a #463 sibling miss) and `approval_voided` instead of silence — attached frontends were getting nothing on exactly the transitions we made 'always render.'

## Tests

Degrade callback + structured log + no-degrade-when-unconfigured (relay-delegation, 47 pass); the incident's exact shape end-to-end through the real tool handler asserting the `[route]` note (interactive-delegation, 21 pass); consent-copy route clause (approval-render). Full suites: runtime 1255, cli 315.

Doctrine: surface-determinism + felt-interior — consent must describe what actually happens; typed-truth — the result states what happened, the prompt only teaches how to read it.

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)