### PR TITLE
fix(cli): owned bottom region — resize repaints in place, in-flight delegation narrates, poll errors render calm (#455, #456)

### DIFF
--- a/.changeset/cli-owned-bottom-region.md
+++ b/.changeset/cli-owned-bottom-region.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+CLI rendering: the REPL now owns the bottom of the screen (#456, #455). One renderer discipline (clear region, append scrollback, repaint) replaces print-and-hope: resizing repaints the prompt in place instead of stacking duplicates; in-flight delegation shows a calm status row with the current step narration, elapsed time, and poll-attempt count instead of animated dots; runtime warnings (delegation poll failures above all) flow through the renderer as calm text instead of raw JSON dumped into the input line. Same treatment on the attached REPL and the background goal scheduler.

--- a/apps/cli/src/__tests__/cli-logger.test.ts
+++ b/apps/cli/src/__tests__/cli-logger.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const writeLine = vi.fn();
+const activeStatus = vi.fn();
+vi.mock("../terminal.js", () => ({ writeLine: (s: string) => writeLine(s) }));
+vi.mock("../statusline.js", () => ({ activeStatus: () => activeStatus() }));
+
+const { createCliLogger, formatContext } = await import("../cli-logger.js");
+
+// eslint-disable-next-line no-control-regex -- stripping ANSI is the point
+const plain = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+describe("createCliLogger", () => {
+  beforeEach(() => {
+    writeLine.mockClear();
+    activeStatus.mockReset();
+    activeStatus.mockReturnValue(null);
+  });
+
+  it("folds poll failures into the active status row, counting attempts", () => {
+    const note = vi.fn();
+    activeStatus.mockReturnValue({ note, step: vi.fn(), stop: vi.fn() });
+    const logger = createCliLogger();
+    logger.warn("delegation poll failed", { taskId: "task-123", status: 503, body: "" });
+    logger.warn("delegation poll failed", { taskId: "task-123", status: 503, body: "" });
+    expect(note).toHaveBeenNthCalledWith(1, "relay hiccup, still waiting (attempt 1)");
+    expect(note).toHaveBeenNthCalledWith(2, "relay hiccup, still waiting (attempt 2)");
+    // Status owns the moment — no scrollback line per retry
+    expect(writeLine).not.toHaveBeenCalled();
+  });
+
+  it("renders poll failures as one calm dim line when no status is active", () => {
+    const logger = createCliLogger();
+    logger.warn("delegation poll failed", { taskId: "task-12345678", status: 503, body: "" });
+    expect(writeLine).toHaveBeenCalledTimes(1);
+    const line = plain(writeLine.mock.calls[0]![0] as string);
+    expect(line).toContain("relay hiccup, still waiting (attempt 1)");
+    expect(line).toContain("task-123");
+    expect(line).not.toMatch(/[{}"]/); // never raw JSON (#456)
+  });
+
+  it("attempt counts are per task", () => {
+    const note = vi.fn();
+    activeStatus.mockReturnValue({ note, step: vi.fn(), stop: vi.fn() });
+    const logger = createCliLogger();
+    logger.warn("delegation poll failed", { taskId: "task-a" });
+    logger.warn("delegation poll failed", { taskId: "task-b" });
+    expect(note).toHaveBeenLastCalledWith("relay hiccup, still waiting (attempt 1)");
+  });
+
+  it("renders other warnings as a calm line with compact context", () => {
+    const logger = createCliLogger();
+    logger.warn("delegation.route_degraded", { from: "p2p", to: "relay" });
+    const line = plain(writeLine.mock.calls[0]![0] as string);
+    expect(line).toContain("delegation.route_degraded");
+    expect(line).toContain("from=p2p");
+    expect(line).toContain("to=relay");
+  });
+});
+
+describe("formatContext", () => {
+  it("drops empty values and bounds long ones", () => {
+    expect(formatContext({ a: "x", b: "", c: undefined })).toBe(" (a=x)");
+    const long = formatContext({ body: "e".repeat(200) });
+    expect(long.length).toBeLessThan(80);
+    expect(long).toContain("…");
+  });
+
+  it("returns empty string for no context", () => {
+    expect(formatContext(undefined)).toBe("");
+  });
+});

--- a/apps/cli/src/__tests__/helpers/vt.ts
+++ b/apps/cli/src/__tests__/helpers/vt.ts
@@ -1,0 +1,231 @@
+/**
+ * Minimal virtual-terminal interpreter for renderer tests.
+ *
+ * Interprets the ANSI subset the CLI renderer emits (cursor moves, line/
+ * screen erase, CR/LF, SGR stripped, synchronized-output markers ignored)
+ * into a character grid, so tests assert on the SCREEN a user would see —
+ * "five resizes produce exactly one `you>`" — instead of on escape-code
+ * strings. This is the honest substitute for a PTY harness: resize can't
+ * be driven through `script(1)`, but reflow can be simulated here.
+ *
+ * Reflow model matches macOS Terminal/iTerm2 (where #455 was witnessed):
+ * on resize, soft-wrapped rows re-join into logical lines and re-wrap at
+ * the new width; the cursor follows its character position.
+ */
+
+interface Row {
+  chars: string[];
+  /** True when this row overflowed and visually continues on the next row. */
+  softWrap: boolean;
+}
+
+export class VirtualTerminal {
+  private rows: Row[] = [{ chars: [], softWrap: false }];
+  private cursorRow = 0;
+  private cursorCol = 0;
+  cols: number;
+
+  constructor(cols = 80) {
+    this.cols = cols;
+  }
+
+  write(data: string): void {
+    let i = 0;
+    while (i < data.length) {
+      const ch = data[i]!;
+      if (ch === "\x1b") {
+        i = this.handleEscape(data, i);
+        continue;
+      }
+      if (ch === "\r") {
+        this.cursorCol = 0;
+        i++;
+        continue;
+      }
+      if (ch === "\n") {
+        // stdout passes through the tty driver with ONLCR, so LF behaves
+        // as CR+LF from the app's point of view.
+        this.currentRow().softWrap = false;
+        this.cursorRow++;
+        this.cursorCol = 0;
+        this.ensureRow();
+        i++;
+        continue;
+      }
+      if (ch === "\b") {
+        this.cursorCol = Math.max(0, this.cursorCol - 1);
+        i++;
+        continue;
+      }
+      if (ch.charCodeAt(0) < 32) {
+        i++; // other control chars: ignore
+        continue;
+      }
+      // Printable
+      if (this.cursorCol >= this.cols) {
+        this.currentRow().softWrap = true;
+        this.cursorRow++;
+        this.cursorCol = 0;
+        this.ensureRow();
+      }
+      this.currentRow().chars[this.cursorCol] = ch;
+      this.cursorCol++;
+      i++;
+    }
+  }
+
+  /** Simulate a reflowing terminal resize (macOS Terminal/iTerm2 model). */
+  resize(newCols: number): void {
+    // Join soft-wrapped runs into logical lines, remembering where the
+    // cursor sits as a (logical line, char offset) pair.
+    interface Logical {
+      text: string[];
+      cursorOffset: number | null;
+    }
+    const logicals: Logical[] = [];
+    let current: Logical | null = null;
+    for (let r = 0; r < this.rows.length; r++) {
+      const row = this.rows[r]!;
+      if (current === null) current = { text: [], cursorOffset: null };
+      if (r === this.cursorRow) {
+        current.cursorOffset = current.text.length + this.cursorCol;
+      }
+      // Pad implicit blanks so column positions survive the join
+      const width = row.softWrap ? this.cols : row.chars.length;
+      for (let c = 0; c < width; c++) current.text.push(row.chars[c] ?? " ");
+      if (!row.softWrap) {
+        logicals.push(current);
+        current = null;
+      }
+    }
+    if (current !== null) logicals.push(current);
+
+    this.cols = newCols;
+    this.rows = [];
+    this.cursorRow = 0;
+    this.cursorCol = 0;
+    for (const logical of logicals) {
+      const startRow = this.rows.length;
+      const chunks = Math.max(1, Math.ceil(logical.text.length / newCols));
+      for (let k = 0; k < chunks; k++) {
+        this.rows.push({
+          chars: logical.text.slice(k * newCols, (k + 1) * newCols),
+          softWrap: k < chunks - 1,
+        });
+      }
+      if (logical.cursorOffset !== null) {
+        this.cursorRow = startRow + Math.floor(logical.cursorOffset / newCols);
+        this.cursorCol = logical.cursorOffset % newCols;
+        // Cursor exactly at end-of-line lands at col == len, not next row
+        if (
+          this.cursorCol === 0 &&
+          logical.cursorOffset > 0 &&
+          logical.cursorOffset === logical.text.length
+        ) {
+          this.cursorRow = startRow + chunks - 1;
+          this.cursorCol = newCols;
+        }
+        this.ensureRow();
+      }
+    }
+    if (this.rows.length === 0) this.rows.push({ chars: [], softWrap: false });
+  }
+
+  /** The visible screen: rows joined by \n, trailing blanks trimmed. */
+  screen(): string {
+    return this.rows
+      .map((r) =>
+        r.chars
+          .map((c) => c ?? " ")
+          .join("")
+          .replace(/\s+$/, ""),
+      )
+      .join("\n")
+      .replace(/\n+$/, "");
+  }
+
+  /** Count occurrences of a visible substring on screen. */
+  count(needle: string): number {
+    return this.screen().split(needle).length - 1;
+  }
+
+  cursor(): { row: number; col: number } {
+    return { row: this.cursorRow, col: this.cursorCol };
+  }
+
+  // -------------------------------------------------------------------------
+
+  private currentRow(): Row {
+    this.ensureRow();
+    return this.rows[this.cursorRow]!;
+  }
+
+  private ensureRow(): void {
+    while (this.rows.length <= this.cursorRow) {
+      this.rows.push({ chars: [], softWrap: false });
+    }
+  }
+
+  /** Returns the index after the escape sequence. */
+  private handleEscape(data: string, start: number): number {
+    const next = data[start + 1];
+    if (next !== "[") return start + 2; // ESC7/ESC8 etc — ignore
+    let j = start + 2;
+    while (j < data.length && !/[a-zA-Z~]/.test(data[j]!)) j++;
+    if (j >= data.length) return data.length;
+    const final = data[j]!;
+    const params = data.slice(start + 2, j);
+    const n =
+      parseInt(params.replace(/[?]/g, ""), 10) || (final === "G" ? 1 : params === "0" ? 0 : NaN);
+    const count = Number.isNaN(n) ? (final === "J" || final === "K" ? 0 : 1) : n;
+    switch (final) {
+      case "A":
+        this.cursorRow = Math.max(0, this.cursorRow - Math.max(1, count));
+        break;
+      case "B":
+        this.cursorRow += Math.max(1, count);
+        this.ensureRow();
+        break;
+      case "C":
+        this.cursorCol = Math.min(this.cols, this.cursorCol + Math.max(1, count));
+        break;
+      case "D":
+        this.cursorCol = Math.max(0, this.cursorCol - Math.max(1, count));
+        break;
+      case "G":
+        this.cursorCol = Math.max(0, Math.max(1, count) - 1);
+        break;
+      case "K": {
+        const row = this.currentRow();
+        if (count === 0) {
+          row.chars.length = Math.min(row.chars.length, this.cursorCol);
+          row.softWrap = false;
+        } else if (count === 2) {
+          row.chars = [];
+          row.softWrap = false;
+        }
+        break;
+      }
+      case "J": {
+        if (count === 0) {
+          // Erase from cursor to end of screen
+          const row = this.currentRow();
+          row.chars.length = Math.min(row.chars.length, this.cursorCol);
+          row.softWrap = false;
+          this.rows.length = this.cursorRow + 1;
+        } else if (count === 2) {
+          for (const row of this.rows) {
+            row.chars = [];
+            row.softWrap = false;
+          }
+        }
+        break;
+      }
+      // m (SGR), h/l (modes incl. ?2026 sync, ?2004 paste), and anything
+      // else: ignored — the VT tracks characters, not attributes.
+      default:
+        break;
+    }
+    return j + 1;
+  }
+}

--- a/apps/cli/src/__tests__/status-render.test.ts
+++ b/apps/cli/src/__tests__/status-render.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { renderStatusRow, formatElapsed, spinnerFrame } from "../status-render.js";
+
+/** Strip ANSI so assertions read the text a human sees, not the escapes —
+ * same convention as approval-render.test.ts. */
+// eslint-disable-next-line no-control-regex -- stripping ANSI is the point
+const plain = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+describe("renderStatusRow", () => {
+  const t0 = 1_000_000;
+
+  it("renders verb, subject, and elapsed", () => {
+    const row = plain(
+      renderStatusRow({ verb: "delegating", subject: "read_url", startedAt: t0 }, t0 + 12_000, 0),
+    );
+    expect(row).toBe("  ·  delegating read_url · 12s");
+  });
+
+  it("renders the current step narration", () => {
+    const row = plain(
+      renderStatusRow(
+        {
+          verb: "delegating",
+          subject: "read_url",
+          step: "payment confirmed onchain",
+          startedAt: t0,
+        },
+        t0 + 30_000,
+        1,
+      ),
+    );
+    expect(row).toBe("  ·· delegating read_url — payment confirmed onchain · 30s");
+  });
+
+  it("a trouble note takes the step's place while set", () => {
+    const row = plain(
+      renderStatusRow(
+        {
+          verb: "delegating",
+          subject: "read_url",
+          step: "worker executing",
+          note: "relay hiccup, still waiting (attempt 3)",
+          startedAt: t0,
+        },
+        t0 + 41_000,
+        2,
+      ),
+    );
+    expect(row).toContain("relay hiccup, still waiting (attempt 3)");
+    expect(row).not.toContain("worker executing");
+  });
+
+  it("renders without a subject", () => {
+    const row = plain(renderStatusRow({ verb: "thinking", startedAt: t0 }, t0 + 1_000, 0));
+    expect(row).toBe("  ·  thinking · 1s");
+  });
+
+  it("never contains raw JSON braces — calm text only", () => {
+    const row = plain(
+      renderStatusRow(
+        {
+          verb: "delegating",
+          subject: "read_url",
+          note: "relay hiccup (attempt 2)",
+          startedAt: t0,
+        },
+        t0 + 5_000,
+        0,
+      ),
+    );
+    expect(row).not.toMatch(/[{}"]/);
+  });
+});
+
+describe("formatElapsed", () => {
+  it("seconds below a minute, m s above", () => {
+    expect(formatElapsed(0, 5_000)).toBe("5s");
+    expect(formatElapsed(0, 59_999)).toBe("59s");
+    expect(formatElapsed(0, 92_000)).toBe("1m 32s");
+  });
+
+  it("never goes negative on clock skew", () => {
+    expect(formatElapsed(10_000, 5_000)).toBe("0s");
+  });
+});
+
+describe("spinnerFrame", () => {
+  it("breathes: grows then shrinks, cycles", () => {
+    expect([0, 1, 2, 3, 4].map(spinnerFrame)).toEqual(["·", "··", "···", "··", "·"]);
+  });
+});

--- a/apps/cli/src/__tests__/terminal-render.test.ts
+++ b/apps/cli/src/__tests__/terminal-render.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import { VirtualTerminal } from "./helpers/vt.js";
+import { createTerminalRenderer, type TerminalRenderer } from "../terminal.js";
+
+function setup(cols = 40): { vt: VirtualTerminal; r: TerminalRenderer } {
+  const vt = new VirtualTerminal(cols);
+  const r = createTerminalRenderer({
+    write: (s) => vt.write(s),
+    columns: () => vt.cols,
+    isTTY: true,
+  });
+  return { vt, r };
+}
+
+function type(r: TerminalRenderer, text: string): void {
+  for (const ch of text) r.handleEvent({ type: "key", key: ch, ctrl: false });
+}
+
+describe("terminal renderer — owned bottom region", () => {
+  it("typing keystrokes repaints one prompt, never stacks", () => {
+    const { vt, r } = setup();
+    void r.readInput("you> ");
+    type(r, "hello world");
+    expect(vt.count("you>")).toBe(1);
+    expect(vt.screen()).toBe("you> hello world");
+  });
+
+  it("five resizes produce exactly one prompt (#455)", () => {
+    const { vt, r } = setup(40);
+    void r.readInput("you> ");
+    type(r, "hi");
+    for (const cols of [35, 30, 25, 30, 40]) {
+      vt.resize(cols);
+      r.repaint();
+    }
+    expect(vt.count("you>")).toBe(1);
+    expect(vt.screen()).toBe("you> hi");
+  });
+
+  it("narrowing below the painted width still repaints a single prompt", () => {
+    const { vt, r } = setup(30);
+    void r.readInput("you> ");
+    type(r, "a somewhat longer input");
+    vt.resize(12);
+    r.repaint();
+    expect(vt.count("you>")).toBe(1);
+    // Repainted for the new width: still a single non-wrapped row
+    expect(vt.screen().split("\n").length).toBe(1);
+  });
+
+  it("writeOutput during active input lands above the prompt", () => {
+    const { vt, r } = setup(60);
+    void r.readInput("you> ");
+    type(r, "typing");
+    r.writeOutput("  · relay hiccup — still waiting (attempt 2)\n");
+    expect(vt.screen()).toBe("  · relay hiccup — still waiting (attempt 2)\nyou> typing");
+    expect(vt.count("you>")).toBe(1);
+    // Input survives: keep typing after the interruption
+    type(r, " more");
+    expect(vt.screen().endsWith("you> typing more")).toBe(true);
+  });
+
+  it("long input h-scrolls in a single region row instead of wrapping", () => {
+    const { vt, r } = setup(20);
+    void r.readInput("you> ");
+    type(r, "abcdefghijklmnopqrstuvwxyz");
+    const lines = vt.screen().split("\n");
+    expect(lines.length).toBe(1);
+    expect(lines[0]!.length).toBeLessThan(20);
+    expect(lines[0]).toContain("…");
+    // Cursor stays on the only row, at the end of the window
+    expect(vt.cursor().row).toBe(0);
+  });
+
+  it("status row sits above the input row and updates in place", () => {
+    const { vt, r } = setup(70);
+    r.setStatusRow("  · delegating read_url · 3s");
+    void r.readInput("you> ");
+    type(r, "hi");
+    expect(vt.screen()).toBe("  · delegating read_url · 3s\nyou> hi");
+    r.setStatusRow("  · delegating read_url — relay hiccup (attempt 2) · 9s");
+    expect(vt.screen()).toBe("  · delegating read_url — relay hiccup (attempt 2) · 9s\nyou> hi");
+    expect(vt.count("delegating")).toBe(1);
+    r.setStatusRow(null);
+    expect(vt.screen()).toBe("you> hi");
+  });
+
+  it("status row truncates to the terminal width, never wraps", () => {
+    const { vt, r } = setup(20);
+    r.setStatusRow("  · delegating a-very-long-tool-name — a long narration step");
+    expect(vt.screen().split("\n").length).toBe(1);
+  });
+
+  it("streamed partial text stays pinned above the status row", () => {
+    const { vt, r } = setup();
+    r.writeOutput("mote> thinking about");
+    r.setStatusRow("  · running web_search · 1s");
+    r.writeOutput(" it");
+    expect(vt.screen()).toBe("mote> thinking about it\n  · running web_search · 1s");
+    r.writeOutput(" — done.\n");
+    r.setStatusRow(null);
+    expect(vt.screen()).toBe("mote> thinking about it — done.");
+  });
+
+  it("a partial line longer than the width flushes wrapped rows to scrollback", () => {
+    const { vt, r } = setup(10);
+    r.setStatusRow("· busy");
+    r.writeOutput("abcdefghijklmno");
+    expect(vt.screen()).toBe("abcdefghij\nklmno\n· busy");
+  });
+
+  it("submit echoes the full line and resolves", async () => {
+    const { vt, r } = setup();
+    const p = r.readInput("you> ");
+    type(r, "hello");
+    r.handleEvent({ type: "key", key: "return", ctrl: false });
+    await expect(p).resolves.toBe("hello");
+    expect(vt.screen()).toBe("you> hello");
+    // Next output lands below the echoed line
+    r.writeOutput("mote> hi\n");
+    expect(vt.screen()).toBe("you> hello\nmote> hi");
+  });
+
+  it("resize during status + input keeps both single", () => {
+    const { vt, r } = setup(40);
+    r.setStatusRow("  · delegating read_url · 12s");
+    void r.readInput("you> ");
+    type(r, "hello");
+    for (const cols of [30, 22, 34]) {
+      vt.resize(cols);
+      r.repaint();
+    }
+    expect(vt.count("you>")).toBe(1);
+    expect(vt.count("delegating")).toBe(1);
+  });
+
+  it("editing keys (backspace, arrows, ctrl+u) repaint correctly", () => {
+    const { vt, r } = setup();
+    void r.readInput("you> ");
+    type(r, "helloo");
+    r.handleEvent({ type: "key", key: "backspace", ctrl: false });
+    expect(vt.screen()).toBe("you> hello");
+    r.handleEvent({ type: "key", key: "home", ctrl: false });
+    type(r, ">");
+    expect(vt.screen()).toBe("you> >hello");
+    r.handleEvent({ type: "key", key: "u", ctrl: true });
+    expect(vt.screen()).toBe("you>");
+    expect(vt.count("you>")).toBe(1);
+  });
+
+  it("paste inserts at the cursor without corrupting the region", () => {
+    const { vt, r } = setup();
+    void r.readInput("you> ");
+    type(r, "ab");
+    r.handleEvent({ type: "key", key: "left", ctrl: false });
+    r.handleEvent({ type: "paste", text: "XY" });
+    expect(vt.screen()).toBe("you> aXYb");
+  });
+});

--- a/apps/cli/src/__tests__/vt.test.ts
+++ b/apps/cli/src/__tests__/vt.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { VirtualTerminal } from "./helpers/vt.js";
+
+describe("VirtualTerminal", () => {
+  it("renders plain text and newlines", () => {
+    const vt = new VirtualTerminal(20);
+    vt.write("hello\nworld\n");
+    expect(vt.screen()).toBe("hello\nworld");
+  });
+
+  it("carriage return + erase-to-EOL overwrites in place", () => {
+    const vt = new VirtualTerminal(20);
+    vt.write("progress 1");
+    vt.write("\r\x1b[K");
+    vt.write("progress 2");
+    expect(vt.screen()).toBe("progress 2");
+  });
+
+  it("strips SGR and ignores sync-output / paste-mode markers", () => {
+    const vt = new VirtualTerminal(40);
+    vt.write("\x1b[?2026h\x1b[2myou>\x1b[22m hi\x1b[?2026l\x1b[?2004h");
+    expect(vt.screen()).toBe("you> hi");
+  });
+
+  it("soft-wraps long lines at the column width", () => {
+    const vt = new VirtualTerminal(5);
+    vt.write("abcdefgh");
+    expect(vt.screen()).toBe("abcde\nfgh");
+    expect(vt.cursor()).toEqual({ row: 1, col: 3 });
+  });
+
+  it("cursor-up + erase-down clears a multi-row region", () => {
+    const vt = new VirtualTerminal(20);
+    vt.write("scrollback\nrow one\nrow two");
+    vt.write("\x1b[1A\r\x1b[J");
+    expect(vt.screen()).toBe("scrollback");
+    vt.write("repainted");
+    expect(vt.screen()).toBe("scrollback\nrepainted");
+  });
+
+  it("reflows soft-wrapped rows on narrowing resize, cursor follows", () => {
+    const vt = new VirtualTerminal(10);
+    vt.write("you> hello");
+    expect(vt.cursor()).toEqual({ row: 0, col: 10 });
+    vt.resize(6);
+    // "you> hello" (10 chars) rewraps to two rows at width 6
+    expect(vt.screen()).toBe("you> h\nello");
+    expect(vt.cursor()).toEqual({ row: 1, col: 4 });
+  });
+
+  it("does not rewrap rows that still fit after widening", () => {
+    const vt = new VirtualTerminal(20);
+    vt.write("line a\nyou> ");
+    vt.resize(40);
+    expect(vt.screen()).toBe("line a\nyou>");
+    expect(vt.cursor()).toEqual({ row: 1, col: 5 });
+  });
+});

--- a/apps/cli/src/attached-repl.ts
+++ b/apps/cli/src/attached-repl.ts
@@ -6,8 +6,10 @@
 // (docs/doctrine/daemon-desktop-unification.md).
 
 import type { RuntimeHostClient } from "@motebit/runtime-host";
-import { dim, warn, meta, prompt as promptColor } from "./colors.js";
-import { askQuestion, destroyTerminal, readInput, writeOutput } from "./terminal.js";
+import { action, dim, warn, meta, prompt as promptColor } from "./colors.js";
+import { askQuestion, destroyTerminal, readInput, writeLine, writeOutput } from "./terminal.js";
+import { startStatus, type StatusHandle } from "./statusline.js";
+import { formatElapsed } from "./status-render.js";
 import { renderApprovalRequest } from "./approval-render.js";
 
 /** The chunk fields the attached renderer reads. Wire chunks are the
@@ -37,6 +39,15 @@ async function renderStream(
   stream: AsyncGenerator<unknown>,
 ): Promise<{ pendingApproval: PendingApproval | null }> {
   let pendingApproval: PendingApproval | null = null;
+  // Same owned-status treatment as the coordinator REPL in stream.ts
+  // (sibling boundary rule): in-flight state lives on the status row,
+  // scrollback gets one durable line per completed act.
+  let status: StatusHandle | null = null;
+  const stopStatus = (): number => {
+    const elapsed = status?.stop() ?? 0;
+    status = null;
+    return elapsed;
+  };
   try {
     for await (const raw of stream) {
       const chunk = raw as WireChunk;
@@ -44,11 +55,23 @@ async function renderStream(
         case "text":
           if (typeof chunk.text === "string") writeOutput(chunk.text);
           break;
-        case "tool_status":
+        case "tool_status": {
+          const name = chunk.name ?? "tool";
           if (chunk.status === "calling") {
-            writeOutput(`\n${meta(`[${chunk.name ?? "tool"}]`)} `);
+            if (name === "delegate_to_agent" && status) break;
+            status =
+              name === "delegate_to_agent"
+                ? startStatus("delegating")
+                : startStatus("running", name);
+          } else if (status) {
+            // A `done` with no status in flight already rendered via
+            // delegation_complete — same guard as stream.ts.
+            writeLine(
+              `  ${action("●")} ${action(name)} ${meta(`· done · ${formatElapsed(0, stopStatus())}`)}`,
+            );
           }
           break;
+        }
         case "approval_request":
           pendingApproval = {
             name: chunk.name ?? "tool",
@@ -57,49 +80,60 @@ async function renderStream(
           };
           break;
         case "delegation_start":
-          writeOutput(`\n${dim(`[delegating · ${chunk.tool ?? ""}]`)} `);
+          if (status) break;
+          status = startStatus("delegating", chunk.tool ?? "task");
           break;
         case "delegation_complete":
+          stopStatus();
           if (chunk.receipt?.task_id != null) {
-            writeOutput(
-              `\n${dim(`[receipt ${chunk.receipt.task_id.slice(0, 8)} · ${chunk.receipt.status ?? ""}]`)}\n`,
+            writeLine(
+              dim(`[receipt ${chunk.receipt.task_id.slice(0, 8)} · ${chunk.receipt.status ?? ""}]`),
             );
           }
           break;
         case "injection_warning":
-          writeOutput(`\n${warn("⚠")} suspicious content in ${chunk.tool_name ?? "tool"} output\n`);
+          writeLine(`${warn("⚠")} suspicious content in ${chunk.tool_name ?? "tool"} output`);
           break;
         case "approval_expired":
           // #457 sibling: the coordinator-owned REPL renders this in
           // stream.ts; an attached frontend must never get silence on an
           // approval outcome either.
-          writeOutput(
-            `\n${warn("[this approval expired before your answer arrived — nothing was executed]")}\n${dim(`(${chunk.tool_name ?? "the tool"} was never run; no money moved. Ask again when ready.)`)}\n`,
+          stopStatus();
+          writeLine(
+            `${warn("[this approval expired before your answer arrived — nothing was executed]")}\n${dim(`(${chunk.tool_name ?? "the tool"} was never run; no money moved. Ask again when ready.)`)}`,
           );
           break;
         case "approval_voided":
           // #462: this turn's message set aside a pending approval (possibly
           // one prompted on another surface). Not a refusal, not an expiry.
-          writeOutput(
-            `\n${warn("[your new message set aside the pending approval — nothing was executed]")}\n${dim(`(${chunk.tool_name ?? "the tool"} was never run; no money moved. It can be proposed again.)`)}\n`,
+          stopStatus();
+          writeLine(
+            `${warn("[your new message set aside the pending approval — nothing was executed]")}\n${dim(`(${chunk.tool_name ?? "the tool"} was never run; no money moved. It can be proposed again.)`)}`,
           );
           break;
         case "invoke_error":
-          writeOutput(
-            `\n${warn(`[invoke failed${chunk.code != null ? ` · ${chunk.code}` : ""}]`)} ${chunk.message ?? ""}\n`,
+          stopStatus();
+          writeLine(
+            `${warn(`[invoke failed${chunk.code != null ? ` · ${chunk.code}` : ""}]`)} ${chunk.message ?? ""}`,
           );
           break;
         case "task_step_narration":
-          if (typeof chunk.text === "string") writeOutput(dim(chunk.text));
+          // Current step on the status row; dim durable echo in scrollback —
+          // the same two-register treatment as the coordinator REPL (#456).
+          if (typeof chunk.text === "string") {
+            status?.step(chunk.text.trim());
+            writeLine(`    ${meta("· " + chunk.text.trim())}`);
+          }
           break;
         default:
           break;
       }
     }
   } catch (err) {
-    writeOutput(
-      `\n${warn("[coordinator error]")} ${err instanceof Error ? err.message : String(err)}\n`,
-    );
+    writeLine(`${warn("[coordinator error]")} ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    // The status row must not outlive the stream (see stream.ts).
+    stopStatus();
   }
   return { pendingApproval };
 }
@@ -122,7 +156,7 @@ async function renderTurn(
       args: pendingApproval.args,
       ...(pendingApproval.riskLevel != null ? { riskLevel: pendingApproval.riskLevel } : {}),
     })) {
-      writeOutput(line + "\n");
+      writeLine(line);
     }
     const answer = await askQuestion(`  ${warn("Allow?")} ${dim("(y/n)")} `);
     const approved = answer.trim().toLowerCase() === "y";

--- a/apps/cli/src/cli-logger.ts
+++ b/apps/cli/src/cli-logger.ts
@@ -1,0 +1,67 @@
+/**
+ * Renderer-aware runtime logger — the calm channel for runtime warnings.
+ *
+ * Without an injected logger the runtime falls back to
+ * `console.warn("[motebit] …", JSON.stringify(ctx))`, which is how
+ * `delegation poll failed {"taskId":…,"status":503,"body":""}` dumped raw
+ * JSON into the input line mid-edit during the 2026-07-29 relay incident
+ * (#456). Everything here flows through the terminal renderer, so a warning
+ * can never corrupt the prompt — and poll trouble folds into the live
+ * status row as "relay hiccup, still waiting (attempt N)" instead of
+ * printing a new line per retry.
+ */
+
+import { writeLine } from "./terminal.js";
+import { activeStatus } from "./statusline.js";
+import { meta, warn } from "./colors.js";
+
+export interface RuntimeLogger {
+  warn(message: string, context?: Record<string, unknown>): void;
+}
+
+const POLL_TROUBLE = new Set(["delegation poll failed", "delegation poll token mint failed"]);
+
+/** Compact human rendering of a context object: `key=value` pairs, bounded. */
+export function formatContext(context: Record<string, unknown> | undefined): string {
+  if (!context) return "";
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(context)) {
+    if (value === undefined || value === "") continue;
+    let rendered = typeof value === "string" ? value : JSON.stringify(value);
+    if (rendered.length > 60) rendered = rendered.slice(0, 57) + "…";
+    parts.push(`${key}=${rendered}`);
+  }
+  return parts.length > 0 ? ` (${parts.join(" · ")})` : "";
+}
+
+export function createCliLogger(): RuntimeLogger {
+  // Poll-failure attempts per task, session-scoped. Delegations are few;
+  // the cap is a leak guard, not a policy.
+  const pollAttempts = new Map<string, number>();
+
+  return {
+    warn(message: string, context?: Record<string, unknown>): void {
+      if (POLL_TROUBLE.has(message)) {
+        const taskId = typeof context?.taskId === "string" ? context.taskId : "unknown";
+        if (pollAttempts.size > 100) pollAttempts.clear();
+        const attempt = (pollAttempts.get(taskId) ?? 0) + 1;
+        pollAttempts.set(taskId, attempt);
+
+        const note = `relay hiccup, still waiting (attempt ${attempt})`;
+        const status = activeStatus();
+        if (status) {
+          // The status row owns the in-flight moment — trouble is the
+          // current step, not a fresh scrollback line per retry.
+          status.note(note);
+        } else {
+          writeLine(meta(`  · ${note} — task ${taskId.slice(0, 8)}`));
+        }
+        return;
+      }
+
+      // Everything else: one calm dim line through the renderer — full
+      // information, never raw JSON into the input line.
+      writeLine(`  ${warn("·")} ${meta(message + formatContext(context))}`);
+    },
+  };
+}

--- a/apps/cli/src/runtime-factory.ts
+++ b/apps/cli/src/runtime-factory.ts
@@ -82,6 +82,7 @@ import { querySelfKnowledge } from "@motebit/self-knowledge";
 import type { SearchProvider } from "@motebit/tools";
 import type { McpServerConfig } from "@motebit/mcp-client";
 import { dim } from "./colors.js";
+import { createCliLogger } from "./cli-logger.js";
 import type { CliConfig } from "./args.js";
 import { CONFIG_DIR, loadFullConfig } from "./config.js";
 
@@ -772,6 +773,11 @@ export async function createRuntime(
     {
       motebitId,
       mcpServers,
+      // Renderer-aware logger: runtime warnings (delegation poll failures
+      // above all) flow through the terminal renderer as calm status/dim
+      // lines instead of the default console.warn JSON dump that corrupted
+      // the input line mid-edit (#456).
+      logger: createCliLogger(),
       // Persistent blast-radius accumulator — load-bearing for the money
       // meter's LIFETIME ceiling (an in-memory accumulator re-arms the
       // delegator's total bound on every restart). The CLI hosts the

--- a/apps/cli/src/scheduler.ts
+++ b/apps/cli/src/scheduler.ts
@@ -18,7 +18,16 @@ import type { PlanEngine, PlanChunk } from "@motebit/planner";
 import type { PlanStoreAdapter } from "@motebit/planner";
 import { embedText } from "@motebit/memory-graph";
 import { parseInterval } from "./intervals.js";
-import { writeOutput } from "./terminal.js";
+import { writeLine, writeOutput } from "./terminal.js";
+import { dim, warn as warnColor, error as errorColor } from "./colors.js";
+
+// Background goal/plan ticks print while the user may be mid-keystroke at
+// the prompt — every line goes through the renderer so it lands above the
+// input row instead of corrupting it (#456). Same writeOutput discipline
+// the streaming path already followed.
+const logLine = (msg: string): void => writeLine(dim(msg));
+const warnLine = (msg: string): void => writeLine(warnColor(msg));
+const errorLine = (msg: string): void => writeLine(errorColor(msg));
 
 interface SuspendedTurn {
   approvalId: string;
@@ -113,7 +122,7 @@ export class GoalScheduler {
       wall_clock_ms: 5 * 60 * 1000, // 5 min wall-clock
       project_id: null,
     });
-    console.log("[scheduler] created system memory maintenance goal (24h interval)");
+    logLine("[scheduler] created system memory maintenance goal (24h interval)");
   }
 
   /** Deny any pending approvals left over from a previous daemon run. */
@@ -123,9 +132,7 @@ export class GoalScheduler {
       this.approvalStore.resolve(a.approval_id, "denied", "daemon_restart");
     }
     if (orphans.length > 0) {
-      console.log(
-        `[scheduler] cleaned up ${orphans.length} orphaned approval(s) from previous run`,
-      );
+      logLine(`[scheduler] cleaned up ${orphans.length} orphaned approval(s) from previous run`);
     }
   }
 
@@ -195,7 +202,7 @@ export class GoalScheduler {
         project_id: projectId,
       });
 
-      console.log(`[goal] sub-goal created: ${goalId.slice(0, 8)} — "${prompt.slice(0, 40)}"`);
+      logLine(`[goal] sub-goal created: ${goalId.slice(0, 8)} — "${prompt.slice(0, 40)}"`);
       return Promise.resolve({
         ok: true,
         data: `Sub-goal created: ${goalId.slice(0, 8)} — "${prompt}"`,
@@ -219,7 +226,7 @@ export class GoalScheduler {
       await this.runtime.goals.completed({ goal_id: goalIdAtComplete, reason });
       this.goalStore.setStatus(goalIdAtComplete, "completed");
 
-      console.log(`[goal] completed by agent: ${goalIdAtComplete.slice(0, 8)} — ${reason}`);
+      logLine(`[goal] completed by agent: ${goalIdAtComplete.slice(0, 8)} — ${reason}`);
       return { ok: true, data: `Goal marked as completed: ${reason}` };
     };
 
@@ -237,7 +244,7 @@ export class GoalScheduler {
       // Outcomes are 1-per-run; progress notes are events within a run.
       await this.runtime.goals.progress({ goal_id: this.currentGoalId, note });
 
-      console.log(`[goal] progress: ${note.slice(0, 60)}`);
+      logLine(`[goal] progress: ${note.slice(0, 60)}`);
       return { ok: true, data: `Progress recorded: ${note}` };
     };
 
@@ -441,7 +448,7 @@ export class GoalScheduler {
         const elapsed = goal.last_run_at != null ? now - goal.last_run_at : Infinity;
         if (elapsed < goal.interval_ms) continue;
 
-        console.log(`[goal] executing: "${goal.prompt.slice(0, 60)}"`);
+        logLine(`[goal] executing: "${goal.prompt.slice(0, 60)}"`);
 
         // Build enriched context
         const outcomes = this.goalOutcomeStore.listForGoal(goal.goal_id, 3);
@@ -527,10 +534,10 @@ export class GoalScheduler {
             this.goalStore.setStatus(goal.goal_id, "completed");
           }
 
-          console.log(`[goal] completed: ${goal.goal_id.slice(0, 8)}`);
+          logLine(`[goal] completed: ${goal.goal_id.slice(0, 8)}`);
         } catch (err: unknown) {
           const msg = err instanceof Error ? err.message : String(err);
-          console.error(`[goal] error for ${goal.goal_id.slice(0, 8)}: ${msg}`);
+          errorLine(`[goal] error for ${goal.goal_id.slice(0, 8)}: ${msg}`);
 
           // Record failed outcome (runId = outcome_id for audit correlation)
           this.goalOutcomeStore.add({
@@ -555,7 +562,7 @@ export class GoalScheduler {
           const refreshed = this.goalStore.get(goal.goal_id);
           if (refreshed && refreshed.consecutive_failures >= refreshed.max_retries) {
             this.goalStore.setStatus(goal.goal_id, "paused");
-            console.warn(
+            warnLine(
               `[goal] auto-paused ${goal.goal_id.slice(0, 8)} after ${refreshed.consecutive_failures} consecutive failures`,
             );
           }
@@ -570,7 +577,7 @@ export class GoalScheduler {
         void this.runtime.consolidationCycle();
       }
     } catch (err: unknown) {
-      console.error("[scheduler] tick failed", err);
+      errorLine(`[scheduler] tick failed: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       this.ticking = false;
     }
@@ -637,9 +644,7 @@ export class GoalScheduler {
             toolCallId: chunk.tool_call_id,
           });
 
-          console.log(
-            `\n  [approval-pending] ${chunk.name} — approval_id: ${approvalId.slice(0, 8)}`,
-          );
+          logLine(`\n  [approval-pending] ${chunk.name} — approval_id: ${approvalId.slice(0, 8)}`);
           void this.logApprovalEvent(
             EventType.ApprovalRequested,
             goalId,
@@ -665,7 +670,7 @@ export class GoalScheduler {
         }
 
         case "injection_warning":
-          console.warn(`\n  [warning] suspicious content in ${chunk.tool_name}`);
+          warnLine(`\n  [warning] suspicious content in ${chunk.tool_name}`);
           break;
 
         case "result": {
@@ -673,7 +678,7 @@ export class GoalScheduler {
           if (result.memoriesFormed != null) {
             memoriesFormed += result.memoriesFormed.length;
           }
-          console.log("\n  [goal turn complete]");
+          logLine("\n  [goal turn complete]");
           break;
         }
       }
@@ -697,7 +702,7 @@ export class GoalScheduler {
     let planStream: AsyncGenerator<PlanChunk>;
 
     if (plan && plan.status === PlanStatus.Active) {
-      console.log(`[plan] resuming: ${plan.title} (${plan.plan_id.slice(0, 8)})`);
+      logLine(`[plan] resuming: ${plan.title} (${plan.plan_id.slice(0, 8)})`);
       planStream = this.planEngine!.resumePlan(plan.plan_id, loopDeps, undefined, runId);
     } else {
       // Retrieve relevant memories to inform plan decomposition
@@ -720,7 +725,7 @@ export class GoalScheduler {
       );
       plan = created.plan;
       if (created.truncatedFrom != null) {
-        console.warn(
+        warnLine(
           `[plan] truncated from ${created.truncatedFrom} to ${plan.total_steps} steps (max ${plan.total_steps})`,
         );
       }
@@ -745,15 +750,15 @@ export class GoalScheduler {
       }
       switch (chunk.type) {
         case "plan_created":
-          console.log(`[plan] created: "${chunk.plan.title}" (${chunk.steps.length} steps)`);
+          logLine(`[plan] created: "${chunk.plan.title}" (${chunk.steps.length} steps)`);
           break;
 
         case "plan_truncated":
-          console.warn(`[plan] truncated from ${chunk.requestedSteps} to ${chunk.maxSteps} steps`);
+          warnLine(`[plan] truncated from ${chunk.requestedSteps} to ${chunk.maxSteps} steps`);
           break;
 
         case "step_started":
-          console.log(`[plan] step ${chunk.step.ordinal + 1}: ${chunk.step.description}`);
+          logLine(`[plan] step ${chunk.step.ordinal + 1}: ${chunk.step.description}`);
           break;
 
         case "step_chunk":
@@ -772,7 +777,7 @@ export class GoalScheduler {
               writeOutput(" done\n");
             }
           } else if (chunk.chunk.type === "injection_warning") {
-            console.warn(`\n  [warning] suspicious content in ${chunk.chunk.tool_name}`);
+            warnLine(`\n  [warning] suspicious content in ${chunk.chunk.tool_name}`);
           } else if (chunk.chunk.type === "result") {
             if (chunk.chunk.result.memoriesFormed != null) {
               memoriesFormed += chunk.chunk.result.memoriesFormed.length;
@@ -781,11 +786,11 @@ export class GoalScheduler {
           break;
 
         case "step_completed":
-          console.log(`\n  [step ${chunk.step.ordinal + 1} complete]`);
+          logLine(`\n  [step ${chunk.step.ordinal + 1} complete]`);
           break;
 
         case "step_failed":
-          console.error(`\n  [step ${chunk.step.ordinal + 1} failed: ${chunk.error}]`);
+          errorLine(`\n  [step ${chunk.step.ordinal + 1} failed: ${chunk.error}]`);
           break;
 
         case "approval_request": {
@@ -818,7 +823,7 @@ export class GoalScheduler {
             createdAt: now,
             toolCallId: innerChunk.tool_call_id,
           });
-          console.log(
+          logLine(
             `\n  [approval-pending] ${innerChunk.name} — approval_id: ${approvalId.slice(0, 8)}`,
           );
           void this.logApprovalEvent(
@@ -833,15 +838,15 @@ export class GoalScheduler {
         }
 
         case "plan_completed":
-          console.log(`[plan] completed: ${chunk.plan.title}`);
+          logLine(`[plan] completed: ${chunk.plan.title}`);
           break;
 
         case "plan_failed":
-          console.error(`[plan] failed: ${chunk.reason}`);
+          errorLine(`[plan] failed: ${chunk.reason}`);
           break;
 
         case "reflection": {
-          console.log(`[plan] reflection: ${chunk.result.summary}`);
+          logLine(`[plan] reflection: ${chunk.result.summary}`);
           const stored = await this.persistReflectionMemories(
             chunk.result.memoryCandidates,
             goalId,
@@ -864,7 +869,7 @@ export class GoalScheduler {
     const now = Date.now();
     const expiredCount = this.approvalStore.expireStale(now);
     if (expiredCount > 0) {
-      console.log(`[approvals] expired ${expiredCount} stale approval(s)`);
+      logLine(`[approvals] expired ${expiredCount} stale approval(s)`);
     }
 
     // Clean up in-memory map for expired items and release runtime
@@ -880,13 +885,13 @@ export class GoalScheduler {
         // old path discarded the resume stream with zero output.
         const pending = this.runtime.pendingApprovalInfo;
         if (pending != null && pending.toolCallId === turn.toolCallId) {
-          console.log(
+          logLine(
             `[approval] expired → denying suspended turn ${id.slice(0, 8)} (${pending.toolName}) to release the runtime`,
           );
           const resumeStream = this.runtime.resumeAfterApproval(false);
           void this.consumeAndDiscard(resumeStream);
         } else if (pending != null) {
-          console.log(
+          logLine(
             `[approval] expired ${id.slice(0, 8)} but the runtime's pending approval belongs to another actor (${pending.toolName}) — leaving it untouched`,
           );
         }
@@ -901,9 +906,7 @@ export class GoalScheduler {
       if (item.status !== "approved" && item.status !== "denied") continue;
 
       const approved = item.status === "approved";
-      console.log(
-        `[approval] draining ${approved ? "approved" : "denied"}: ${approvalId.slice(0, 8)}`,
-      );
+      logLine(`[approval] draining ${approved ? "approved" : "denied"}: ${approvalId.slice(0, 8)}`);
 
       // Resume ONLY the approval this suspended turn owns (#462). If the
       // runtime's pending approval is a different one (another actor's — in
@@ -920,11 +923,11 @@ export class GoalScheduler {
           this.goalStore.updateLastRun(turn.goalId, Date.now());
         }
       } else if (pending != null) {
-        console.log(
+        logLine(
           `[approval] ${approvalId.slice(0, 8)} resolved, but the runtime's pending approval belongs to another actor (${pending.toolName}) — this turn was already voided; not resuming`,
         );
       } else {
-        console.log(
+        logLine(
           `[approval] ${approvalId.slice(0, 8)} resolved, but its suspended turn is gone (voided or expired) — nothing to resume`,
         );
       }
@@ -953,7 +956,7 @@ export class GoalScheduler {
       }
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.error(`[approval] release drain failed (will retry next tick): ${msg}`);
+      errorLine(`[approval] release drain failed (will retry next tick): ${msg}`);
     }
   }
 
@@ -982,7 +985,7 @@ export class GoalScheduler {
       }
     }
     if (stored > 0) {
-      console.log(`[plan] stored ${stored} learning memor${stored === 1 ? "y" : "ies"}`);
+      logLine(`[plan] stored ${stored} learning memor${stored === 1 ? "y" : "ies"}`);
     }
     return stored;
   }

--- a/apps/cli/src/status-render.ts
+++ b/apps/cli/src/status-render.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure render for the status row — the calm one-line answer to "is it
+ * waiting on me or working?" during any await (#456).
+ *
+ * Same precedent as approval-render.ts: pure function, unit-tested, no IO.
+ * The terminal renderer truncates the row to the terminal width, so this
+ * builds content without worrying about wrap; statusline.ts owns the clock
+ * and the repaint tick.
+ *
+ * Register (felt-interior: minimum display ≠ minimum legibility):
+ *   · delegating read_url — payment confirmed onchain · 12s
+ *   ·· delegating read_url — relay hiccup, still waiting (attempt 3) · 41s
+ */
+
+import { meta, progress, warn } from "./colors.js";
+
+export interface StatusState {
+  /** What kind of work: "delegating", "running", "thinking". */
+  verb: string;
+  /** The tool or worker the verb applies to. */
+  subject?: string;
+  /** Latest step narration — what it's doing right now. */
+  step?: string;
+  /**
+   * Transient trouble note ("relay hiccup, still waiting (attempt 3)").
+   * Takes the step's place while set — trouble is the current step.
+   */
+  note?: string;
+  /** Epoch ms when the work started; elapsed renders from this. */
+  startedAt: number;
+}
+
+/** The animated pulse — the CLI's existing dots language, breathing. */
+const FRAMES = ["·", "··", "···", "··"] as const;
+
+export function spinnerFrame(frame: number): string {
+  return FRAMES[frame % FRAMES.length]!;
+}
+
+export function formatElapsed(startedAt: number, nowMs: number): string {
+  const totalSec = Math.max(0, Math.floor((nowMs - startedAt) / 1000));
+  if (totalSec < 60) return `${totalSec}s`;
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return `${min}m ${sec}s`;
+}
+
+export function renderStatusRow(state: StatusState, nowMs: number, frame: number): string {
+  const glyph = spinnerFrame(frame).padEnd(3);
+  const subject = state.subject ? ` ${state.subject}` : "";
+  const detail = state.note ?? state.step;
+  const detailPart = detail ? ` ${meta("—")} ${state.note ? warn(detail) : meta(detail)}` : "";
+  return (
+    `  ${progress(glyph)}` +
+    meta(`${state.verb}${subject}`) +
+    detailPart +
+    meta(` · ${formatElapsed(state.startedAt, nowMs)}`)
+  );
+}

--- a/apps/cli/src/statusline.ts
+++ b/apps/cli/src/statusline.ts
@@ -1,0 +1,80 @@
+/**
+ * Status-line controller — owns the clock behind the status row.
+ *
+ * One status is active at a time (the CLI runs one turn at a time); starting
+ * a new one replaces the old. The controller ticks a repaint every 250ms so
+ * elapsed time and the pulse stay honest, and exposes the active handle so
+ * the injected runtime logger can fold poll trouble into the same row
+ * instead of dumping JSON into the input line (#456).
+ */
+
+import { setStatusRow } from "./terminal.js";
+import { renderStatusRow, type StatusState } from "./status-render.js";
+
+const TICK_MS = 250;
+
+export interface StatusHandle {
+  /** Update the current-step narration. */
+  step(text: string): void;
+  /** Set (or clear with null) a transient trouble note + attempt count. */
+  note(text: string | null): void;
+  /** Clear the row and stop the clock. Returns elapsed ms. Idempotent. */
+  stop(): number;
+}
+
+let current: { handle: StatusHandle; stopFn: () => void } | null = null;
+
+export function startStatus(verb: string, subject?: string): StatusHandle {
+  // One turn, one status: a newly started status replaces any prior one.
+  current?.stopFn();
+
+  const state: StatusState = {
+    verb,
+    ...(subject !== undefined ? { subject } : {}),
+    startedAt: Date.now(),
+  };
+  let frame = 0;
+  let stopped = false;
+
+  const paint = (): void => {
+    setStatusRow(renderStatusRow(state, Date.now(), frame));
+  };
+  const timer = setInterval(() => {
+    frame++;
+    paint();
+  }, TICK_MS);
+
+  const stop = (): number => {
+    if (stopped) return 0;
+    stopped = true;
+    clearInterval(timer);
+    if (current?.handle === handle) current = null;
+    setStatusRow(null);
+    return Date.now() - state.startedAt;
+  };
+
+  const handle: StatusHandle = {
+    step(text: string): void {
+      if (stopped) return;
+      state.step = text;
+      delete state.note; // fresh progress clears stale trouble
+      paint();
+    },
+    note(text: string | null): void {
+      if (stopped) return;
+      if (text === null) delete state.note;
+      else state.note = text;
+      paint();
+    },
+    stop,
+  };
+
+  current = { handle, stopFn: () => void stop() };
+  paint();
+  return handle;
+}
+
+/** The active status, if any — the logger folds poll trouble into it. */
+export function activeStatus(): StatusHandle | null {
+  return current?.handle ?? null;
+}

--- a/apps/cli/src/stream.ts
+++ b/apps/cli/src/stream.ts
@@ -3,26 +3,19 @@
 import type { MotebitRuntime, StreamChunk } from "@motebit/runtime";
 import { formatBodyAwareness } from "@motebit/ai-core";
 import { action, meta, warn, dim, prompt as promptColor } from "./colors.js";
-import { writeOutput, askQuestion } from "./terminal.js";
+import { writeOutput, writeLine, askQuestion } from "./terminal.js";
+import { startStatus, type StatusHandle } from "./statusline.js";
+import { formatElapsed } from "./status-render.js";
 import { archiveReceipt, renderReceipt } from "./receipt.js";
 import { renderApprovalRequest } from "./approval-render.js";
 import { renderAuthorityDelta } from "./authority-delta-render.js";
 import type { VoiceController } from "./voice.js";
 
-// Animated dots: cycles .  → .. → ... while a tool call is in flight.
-// Returns a stop function that clears the interval and writes " done\n".
-function startDotAnimation(): () => void {
-  let dots = 1;
-  const timer = setInterval(() => {
-    dots = (dots % 3) + 1;
-    // Erase previous dots (max 3 chars) and rewrite
-    writeOutput(`\x1b[${3}D${meta(".".repeat(dots) + " ".repeat(3 - dots))}`);
-  }, 400);
-  return () => {
-    clearInterval(timer);
-    // Erase dots, write " done\n"
-    writeOutput(`\x1b[${3}D${meta("...")} ${meta("done")}\n`);
-  };
+/** The durable scrollback record of a finished tool call. In-flight state
+ * lives on the status row (statusline.ts); scrollback gets one calm line
+ * per completed act, with how long it took. */
+function toolDoneLine(name: string, elapsedMs: number): string {
+  return `  ${action("●")} ${action(name)} ${meta(`· done · ${formatElapsed(0, elapsedMs)}`)}`;
 }
 
 export async function consumeStream(
@@ -37,161 +30,169 @@ export async function consumeStream(
     quorum?: { required: number; approvers: string[]; collected: string[] };
     risk_level?: number;
   } | null = null;
-  let stopAnimation: (() => void) | null = null;
+  let status: StatusHandle | null = null;
+  const stopStatus = (): number => {
+    const elapsed = status?.stop() ?? 0;
+    status = null;
+    return elapsed;
+  };
   let lastCompletedReceiptResult: string | null = null;
   // #457: whether ANY chunk arrived — the caller uses this to guarantee an
   // approval answer never ends in pure silence. Returns true once a chunk
   // is observed (every chunk type renders or deliberately captures).
   let sawAnyChunk = false;
 
-  for await (const chunk of stream) {
-    sawAnyChunk = true;
-    switch (chunk.type) {
-      case "text":
-        writeOutput(chunk.text);
-        break;
+  try {
+    for await (const chunk of stream) {
+      sawAnyChunk = true;
+      switch (chunk.type) {
+        case "text":
+          writeOutput(chunk.text);
+          break;
 
-      case "tool_status":
-        // Owner-facing authority residual — render the exact repair even
-        // for delegation tools (the delta rides only this surface channel;
-        // the model saw the coarse reason). See AuthorityDelta invariants.
-        if (chunk.status === "done" && chunk.missing_authority != null) {
-          if (stopAnimation) {
-            stopAnimation();
-            stopAnimation = null;
+        case "tool_status":
+          // Owner-facing authority residual — render the exact repair even
+          // for delegation tools (the delta rides only this surface channel;
+          // the model saw the coarse reason). See AuthorityDelta invariants.
+          if (chunk.status === "done" && chunk.missing_authority != null) {
+            stopStatus();
+            for (const line of renderAuthorityDelta(chunk.name, chunk.missing_authority)) {
+              writeLine(meta(line));
+            }
+            break;
           }
-          for (const line of renderAuthorityDelta(chunk.name, chunk.missing_authority)) {
-            writeOutput(meta(line) + "\n");
+          // Delegation normally announces itself via delegation_start/complete,
+          // so tool_status is redundant — UNLESS this is the post-approval
+          // execution path, which executes the tool directly and emits ONLY
+          // tool_status. Blanket-skipping delegate_to_agent here meant the one
+          // path that runs after a human approves a PAID hire rendered nothing
+          // at all: the screen went blank for the entire task (#432). Skip only
+          // when a status is already running (delegation_start beat us).
+          if (chunk.name === "delegate_to_agent" && chunk.status === "calling" && status) {
+            break;
+          }
+          if (chunk.status === "calling") {
+            status =
+              chunk.name === "delegate_to_agent"
+                ? startStatus("delegating")
+                : startStatus("running", chunk.name);
+          } else if (status) {
+            // Scrollback gets one durable line per completed act; the
+            // in-flight state lived on the status row. A `done` with no
+            // status in flight is the redundant twin of a delegation_complete
+            // that already rendered — old code printed a stray " done" here.
+            writeLine(toolDoneLine(chunk.name, stopStatus()));
           }
           break;
-        }
-        // Delegation normally announces itself via delegation_start/complete,
-        // so tool_status is redundant — UNLESS this is the post-approval
-        // execution path, which executes the tool directly and emits ONLY
-        // tool_status. Blanket-skipping delegate_to_agent here meant the one
-        // path that runs after a human approves a PAID hire rendered nothing
-        // at all: the screen went blank for the entire task (#432). Skip only
-        // when an animation is already running (delegation_start beat us).
-        if (chunk.name === "delegate_to_agent" && chunk.status === "calling" && stopAnimation) {
+
+        case "approval_request":
+          pendingApproval = {
+            tool_call_id: chunk.tool_call_id,
+            name: chunk.name,
+            args: chunk.args,
+            quorum: chunk.quorum,
+            // Carried so the prompt can name the stakes. Previously dropped —
+            // which is why a money act rendered identically to a read (#432).
+            risk_level: chunk.risk_level,
+          };
           break;
-        }
-        if (chunk.status === "calling") {
-          writeOutput(`\n  ${action("●")} ${action(chunk.name)}${meta("...")}`);
-          stopAnimation = startDotAnimation();
-        } else {
-          if (stopAnimation) {
-            stopAnimation();
-            stopAnimation = null;
-          } else writeOutput(meta(" done") + "\n");
-        }
-        break;
 
-      case "approval_request":
-        pendingApproval = {
-          tool_call_id: chunk.tool_call_id,
-          name: chunk.name,
-          args: chunk.args,
-          quorum: chunk.quorum,
-          // Carried so the prompt can name the stakes. Previously dropped —
-          // which is why a money act rendered identically to a read (#432).
-          risk_level: chunk.risk_level,
-        };
-        break;
+        case "delegation_start":
+          // Guard against a second status when tool_status already started
+          // one (the post-approval path emits tool_status first).
+          if (status) break;
+          status = startStatus("delegating", chunk.tool);
+          break;
 
-      case "delegation_start":
-        // Guard against a second animation when tool_status already started
-        // one (the post-approval path emits tool_status first).
-        if (stopAnimation) break;
-        writeOutput(
-          `\n  ${action("●")} ${dim("[delegating]")} ${action(chunk.tool)}${meta("...")}`,
-        );
-        stopAnimation = startDotAnimation();
-        break;
+        case "task_step_narration":
+          // What it's doing right now, at supervisor granularity — "payment
+          // confirmed onchain, waiting on the worker" is a different emotional
+          // state than animated dots (#456). The status row shows the current
+          // step; scrollback keeps a dim durable echo so a fast next step
+          // doesn't erase the story.
+          status?.step(chunk.text.trim());
+          writeLine(`    ${meta("· " + chunk.text.trim())}`);
+          break;
 
-      case "delegation_complete":
-        if (stopAnimation) {
-          stopAnimation();
-          stopAnimation = null;
-        } else writeOutput(meta(" done") + "\n");
-        // Archive the signed receipt so `/receipt <task-id>` can re-render
-        // it, and emerge a CLI-native rendering right here — the "oh" beat
-        // that proves the delegation actually happened and the signature
-        // checks out locally. Mirrors the web receipt-artifact.
-        if (chunk.full_receipt) {
-          archiveReceipt(chunk.full_receipt);
-          await renderReceipt(chunk.full_receipt, (line) => writeOutput(line + "\n"));
-          if (chunk.full_receipt.status === "completed" && chunk.full_receipt.result) {
-            lastCompletedReceiptResult = chunk.full_receipt.result;
+        case "delegation_complete":
+          if (status) writeLine(toolDoneLine(chunk.tool, stopStatus()));
+          // Archive the signed receipt so `/receipt <task-id>` can re-render
+          // it, and emerge a CLI-native rendering right here — the "oh" beat
+          // that proves the delegation actually happened and the signature
+          // checks out locally. Mirrors the web receipt-artifact.
+          if (chunk.full_receipt) {
+            archiveReceipt(chunk.full_receipt);
+            await renderReceipt(chunk.full_receipt, (line) => writeOutput(line + "\n"));
+            if (chunk.full_receipt.status === "completed" && chunk.full_receipt.result) {
+              lastCompletedReceiptResult = chunk.full_receipt.result;
+            }
           }
-        }
-        break;
+          break;
 
-      case "injection_warning":
-        writeOutput(`\n  ${warn("⚠")} ${warn("suspicious content in " + chunk.tool_name)}\n`);
-        break;
+        case "injection_warning":
+          writeLine(`  ${warn("⚠")} ${warn("suspicious content in " + chunk.tool_name)}`);
+          break;
 
-      case "approval_expired":
-        // #457: an approval submitted after the timeout voided it used to
-        // end with NOTHING on screen — an approved money action with no
-        // rendered outcome. The runtime now emits this typed chunk; say
-        // plainly that nothing executed and how to proceed.
-        if (stopAnimation) {
-          stopAnimation();
-          stopAnimation = null;
-        }
-        writeOutput(
-          `\n  ${warn("[this approval expired before your answer arrived — nothing was executed]")}\n` +
-            `  ${dim(`(${chunk.tool_name} was never run; no money moved. Ask again when ready.)`)}\n`,
-        );
-        break;
+        case "approval_expired":
+          // #457: an approval submitted after the timeout voided it used to
+          // end with NOTHING on screen — an approved money action with no
+          // rendered outcome. The runtime now emits this typed chunk; say
+          // plainly that nothing executed and how to proceed.
+          stopStatus();
+          writeLine(
+            `  ${warn("[this approval expired before your answer arrived — nothing was executed]")}\n` +
+              `  ${dim(`(${chunk.tool_name} was never run; no money moved. Ask again when ready.)`)}`,
+          );
+          break;
 
-      case "approval_voided":
-        // #462: this turn's message set aside a pending approval before the
-        // human answered. Not a refusal, not an expiry — say what happened
-        // and that nothing ran.
-        if (stopAnimation) {
-          stopAnimation();
-          stopAnimation = null;
-        }
-        writeOutput(
-          `\n  ${warn("[your new message set aside the pending approval — nothing was executed]")}\n` +
-            `  ${dim(`(${chunk.tool_name} was never run; no money moved. It can be proposed again.)`)}\n`,
-        );
-        break;
+        case "approval_voided":
+          // #462: this turn's message set aside a pending approval before the
+          // human answered. Not a refusal, not an expiry — say what happened
+          // and that nothing ran.
+          stopStatus();
+          writeLine(
+            `  ${warn("[your new message set aside the pending approval — nothing was executed]")}\n` +
+              `  ${dim(`(${chunk.tool_name} was never run; no money moved. It can be proposed again.)`)}`,
+          );
+          break;
 
-      case "invoke_error":
-        if (stopAnimation) {
-          stopAnimation();
-          stopAnimation = null;
-        }
-        writeOutput(`\n  ${warn("[invoke failed · " + chunk.code + "]")}\n`);
-        if (chunk.message) writeOutput(`  ${dim(chunk.message)}\n`);
-        break;
+        case "invoke_error":
+          stopStatus();
+          writeLine(`  ${warn("[invoke failed · " + chunk.code + "]")}`);
+          if (chunk.message) writeLine(`  ${dim(chunk.message)}`);
+          break;
 
-      case "result": {
-        const result = chunk.result;
-        writeOutput("\n\n");
+        case "result": {
+          const result = chunk.result;
+          stopStatus();
+          writeOutput("\n\n");
 
-        if (result.memoriesFormed.length > 0) {
+          if (result.memoriesFormed.length > 0) {
+            writeOutput(
+              meta(
+                `  [memories: ${result.memoriesFormed.map((m: { content: string }) => m.content).join(", ")}]`,
+              ) + "\n",
+            );
+          }
+
+          const s = result.stateAfter;
           writeOutput(
             meta(
-              `  [memories: ${result.memoriesFormed.map((m: { content: string }) => m.content).join(", ")}]`,
+              `  [state: attention=${s.attention.toFixed(2)} confidence=${s.confidence.toFixed(2)} valence=${s.affect_valence.toFixed(2)} curiosity=${s.curiosity.toFixed(2)}]`,
             ) + "\n",
           );
+          const bodyLine = formatBodyAwareness(result.cues);
+          if (bodyLine) writeOutput(meta(`  ${bodyLine}`) + "\n");
+          writeOutput("\n");
+          break;
         }
-
-        const s = result.stateAfter;
-        writeOutput(
-          meta(
-            `  [state: attention=${s.attention.toFixed(2)} confidence=${s.confidence.toFixed(2)} valence=${s.affect_valence.toFixed(2)} curiosity=${s.curiosity.toFixed(2)}]`,
-          ) + "\n",
-        );
-        const bodyLine = formatBodyAwareness(result.cues);
-        if (bodyLine) writeOutput(meta(`  ${bodyLine}`) + "\n");
-        writeOutput("\n");
-        break;
       }
     }
+  } finally {
+    // The status row must not outlive the stream — a thrown provider or
+    // relay error would otherwise leave a forever-pulsing "delegating"
+    // above the prompt (and its interval alive).
+    stopStatus();
   }
 
   // Handle approval request after stream ends -- deterministic resumption
@@ -207,7 +208,7 @@ export async function consumeStream(
       ...(pendingApproval.quorum ? { quorum: pendingApproval.quorum } : {}),
       ...(opts?.budgetUsd != null ? { budgetUsd: opts.budgetUsd } : {}),
     })) {
-      writeOutput(line + "\n");
+      writeLine(line);
     }
     const answer = await askQuestion(`  ${warn("Allow?")} ${dim("(y/n)")} `);
 

--- a/apps/cli/src/terminal.ts
+++ b/apps/cli/src/terminal.ts
@@ -1,12 +1,22 @@
 /**
- * Custom terminal renderer — owns raw stdin, no readline.
+ * Custom terminal renderer — owns raw stdin and the bottom of the screen.
  *
- * Two regions: output scrolls above, input pinned to bottom.
- * Event-driven redraw — each event redraws the affected region.
- * No cursor tracking state accumulates across events.
+ * The screen splits into two regions:
+ *   - scrollback (above): append-only, plain prints, never edited
+ *   - the owned bottom region: up to three non-wrapping rows —
+ *     a pending partial output line, a status row, and the input row
  *
- * Replaces input.ts entirely. stream.ts uses writeOutput() instead of
- * process.stdout.write() so output and input never collide.
+ * Every mutation goes through one `commit()`: clear the previously painted
+ * region, append any completed scrollback, repaint the region rows, park the
+ * cursor. Because region rows are truncated/h-scrolled to the terminal width
+ * they NEVER soft-wrap, so "how many rows do I move up to clear" has an exact
+ * answer — including across a resize, where the clear recomputes row heights
+ * at the new width under the macOS reflow model (#455: resize is a repaint,
+ * never a fresh print). Repaints are wrapped in synchronized-output markers
+ * (ESC[?2026) so a repaint is never seen half-done.
+ *
+ * stream.ts, the scheduler, and the injected runtime logger all write through
+ * writeOutput() so output and input never collide (#456).
  */
 
 // ---------------------------------------------------------------------------
@@ -25,40 +35,389 @@ interface InputState {
   promptWidth: number;
 }
 
+/** IO seam so tests can render into a virtual terminal. */
+export interface TerminalIO {
+  write(s: string): void;
+  columns(): number;
+  isTTY: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // ANSI helpers
 // ---------------------------------------------------------------------------
 
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1b\[[0-9;?]*[a-zA-Z~]/g;
+
 /** Strip ANSI escape codes to get visible character count. */
-function visibleLength(s: string): number {
-  // eslint-disable-next-line no-control-regex
-  return s.replace(/\x1b\[[0-9;]*[a-zA-Z~]/g, "").length;
+export function visibleLength(s: string): number {
+  return s.replace(ANSI_RE, "").length;
 }
+
+/**
+ * Slice a string by VISIBLE character index, preserving every escape
+ * sequence encountered up to the end of the slice (styling opened before
+ * the window still applies inside it).
+ */
+function sliceVisible(s: string, start: number, end: number): string {
+  let out = "";
+  let vis = 0;
+  let i = 0;
+  while (i < s.length && vis < end) {
+    if (s[i] === "\x1b") {
+      ANSI_RE.lastIndex = i;
+      const m = ANSI_RE.exec(s);
+      if (m && m.index === i) {
+        out += m[0];
+        i += m[0].length;
+        continue;
+      }
+    }
+    if (vis >= start) out += s[i]!;
+    vis++;
+    i++;
+  }
+  return out;
+}
+
+const RESET = "\x1b[0m";
+const SYNC_START = "\x1b[?2026h";
+const SYNC_END = "\x1b[?2026l";
 
 const PASTE_OPEN = "\x1b[200~";
 const PASTE_CLOSE = "\x1b[201~";
 
+/** Rows a painted row of visible width `w` occupies after reflow at `cols`. */
+function rowsAt(w: number, cols: number): number {
+  return w > 0 ? Math.floor((w - 1) / cols) + 1 : 1;
+}
+
+/** The cursor's visual row within a row of text, given its column. */
+function cursorVisRow(col: number, cols: number): number {
+  return col > 0 ? Math.floor((col - 1) / cols) : 0;
+}
+
 // ---------------------------------------------------------------------------
-// Singleton state
+// Renderer
 // ---------------------------------------------------------------------------
 
-let initialized = false;
-let inputActive = false;
-let inputState: InputState = { line: "", cursor: 0, prompt: "", promptWidth: 0 };
-let inputResolver: ((line: string) => void) | null = null;
+export interface TerminalRenderer {
+  writeOutput(text: string): void;
+  /** Write a full line of output: completes any pending partial line first,
+   * appends a newline. For line-shaped records (status echoes, tool
+   * completion lines) that must never glue onto streamed text. */
+  writeLine(text: string): void;
+  readInput(promptText: string): Promise<string>;
+  setStatusRow(row: string | null): void;
+  handleEvent(event: TerminalEvent): void;
+  /** Repaint in place — the resize path. Idempotent. */
+  repaint(): void;
+  /** Abandon any active input (stdin closed / shutdown). */
+  detach(): void;
+}
+
+export function createTerminalRenderer(io: TerminalIO): TerminalRenderer {
+  let inputActive = false;
+  let inputState: InputState = { line: "", cursor: 0, prompt: "", promptWidth: 0 };
+  let inputResolver: ((line: string) => void) | null = null;
+  let inputRejecter: (() => void) | null = null;
+
+  /** Partial output line not yet completed by a \n — painted as the region's
+   * top row so streamed text and the status/input rows never collide. */
+  let tail = "";
+  let statusRow: string | null = null;
+
+  // What the last commit painted, for exact clearing (widths are VISIBLE
+  // widths; cursorCol is where the cursor was parked on the last row).
+  let painted: { widths: number[]; cursorCol: number } = { widths: [], cursorCol: 0 };
+
+  function buildInputRow(cols: number): { row: string; width: number; cursorCol: number } {
+    const avail = Math.max(1, cols - 1 - inputState.promptWidth);
+    if (inputState.line.length <= avail) {
+      return {
+        row: inputState.prompt + inputState.line,
+        width: inputState.promptWidth + inputState.line.length,
+        cursorCol: inputState.promptWidth + inputState.cursor,
+      };
+    }
+    // Horizontal scroll: window the line around the cursor. Never wrap —
+    // the non-wrapping region row is what makes clearing (and resize) exact.
+    const start = Math.max(
+      0,
+      Math.min(inputState.cursor - Math.floor(avail / 2), inputState.line.length - avail),
+    );
+    const windowText = inputState.line.slice(start, start + avail);
+    const shown = start > 0 ? "…" + windowText.slice(1) : windowText;
+    return {
+      row: inputState.prompt + shown,
+      width: inputState.promptWidth + shown.length,
+      cursorCol: inputState.promptWidth + (inputState.cursor - start),
+    };
+  }
+
+  /**
+   * The one write path. Clears the previously painted region (reflow-aware),
+   * appends completed scrollback, repaints the region rows, parks the cursor.
+   */
+  function commit(scrollback: string): void {
+    const cols = Math.max(2, io.columns());
+    let out = "";
+
+    if (painted.widths.length > 0) {
+      // Clear the old region. Row heights are recomputed at the CURRENT
+      // width: if the terminal narrowed since the last paint, a reflowing
+      // terminal (macOS Terminal/iTerm2 — where #455 was witnessed) rewrapped
+      // our rows and moved the cursor with the text. On a non-reflowing
+      // terminal this can overshoot by a scrollback line on shrink — a far
+      // smaller wound than the duplicate-prompt class it closes.
+      let up = cursorVisRow(painted.cursorCol, cols);
+      for (let i = 0; i < painted.widths.length - 1; i++) {
+        up += rowsAt(painted.widths[i]!, cols);
+      }
+      if (up > 0) out += `\x1b[${up}A`;
+      out += "\r\x1b[J";
+    }
+
+    out += scrollback;
+
+    const rows: string[] = [];
+    const widths: number[] = [];
+    if (tail !== "") {
+      rows.push(tail + (io.isTTY ? RESET : ""));
+      widths.push(visibleLength(tail));
+    }
+    if (statusRow !== null) {
+      const truncated = sliceVisible(statusRow, 0, cols - 1);
+      rows.push(truncated + (io.isTTY ? RESET : ""));
+      widths.push(visibleLength(truncated));
+    }
+    let cursorCol = 0;
+    if (inputActive) {
+      const built = buildInputRow(cols);
+      rows.push(built.row);
+      widths.push(built.width);
+      cursorCol = built.cursorCol;
+    } else if (widths.length > 0) {
+      cursorCol = widths[widths.length - 1]!;
+    }
+
+    if (rows.length > 0) {
+      out += rows.join("\n");
+      out += "\r";
+      if (cursorCol > 0) out += `\x1b[${cursorCol}C`;
+    }
+
+    const hadOrHasRegion = painted.widths.length > 0 || rows.length > 0;
+    painted = { widths, cursorCol };
+    if (out === "") return;
+    io.write(io.isTTY && hadOrHasRegion ? SYNC_START + out + SYNC_END : out);
+  }
+
+  /** Whether raw passthrough output (non-TTY path) is at a line start. */
+  let atLineStart = true;
+
+  function writeOutput(text: string): void {
+    if (!io.isTTY && statusRow === null && !inputActive && tail === "") {
+      if (text.length > 0) atLineStart = text.endsWith("\n");
+      io.write(text);
+      return;
+    }
+    // Fold into the tail, flushing completed lines (and any full-width
+    // overflow of the remaining partial line) to scrollback in order.
+    let buffer = tail + text;
+    tail = "";
+    let scrollback = "";
+    const lastNl = buffer.lastIndexOf("\n");
+    if (lastNl !== -1) {
+      scrollback = buffer.slice(0, lastNl + 1);
+      buffer = buffer.slice(lastNl + 1);
+    }
+    const cols = Math.max(2, io.columns());
+    while (visibleLength(buffer) >= cols) {
+      // The partial line has visually wrapped — commit the wrapped slice as
+      // scrollback (exactly `cols` visible chars: the terminal soft-wraps it
+      // identically) and keep only the last visual row pinned.
+      scrollback += sliceVisible(buffer, 0, cols);
+      buffer = sliceVisible(buffer, cols, Number.MAX_SAFE_INTEGER);
+    }
+    tail = buffer;
+    commit(scrollback);
+  }
+
+  function writeLine(text: string): void {
+    const midLine = io.isTTY ? tail !== "" : !atLineStart;
+    writeOutput((midLine ? "\n" : "") + text + "\n");
+  }
+
+  function setStatusRow(row: string | null): void {
+    if (!io.isTTY) return;
+    if (row === statusRow) return;
+    statusRow = row;
+    commit("");
+  }
+
+  function submit(): void {
+    const line = inputState.line;
+    inputActive = false;
+    // Durable echo of the full typed line (even if it was h-scrolled).
+    commit(inputState.prompt + line + "\n");
+    if (inputResolver) {
+      const resolve = inputResolver;
+      inputResolver = null;
+      inputRejecter = null;
+      resolve(line);
+    }
+  }
+
+  function handleEvent(event: TerminalEvent): void {
+    if (event.type === "resize") {
+      commit("");
+      return;
+    }
+    if (!inputActive) return;
+    const result = applyEvent(inputState, event);
+    if (result === "submit") {
+      submit();
+    } else if (result === "exit") {
+      io.write("\n");
+      destroyTerminal();
+      process.exit(0);
+    } else {
+      inputState = result.state;
+      commit("");
+    }
+  }
+
+  function readInput(promptText: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      // The input row needs its own line — complete any pending partial.
+      if (tail !== "") writeOutput("\n");
+      inputState = {
+        line: "",
+        cursor: 0,
+        prompt: promptText,
+        promptWidth: visibleLength(promptText),
+      };
+      inputActive = true;
+      inputResolver = resolve;
+      inputRejecter = reject;
+      if (!io.isTTY) {
+        io.write(promptText);
+        return;
+      }
+      commit("");
+    });
+  }
+
+  function detach(): void {
+    if (inputRejecter) {
+      const reject = inputRejecter;
+      inputResolver = null;
+      inputRejecter = null;
+      inputActive = false;
+      reject();
+    }
+  }
+
+  return {
+    writeOutput,
+    writeLine,
+    readInput,
+    setStatusRow,
+    handleEvent,
+    repaint: () => commit(""),
+    detach,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Input reducer (pure)
+// ---------------------------------------------------------------------------
+
+type ReducerResult = { state: InputState } | "submit" | "exit";
+
+function applyEvent(state: InputState, event: TerminalEvent): ReducerResult {
+  switch (event.type) {
+    case "key": {
+      if (event.ctrl) {
+        if (event.key === "c") return "exit";
+        if (event.key === "u") return { state: { ...state, line: "", cursor: 0 } };
+        return { state };
+      }
+      switch (event.key) {
+        case "return":
+          return "submit";
+        case "backspace":
+          if (state.cursor > 0) {
+            return {
+              state: {
+                ...state,
+                line: state.line.slice(0, state.cursor - 1) + state.line.slice(state.cursor),
+                cursor: state.cursor - 1,
+              },
+            };
+          }
+          return { state };
+        case "delete":
+          if (state.cursor < state.line.length) {
+            return {
+              state: {
+                ...state,
+                line: state.line.slice(0, state.cursor) + state.line.slice(state.cursor + 1),
+              },
+            };
+          }
+          return { state };
+        case "left":
+          return { state: { ...state, cursor: Math.max(0, state.cursor - 1) } };
+        case "right":
+          return { state: { ...state, cursor: Math.min(state.line.length, state.cursor + 1) } };
+        case "home":
+          return { state: { ...state, cursor: 0 } };
+        case "end":
+          return { state: { ...state, cursor: state.line.length } };
+        case "up":
+        case "down":
+          return { state }; // No history (yet)
+        default:
+          // Printable character
+          if (event.key.length === 1) {
+            return {
+              state: {
+                ...state,
+                line:
+                  state.line.slice(0, state.cursor) + event.key + state.line.slice(state.cursor),
+                cursor: state.cursor + 1,
+              },
+            };
+          }
+          return { state };
+      }
+    }
+    case "paste": {
+      return {
+        state: {
+          ...state,
+          line: state.line.slice(0, state.cursor) + event.text + state.line.slice(state.cursor),
+          cursor: state.cursor + event.text.length,
+        },
+      };
+    }
+    case "resize":
+      return { state }; // Repaint is triggered externally
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Stdin event parser (module-level: stdin is inherently a singleton)
+// ---------------------------------------------------------------------------
+
 let lastEscTime = 0;
 let pendingEscTimer: ReturnType<typeof setTimeout> | null = null;
 let pasteBuffer: string | null = null; // non-null = inside paste brackets
 let pasteSplitCarry = ""; // partial PASTE_CLOSE held across chunks
 
-// Track how many terminal rows the input occupies for proper clearing
-let inputRows = 0;
-
-// ---------------------------------------------------------------------------
-// Event parser
-// ---------------------------------------------------------------------------
-
-function parseChunk(buf: Buffer): TerminalEvent[] {
+function parseChunk(buf: Buffer, onBareEscape: () => void): TerminalEvent[] {
   const events: TerminalEvent[] = [];
   // Prepend any partial PASTE_CLOSE carried from the previous chunk
   let data = buf.toString("utf-8");
@@ -152,12 +511,12 @@ function parseChunk(buf: Buffer): TerminalEvent[] {
         if (pendingEscTimer) clearTimeout(pendingEscTimer);
         pendingEscTimer = setTimeout(() => {
           pendingEscTimer = null;
-          handleBareEscape();
+          onBareEscape();
         }, 50);
         i++;
       } else {
         // Bare \x1b followed by non-'[' — real Escape key
-        handleBareEscape();
+        onBareEscape();
         i++;
       }
       continue;
@@ -194,221 +553,48 @@ function parseChunk(buf: Buffer): TerminalEvent[] {
   return events;
 }
 
+// ---------------------------------------------------------------------------
+// Singleton wiring over process.stdout / process.stdin
+// ---------------------------------------------------------------------------
+
+const stdoutIO: TerminalIO = {
+  write: (s) => void process.stdout.write(s),
+  columns: () => process.stdout.columns || 80,
+  isTTY: process.stdout.isTTY === true,
+};
+
+const renderer = createTerminalRenderer(stdoutIO);
+
+let initialized = false;
+
 function handleBareEscape(): void {
-  if (!inputActive) return;
   const now = Date.now();
   if (now - lastEscTime < 300) {
     // Double-tap Escape — clear input
     lastEscTime = 0;
-    inputState = { ...inputState, line: "", cursor: 0 };
-    redrawInput();
+    renderer.handleEvent({ type: "key", key: "u", ctrl: true });
   } else {
     lastEscTime = now;
   }
 }
 
-// ---------------------------------------------------------------------------
-// Input reducer (pure)
-// ---------------------------------------------------------------------------
-
-type ReducerResult = { state: InputState } | "submit" | "exit";
-
-function applyEvent(state: InputState, event: TerminalEvent): ReducerResult {
-  switch (event.type) {
-    case "key": {
-      if (event.ctrl) {
-        if (event.key === "c") return "exit";
-        if (event.key === "u") return { state: { ...state, line: "", cursor: 0 } };
-        return { state };
-      }
-      switch (event.key) {
-        case "return":
-          return "submit";
-        case "backspace":
-          if (state.cursor > 0) {
-            return {
-              state: {
-                ...state,
-                line: state.line.slice(0, state.cursor - 1) + state.line.slice(state.cursor),
-                cursor: state.cursor - 1,
-              },
-            };
-          }
-          return { state };
-        case "delete":
-          if (state.cursor < state.line.length) {
-            return {
-              state: {
-                ...state,
-                line: state.line.slice(0, state.cursor) + state.line.slice(state.cursor + 1),
-              },
-            };
-          }
-          return { state };
-        case "left":
-          return { state: { ...state, cursor: Math.max(0, state.cursor - 1) } };
-        case "right":
-          return { state: { ...state, cursor: Math.min(state.line.length, state.cursor + 1) } };
-        case "home":
-          return { state: { ...state, cursor: 0 } };
-        case "end":
-          return { state: { ...state, cursor: state.line.length } };
-        case "up":
-        case "down":
-          return { state }; // No history (yet)
-        default:
-          // Printable character
-          if (event.key.length === 1) {
-            return {
-              state: {
-                ...state,
-                line:
-                  state.line.slice(0, state.cursor) + event.key + state.line.slice(state.cursor),
-                cursor: state.cursor + 1,
-              },
-            };
-          }
-          return { state };
-      }
-    }
-    case "paste": {
-      return {
-        state: {
-          ...state,
-          line: state.line.slice(0, state.cursor) + event.text + state.line.slice(state.cursor),
-          cursor: state.cursor + event.text.length,
-        },
-      };
-    }
-    case "resize":
-      return { state }; // Redraw is triggered externally
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Input redraw
-// ---------------------------------------------------------------------------
-
-function redrawInput(): void {
-  const cols = process.stdout.columns || 80;
-  const fullLine = inputState.prompt + inputState.line;
-  const totalLen = inputState.promptWidth + inputState.line.length;
-  const newRows = Math.max(1, Math.ceil(totalLen / cols) || 1);
-
-  // Move up to start of previous input area and clear
-  if (inputRows > 1) {
-    process.stdout.write(`\x1b[${inputRows - 1}A`);
-  }
-  process.stdout.write("\r");
-  // Clear from cursor to end of screen (covers all old input rows)
-  process.stdout.write("\x1b[J");
-
-  // Write the full line
-  process.stdout.write(fullLine);
-
-  // Position cursor: compute where cursor should be
-  const cursorPos = inputState.promptWidth + inputState.cursor;
-  const cursorRow = Math.floor(cursorPos / cols);
-  const cursorCol = cursorPos % cols;
-  const endRow = Math.floor(Math.max(0, totalLen - 1) / cols);
-
-  // Move from end position to cursor position
-  if (endRow > cursorRow) {
-    process.stdout.write(`\x1b[${endRow - cursorRow}A`);
-  }
-  process.stdout.write(`\r`);
-  if (cursorCol > 0) {
-    process.stdout.write(`\x1b[${cursorCol}C`);
-  }
-
-  inputRows = newRows;
-}
-
-// ---------------------------------------------------------------------------
-// Output region — "lift input, write, replace"
-// ---------------------------------------------------------------------------
-
-/**
- * Write text to the output region above the input line.
- * If input is active, lifts it, writes output, then repaints input.
- * Safe to call from streaming, tool status, etc.
- */
-export function writeOutput(text: string): void {
-  if (!inputActive) {
-    process.stdout.write(text);
-    return;
-  }
-
-  // Move to start of input area
-  if (inputRows > 1) {
-    process.stdout.write(`\x1b[${inputRows - 1}A`);
-  }
-  process.stdout.write("\r\x1b[J"); // Clear input area
-
-  // Write output (scrolls naturally)
-  process.stdout.write(text);
-
-  // Repaint input at new bottom
-  inputRows = 1; // Reset — redrawInput will recalculate
-  redrawInput();
-}
-
-// ---------------------------------------------------------------------------
-// Stdin listener
-// ---------------------------------------------------------------------------
-
 function onStdinData(buf: Buffer): void {
-  const events = parseChunk(buf);
-  for (const event of events) {
-    if (!inputActive) continue;
-
-    if (event.type === "resize") {
-      redrawInput();
-      continue;
-    }
-
-    const result = applyEvent(inputState, event);
-    if (result === "submit") {
-      const line = inputState.line;
-      // Move cursor to end of input, then newline
-      process.stdout.write("\n");
-      inputActive = false;
-      inputRows = 0;
-      if (inputResolver) {
-        const resolve = inputResolver;
-        inputResolver = null;
-        resolve(line);
-      }
-    } else if (result === "exit") {
-      process.stdout.write("\n");
-      process.exit(0);
-    } else {
-      inputState = result.state;
-      redrawInput();
-    }
+  for (const event of parseChunk(buf, handleBareEscape)) {
+    renderer.handleEvent(event);
   }
 }
 
 let resizeTimer: ReturnType<typeof setTimeout> | null = null;
 function onResize(): void {
-  if (!inputActive) return;
-  // Debounce: terminal fires many resize events while dragging.
-  // Only redraw once the resize settles.
+  // Debounce: terminals fire many resize events while dragging. The commit
+  // discipline makes each repaint idempotent, so the debounce is only about
+  // not doing wasted work — not about correctness.
   if (resizeTimer) clearTimeout(resizeTimer);
   resizeTimer = setTimeout(() => {
     resizeTimer = null;
-    if (!inputActive) return;
-    // The terminal already reflowed all text on screen.
-    // Don't try to edit scrollback. Start fresh on a new line.
-    process.stdout.write("\n");
-    inputRows = 1;
-    redrawInput();
-  }, 100);
+    renderer.repaint();
+  }, 80);
 }
-
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
 
 /** Initialize terminal: raw mode, bracketed paste, attach listeners. */
 export function initTerminal(): void {
@@ -447,22 +633,28 @@ export function destroyTerminal(): void {
 }
 
 /**
- * Read a line of input. Drop-in replacement for the old readInput.
- * Returns a Promise that resolves when the user presses Enter.
+ * Write text to the output region above the input line.
+ * If input or a status row is active, output is folded in above them.
+ * Safe to call from streaming, tool status, the runtime logger, etc.
+ */
+export function writeOutput(text: string): void {
+  renderer.writeOutput(text);
+}
+
+/**
+ * Write a full line of output, completing any pending partial line first.
+ * For line-shaped records that must never glue onto streamed text.
+ */
+export function writeLine(text: string): void {
+  renderer.writeLine(text);
+}
+
+/**
+ * Read a line of input. Returns a Promise that resolves when the user
+ * presses Enter.
  */
 export function readInput(promptText: string): Promise<string> {
-  return new Promise((resolve) => {
-    inputState = {
-      line: "",
-      cursor: 0,
-      prompt: promptText,
-      promptWidth: visibleLength(promptText),
-    };
-    inputRows = 1;
-    inputActive = true;
-    inputResolver = resolve;
-    redrawInput();
-  });
+  return renderer.readInput(promptText);
 }
 
 /**
@@ -471,4 +663,14 @@ export function readInput(promptText: string): Promise<string> {
  */
 export function askQuestion(promptText: string): Promise<string> {
   return readInput(promptText);
+}
+
+/**
+ * Set (or clear, with null) the status row rendered directly above the
+ * input line — the calm one-line answer to "is it waiting on me or
+ * working?" during any await. Content is pre-rendered by status-render.ts;
+ * the renderer truncates it to the terminal width so it never wraps.
+ */
+export function setStatusRow(row: string | null): void {
+  renderer.setStatusRow(row);
 }


### PR DESCRIPTION
## The arc (#456, with #455 folded in)

Last open board item from the 2026-07-29 E2E validation run. Three witnessed failures, one structural cause: the CLI printed lines and hoped — no owned screen state.

1. **Resize duplicated the prompt** (#455): the SIGWINCH handler deliberately printed `\n` + fresh prompt because it couldn't clear safely — the old wrapped multi-row input made "how many rows up?" unanswerable after reflow.
2. **In-flight delegation was an animating `...`** — no step identity, no elapsed. The coordinator REPL had **no `task_step_narration` case at all** (the attached REPL rendered it; stream.ts dropped it).
3. **Poll errors dumped raw JSON into the input line**: the CLI injected no logger, so `relay-delegation.ts` fell back to `console.warn("[motebit] delegation poll failed", JSON)`.

## The design (Claude Code mechanics, motebit register)

One renderer discipline owns the bottom of the screen (`terminal.ts`, injectable IO). Every mutation goes through `commit()`: clear the previously painted region → append completed scrollback → repaint region rows (pending partial output line · status row · input row) → park the cursor.

**The invariant that closes the resize class:** region rows are truncated / h-scrolled to the terminal width, so they never soft-wrap — clearing by moving up N rows is always exact, and on resize the clear recomputes row heights at the new width under the macOS reflow model. Resize becomes an idempotent repaint. Repaints ride synchronized-output markers (`ESC[?2026`) — never seen half-done.

**Every await has a visible state:** `status-render.ts` (pure, tested — the approval-render precedent) renders `·· delegating — payment confirmed onchain · 41s`; narration updates the row AND leaves a dim durable echo in scrollback so a fast next step doesn't erase the story. Completed acts get one calm scrollback line with elapsed.

**Nothing writes past the renderer:** `cli-logger.ts` injected into the runtime folds poll failures into the status row as *relay hiccup, still waiting (attempt N)* — calm text, never JSON; scheduler goal/plan prints swept through the renderer (they fire while the user is mid-keystroke).

**Sibling rule:** attached-repl.ts gets the identical treatment (status row, narration, done-lines, guards). Daemon untouched — headless, no input line to corrupt.

## Proof

`__tests__/helpers/vt.ts` — a small virtual-terminal interpreter (with macOS-model reflow) so tests assert on the *screen a user sees*: five resizes → exactly one `you>`; status + input coexist through narrowing; streamed partial text stays pinned above the status row; h-scrolled input never wraps. 46 new tests (VT self-test, renderer golden-screens, status renderer, logger routing); CLI suite 349 green; all 137 drift gates pass.

Also fixed en route: a latent stray `" done"` print when `tool_status done` and `delegation_complete` both arrived for one delegation (now guarded on both surfaces).

Closes #455. Closes #456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)