### PR TITLE
fix(runtime): exchange-scoped denial brake — refused tool cannot re-prompt via reworded args (#470)

### DIFF
--- a/.changeset/exchange-scoped-denial-brake.md
+++ b/.changeset/exchange-scoped-denial-brake.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+A human "no" to a money approval is now terminal for that tool for the rest of the exchange — however the model rewords the arguments (#470). The exact-args denied-intent ledger deliberately let a reworked proposal ask once more; witnessed live, a weak model reworded a denied paid hire trivially and re-prompted seconds after the refusal. The new exchange-scoped brake suppresses any same-tool approval request until the human's next message (which always releases it — a human-initiated follow-up is never swallowed), renders a calm owner-visible line when it fires, and tells the model to return to the conversation instead of retrying. Per-tool, not global: unrelated approval-gated proposals in the same exchange still prompt.

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"f3bc4f4b-22f2-4fef-bb0f-de6d9788019c","pid":34906,"procStart":"Sun May 10 22:26:54 2026","acquiredAt":1778454057738}
+{"sessionId":"9cbf181d-0b3f-4c2c-9d4a-6681d50926b2","pid":93157,"procStart":"Wed Jul 29 23:33:58 2026","acquiredAt":1785369651984}

--- a/packages/runtime/src/__tests__/streaming.test.ts
+++ b/packages/runtime/src/__tests__/streaming.test.ts
@@ -1110,6 +1110,114 @@ describe("resumeAfterApproval — signed consent decision", () => {
     expect(runtime.hasPendingApproval).toBe(true);
   });
 
+  it("a REWORDED re-proposal in the same exchange is suppressed (#470)", async () => {
+    // The live failure (2026-07-29, v1.11.0, llama3.2): deny a paid hire →
+    // the resumed continuation re-proposed it with the prompt trivially
+    // reworded (one more sentence of the user's own words folded in) → the
+    // exact-args ledger missed → the human was re-prompted seconds after
+    // their "no". Within one exchange, a denial is terminal for the TOOL.
+    mockRunTurnStreaming.mockReturnValueOnce(
+      yieldChunks(
+        {
+          type: "approval_request",
+          tool_call_id: "tc-470-a",
+          name: "delegate_to_agent",
+          args: { prompt: "What version of motebit is live on npm?" },
+          risk_level: 4,
+        },
+        { type: "result", result: makeTurnResult() },
+      ),
+    );
+    await collectChunks(runtime.sendMessageStreaming("check npm, don't guess"));
+    expect(runtime.hasPendingApproval).toBe(true);
+
+    // The continuation after the denial re-proposes with REWORDED args.
+    mockRunTurnStreaming.mockReturnValueOnce(
+      yieldChunks(
+        {
+          type: "approval_request",
+          tool_call_id: "tc-470-b",
+          name: "delegate_to_agent",
+          args: {
+            prompt: "What version of motebit is live on npm? Check the real registry, don't guess.",
+          },
+          risk_level: 4,
+        },
+        { type: "result", result: makeTurnResult() },
+      ),
+    );
+    const chunks = await collectChunks(runtime.resumeAfterApproval(false));
+
+    // Suppressed: no surface can render a second prompt this exchange.
+    expect(runtime.hasPendingApproval).toBe(false);
+    const injected = runtime
+      .getConversationHistory()
+      .map((m) => String(m.content))
+      .join("\n");
+    expect(injected).toContain("REFUSED_BY_HUMAN_THIS_EXCHANGE");
+    // The brake renders an owner-visible line — the owner sees it fired.
+    const text = chunks
+      .filter((c): c is { type: "text"; text: string } => c.type === "text")
+      .map((c) => c.text)
+      .join("");
+    expect(text).toContain("already declined delegate_to_agent");
+  });
+
+  it("the human's next message releases the exchange brake — even for reworded args (#470)", async () => {
+    await enterPendingApproval("tc-470-c", "delegate_to_agent", { prompt: "hire for task X" });
+    await collectChunks(runtime.resumeAfterApproval(false));
+
+    // A NEW user message re-opens the line the human closed: the same tool
+    // with reworded args prompts again (a human-initiated follow-up is never
+    // swallowed — the void/deny asymmetry that keeps the gate honest).
+    mockRunTurnStreaming.mockReturnValueOnce(
+      yieldChunks(
+        {
+          type: "approval_request",
+          tool_call_id: "tc-470-d",
+          name: "delegate_to_agent",
+          args: { prompt: "hire for task X, please reconsider" },
+          risk_level: 4,
+        },
+        { type: "result", result: makeTurnResult() },
+      ),
+    );
+    await collectChunks(runtime.sendMessageStreaming("actually, go ahead and hire someone"));
+    expect(runtime.hasPendingApproval).toBe(true);
+  });
+
+  it("a different TOOL in the same exchange still reaches the human (#470)", async () => {
+    // The brake is per-tool, not global: refusing a hire must not swallow an
+    // unrelated approval-gated proposal in the same continuation.
+    mockRunTurnStreaming.mockReturnValueOnce(
+      yieldChunks(
+        {
+          type: "approval_request",
+          tool_call_id: "tc-470-e",
+          name: "delegate_to_agent",
+          args: { prompt: "hire someone" },
+          risk_level: 4,
+        },
+        { type: "result", result: makeTurnResult() },
+      ),
+    );
+    await collectChunks(runtime.sendMessageStreaming("do the task"));
+    mockRunTurnStreaming.mockReturnValueOnce(
+      yieldChunks(
+        {
+          type: "approval_request",
+          tool_call_id: "tc-470-f",
+          name: "send_money",
+          args: { to: "y", amount: 2 },
+          risk_level: 4,
+        },
+        { type: "result", result: makeTurnResult() },
+      ),
+    );
+    await collectChunks(runtime.resumeAfterApproval(false));
+    expect(runtime.hasPendingApproval).toBe(true);
+  });
+
   it("buffers the decision in getRecentApprovalDecisions(), verifiable, same contract as getRecentReceipts()", async () => {
     await enterPendingApproval("tc-buffer", "transfer", { amt: 1 });
     await collectChunks(runtime.resumeAfterApproval(true));

--- a/packages/runtime/src/motebit-runtime.ts
+++ b/packages/runtime/src/motebit-runtime.ts
@@ -2424,6 +2424,11 @@ export class MotebitRuntime {
     // system-triggered and should not reset the quiet window.
     this._lastUserMessageAt = Date.now();
     this._currentTypedIntent = options?.userActionAttestation ?? null;
+    // A genuine user message releases the exchange-scoped denial brake
+    // (#470): the human can re-open a line they closed — and only the human.
+    // This sits ONLY on the user-initiated path; proactive/system turns
+    // (generateActivation, consolidation) must not launder a "no".
+    this.streaming.beginExchange();
     // A new user turn sets aside any pending approval — but never silently
     // (#462): the void renders on THIS stream via the typed chunk below, and
     // the owning surface hears it through the onApprovalVoided callback. A

--- a/packages/runtime/src/streaming.ts
+++ b/packages/runtime/src/streaming.ts
@@ -258,6 +258,28 @@ export class StreamingManager {
    * exit.
    */
   private readonly deniedIntents = new Map<string, number>();
+  /**
+   * Tools the human refused THIS exchange — since their last message (#470).
+   *
+   * The exact-args ledger above deliberately lets a reworked proposal ask
+   * once more ("a model that meaningfully reworks its arguments gets to ask
+   * once more; the prompt text it just received tells it not to"). That bet
+   * lost, live, 2026-07-29: a weak model reworded the denied paid hire
+   * trivially — folding one more sentence of the user's own words into the
+   * prompt — and re-prompted seconds after the "no", with the terminal
+   * REFUSED_BY_HUMAN instruction in its context. Model compliance cannot
+   * carry a money boundary.
+   *
+   * So the exact ledger gets a complement, not a replacement: within one
+   * exchange, a human denial is terminal for the TOOL, however the arguments
+   * are reworded. The set clears on the next genuine user message
+   * (`beginExchange`) — a human-initiated follow-up can always re-open the
+   * line it closed, so no future request is silently swallowed. Fuzzy arg
+   * matching was rejected for the same reason exact was chosen: a false
+   * match breaks the approval gate; tool-until-next-message cannot
+   * mis-classify.
+   */
+  private readonly deniedToolsThisExchange = new Set<string>();
   private approvalExpiredCallback: (() => void) | null = null;
   /** Fired when a NEW turn voids a pending approval (#462) — the owning surface renders the void. */
   private approvalVoidedCallback: ((toolName: string) => void) | null = null;
@@ -333,6 +355,17 @@ export class StreamingManager {
   /** Register a callback invoked when a new turn voids a pending approval (#462). */
   onApprovalVoided(cb: (toolName: string) => void): void {
     this.approvalVoidedCallback = cb;
+  }
+
+  /**
+   * Mark the start of a genuine user turn (#470). The exchange-scoped denial
+   * brake stops re-asks BETWEEN user messages; the user's own next message
+   * always releases it — the human can re-open any line they closed, and
+   * only the human can. Callers: user-initiated turns only, never proactive
+   * or system-triggered ones (a consolidation tick must not launder a "no").
+   */
+  beginExchange(): void {
+    this.deniedToolsThisExchange.clear();
   }
 
   /** Shared stream processing — extracts state tags, handles tool/approval/injection chunks. */
@@ -540,6 +573,39 @@ export class StreamingManager {
         continue;
       }
 
+      // Same-exchange re-proposal of a tool the human already refused —
+      // however the arguments were reworded (#470). Within one exchange the
+      // denial is terminal for the tool; the human's next message releases
+      // the brake. See deniedToolsThisExchange for why exact-args alone
+      // proved insufficient.
+      if (chunk.type === "approval_request" && this.deniedToolsThisExchange.has(chunk.name)) {
+        this.deps.injectIntermediateMessages(
+          {
+            role: "assistant" as const,
+            content: `[tool_use: ${chunk.name}(${JSON.stringify(chunk.args)})]`,
+          },
+          {
+            role: "user" as const,
+            content: `[tool_result: ${JSON.stringify({
+              ok: false,
+              error: "REFUSED_BY_HUMAN_THIS_EXCHANGE",
+              terminal: true,
+              message:
+                `The human refused a ${chunk.name} call moments ago in this same exchange. ` +
+                `Rewording the arguments does not make it a new request — this proposal was ` +
+                `NOT shown to them. Do not propose ${chunk.name} again until the human sends ` +
+                `a new message. Tell the user plainly what you wanted to do and that they ` +
+                `declined, then ask what they would like instead.`,
+            })}]`,
+          },
+        );
+        yield {
+          type: "text" as const,
+          text: `\n[you already declined ${chunk.name} this turn — not asking again]\n`,
+        };
+        continue;
+      }
+
       // Approval request: capture pending state and start timeout
       if (chunk.type === "approval_request") {
         this._pendingApproval = {
@@ -695,6 +761,9 @@ export class StreamingManager {
         // re-prompting the human (#433).
         const key = deniedIntentKey(pending.toolName, pending.args);
         this.deniedIntents.set(key, (this.deniedIntents.get(key) ?? 0) + 1);
+        // And the exchange-scoped tool brake (#470): until the human's next
+        // message, no rewording of this tool's arguments re-prompts them.
+        this.deniedToolsThisExchange.add(pending.toolName);
 
         // Push denial into conversation history. The wording is load-bearing:
         // a neutral "denied" reads to the model as a retryable failure — the


### PR DESCRIPTION
## The finding (#470, witnessed live 2026-07-29 on v1.11.0)

The #433/#434 denied-intent ledger keys on **exact args** — deliberately, with the recorded bet: *"a model that meaningfully reworks its arguments gets to ask once more; the prompt text it just received tells it not to."* During the #456 rendering validation, llama3.2 lost that bet in the cheapest possible way: denied a paid hire, it folded one more sentence of the user's own words into the prompt and re-prompted the human seconds after their "no" — `REFUSED_BY_HUMAN / do NOT reword` sitting ignored in its context. The human gate held (nothing spends without `y`), but the coercion shape is live: re-ask until the owner slips. Weak models are exactly the population where structure, not compliance, must carry the boundary.

## The fix — complement, not replacement

**Exchange-scoped tool-level terminality** on the StreamingManager (the session object — the recorded home for state that must survive the fresh-turn-context boundary a denial resumption crosses):

- On human denial, the tool enters `deniedToolsThisExchange`.
- Any `approval_request` for that tool **before the human's next message** is suppressed exactly like the existing exact-match path: chunk never yielded (no surface can render a prompt, no keystroke can approve), model receives terminal `REFUSED_BY_HUMAN_THIS_EXCHANGE` directing it back to prose, owner sees a calm `[you already declined X this turn — not asking again]` line (same register as the existing `[refused already]` render).
- `beginExchange()` clears the set — called ONLY from `sendMessageStreaming` (user-initiated turns), sited beside the #462 approval-void. The human can re-open any line they closed, and only the human; proactive/system turns never launder a "no".

Fuzzy arg matching was rejected for the same reason exact-match was originally chosen: a false positive silently breaks the approval gate. Tool-until-next-message cannot mis-classify — after a "no", the model returns to prose and the human redirects.

The exact ledger stays: it still blocks byte-identical repeats **across** turns, which the exchange brake deliberately does not.

## Proof

Three new tests in the `resumeAfterApproval` suite, mirroring the live incident: (1) reworded same-exchange re-proposal suppressed, with the owner-visible line asserted; (2) the human's next message releases the brake even for reworded args; (3) a different tool in the same exchange still prompts (per-tool, not global). Existing #433/#434/#462 tests untouched. Runtime: 71 files, 1258 tests green; typecheck + lint clean.

Single chokepoint verified: `REFUSED_BY_HUMAN` exists only in `streaming.ts` — every surface (REPL, attached, scheduler) resolves through `resumeAfterApproval`, so no sibling path bypasses the brake.

Closes #470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)