### PR TITLE
fix(cli,ai-core): real Claude model ids — /model aliases and task-router tiers 404'd (#471)

### DIFF
--- a/.changeset/real-claude-model-ids.md
+++ b/.changeset/real-claude-model-ids.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+Claude model ids are now real (#471, first half). `/model opus` pointed at a fabricated id (`claude-opus-4-6-20250414` — Anthropic 404s it) and `sonnet` at the equally fictional `claude-sonnet-4-5-latest`; switching persisted the broken id as the session default. The alias table now carries the current live aliases (`claude-opus-5`, `claude-sonnet-5`, `claude-haiku-4-5`), and the task router's model tiers — which fed unservable family names like `claude-opus` straight into the provider — resolve to the same real ids. The provider-blind half of #471 (offering models the active provider cannot serve, and persisting an un-admitted default) remains open as designed work.

--- a/apps/cli/src/slash-commands.ts
+++ b/apps/cli/src/slash-commands.ts
@@ -558,10 +558,13 @@ export async function handleSlashCommand(
 
     case "model": {
       // Known models with short aliases
+      // Anthropic ids are the REAL current aliases (verified against the
+      // models catalog 2026-07-29 — #471 found the previous entries were
+      // fabricated: date-suffixed and "-latest" variants that 404).
       const MODEL_ALIASES: Record<string, string> = {
-        opus: "claude-opus-4-6-20250414",
-        sonnet: "claude-sonnet-4-5-latest",
-        haiku: "claude-haiku-4-5-20251001",
+        opus: "claude-opus-5",
+        sonnet: "claude-sonnet-5",
+        haiku: "claude-haiku-4-5",
         "gpt-5.4": "gpt-5.4",
         "gpt-5.4-mini": "gpt-5.4-mini",
         "gpt-5.4-nano": "gpt-5.4-nano",

--- a/packages/ai-core/src/__tests__/coverage-uplift.test.ts
+++ b/packages/ai-core/src/__tests__/coverage-uplift.test.ts
@@ -170,9 +170,9 @@ describe("isModelTier", () => {
 
 describe("resolveModelTier", () => {
   it("resolves Anthropic family tiers", () => {
-    expect(resolveModelTier("strongest", "claude-sonnet-4-5-20250929")).toBe("claude-opus");
-    expect(resolveModelTier("default", "claude-haiku-3")).toBe("claude-sonnet");
-    expect(resolveModelTier("fast", "anthropic-x")).toBe("claude-haiku");
+    expect(resolveModelTier("strongest", "claude-sonnet-4-5-20250929")).toBe("claude-opus-5");
+    expect(resolveModelTier("default", "claude-haiku-3")).toBe("claude-sonnet-5");
+    expect(resolveModelTier("fast", "anthropic-x")).toBe("claude-haiku-4-5");
   });
   it("resolves OpenAI family tiers", () => {
     expect(resolveModelTier("strongest", "gpt-5.4-mini")).toBe("gpt-5.4");
@@ -213,7 +213,7 @@ describe("withTaskConfig — tier-to-concrete resolution + fallback restore", ()
         seenModel = current;
       },
     );
-    expect(seenModel).toBe("claude-opus");
+    expect(seenModel).toBe("claude-opus-5");
     // restored
     expect(current).toBe("claude-sonnet-4-5");
   });

--- a/packages/ai-core/src/task-router.ts
+++ b/packages/ai-core/src/task-router.ts
@@ -124,13 +124,17 @@ export function isModelTier(model: string): model is ModelTier {
 export function resolveModelTier(tier: ModelTier, currentModel: string): string {
   // Detect provider family from current model
   if (currentModel.includes("claude") || currentModel.includes("anthropic")) {
+    // Real API aliases, not family names: the previous values
+    // ("claude-opus" etc.) are not servable model ids — a tier switch fed
+    // them to provider.setModel() and 404'd the turn (#471's sibling,
+    // found in the same sweep).
     switch (tier) {
       case "strongest":
-        return "claude-opus";
+        return "claude-opus-5";
       case "default":
-        return "claude-sonnet";
+        return "claude-sonnet-5";
       case "fast":
-        return "claude-haiku";
+        return "claude-haiku-4-5";
     }
   }
 


### PR DESCRIPTION
First half of #471, found live during the v1.11.0 anthropic validation round: `/model opus` set `claude-opus-4-6-20250414` — a fabricated, date-suffixed id Anthropic 404s (even Opus 4.6's real id is bare `claude-opus-4-6`) — and persisted it into config as the session default. The `sonnet` alias carried the equally fictional `claude-sonnet-4-5-latest`.

The sweep found the same defect one layer down: `resolveModelTier` returns family names (`claude-opus` / `claude-sonnet` / `claude-haiku`) that `withTaskConfig` feeds straight into `provider.setModel()` — so a planning-router tier switch on the anthropic provider would 404 identically. Latent only because recent runs rode local-server.

Both sites now resolve to the current live aliases verified against the models catalog: **`claude-opus-5`**, **`claude-sonnet-5`**, **`claude-haiku-4-5`**. Tier tests updated to assert the real ids; opaque-string mechanics tests untouched (they never reach the API). ai-core 558 + cli 349 tests green; typecheck/lint/build clean.

The provider-blind half of #471 (offering models the active provider can't serve, marking the switch successful, persisting an un-admitted default — pre-flight admission per the intelligence-pluggability contract) stays open as designed work.

Also observed in the same incident, for the record: the 404 rendered through the new #469 pipeline as one calm dim `chat.turn.failed` line + typed `[error: …]` — under 1.10.0 that was raw JSON into the input line.

Refs #471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)