### PR TITLE
fix(ai-core): shape requests to the Opus 4.7+/Claude-5 family — sampling params and budget_tokens removed there (#471 sibling)

### DIFF
--- a/.changeset/opus5-request-shape.md
+++ b/.changeset/opus5-request-shape.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+Requests to the Opus 4.7+/Claude-5 model family are now shaped to what those models accept (#471 sibling, witnessed live: every claude-opus-5 turn 400'd because the CLI's personality default temperature rode every request — Anthropic removed sampling parameters on that family). The provider now omits `temperature` at the request-body build for models that reject it, whatever any caller configured, and extended thinking emits the adaptive shape instead of the removed `budget_tokens` form on the same family. Models that still accept sampling (Opus 4.6, Sonnet 4.5, Haiku 4.5, local models) are untouched.

--- a/packages/ai-core/src/__tests__/anthropic.test.ts
+++ b/packages/ai-core/src/__tests__/anthropic.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   __test_buildToolResultContentForAnthropic as toAnthropicContent,
   modelSupportsExtendedThinking,
+  modelRejectsSamplingParams,
 } from "../core";
 import type { AnthropicProviderConfig } from "../index";
 import { TrustMode, BatteryMode, SensitivityLevel } from "@motebit/sdk";
@@ -280,6 +281,34 @@ describe("modelSupportsExtendedThinking", () => {
   });
 });
 
+describe("modelRejectsSamplingParams — Opus 4.7+/Claude-5 request-shape guard", () => {
+  it("rejects sampling params on the removed-family models (each was a live or latent 400)", () => {
+    for (const m of [
+      "claude-opus-5",
+      "claude-opus-4-7",
+      "claude-opus-4-8",
+      "claude-sonnet-5",
+      "claude-fable-5",
+      "claude-mythos-5",
+    ]) {
+      expect(modelRejectsSamplingParams(m)).toBe(true);
+    }
+  });
+
+  it("keeps sampling on models that still accept it", () => {
+    for (const m of [
+      "claude-opus-4-6",
+      "claude-sonnet-4-6",
+      "claude-sonnet-4-5-20250929",
+      "claude-haiku-4-5-20251001",
+      "llama3.2",
+      "gpt-5.4",
+    ]) {
+      expect(modelRejectsSamplingParams(m)).toBe(false);
+    }
+  });
+});
+
 describe("AnthropicProvider Anthropic integration", () => {
   const config: AnthropicProviderConfig = {
     api_key: "test-api-key",
@@ -392,6 +421,37 @@ describe("AnthropicProvider Anthropic integration", () => {
         makeContextPack(),
       );
       expect((bodyOf().thinking as { budget_tokens: number }).budget_tokens).toBe(1024);
+    });
+
+    it("omits configured temperature for claude-opus-5 (sampling removed — 400'd every live CLI turn, 2026-07-29)", async () => {
+      mockFetchSuccess("Hi");
+      await new AnthropicProvider({ ...config, model: "claude-opus-5" }).generate(
+        makeContextPack(),
+      );
+      const body = bodyOf();
+      expect(body.model).toBe("claude-opus-5");
+      expect(body.temperature).toBeUndefined();
+    });
+
+    it("still sends configured temperature for claude-opus-4-6 (sampling accepted there)", async () => {
+      mockFetchSuccess("Hi");
+      await new AnthropicProvider({ ...config, model: "claude-opus-4-6" }).generate(
+        makeContextPack(),
+      );
+      expect(bodyOf().temperature).toBe(0.5);
+    });
+
+    it("extended thinking on claude-opus-5 emits the adaptive shape, never budget_tokens", async () => {
+      mockFetchSuccess("Hi");
+      await new AnthropicProvider({
+        ...config,
+        model: "claude-opus-5",
+        extendedThinking: { budgetTokens: 4000 },
+      }).generate(makeContextPack());
+      const body = bodyOf();
+      expect(body.thinking).toEqual({ type: "adaptive" });
+      expect(body.temperature).toBeUndefined();
+      expect(body.max_tokens as number).toBeGreaterThan(4000);
     });
 
     it("safety net: does NOT enable thinking on an unsupported model even when configured", async () => {

--- a/packages/ai-core/src/core.ts
+++ b/packages/ai-core/src/core.ts
@@ -583,6 +583,26 @@ export function modelSupportsExtendedThinking(model: string): boolean {
   return /claude-(?:3-7-sonnet|(?:opus|sonnet)-(?:[4-9]|\d\d))/i.test(model);
 }
 
+/**
+ * Models that REJECT classic sampling parameters (`temperature`/`top_p`/
+ * `top_k`) with HTTP 400 — the Opus 4.7+/Claude-5 family, where sampling
+ * params were removed and `thinking: {type:"enabled", budget_tokens}` was
+ * replaced by adaptive thinking.
+ *
+ * Witnessed live 2026-07-29: every CLI turn on claude-opus-5 400'd because
+ * the personality default temperature (0.7) rode every request. The task
+ * router already propagates `undefined` carefully (the 2026-04-18
+ * motebit.com incident — see ResolvedTaskConfig); this guard makes the
+ * illegal request unrepresentable at the body build itself, whatever any
+ * caller configured. Sonnet 5 is included: it rejects NON-default values,
+ * and omitting is the only always-valid shape.
+ */
+export function modelRejectsSamplingParams(model: string): boolean {
+  return /claude-(?:opus-(?:4-[7-9]|[5-9]\b|\d\d)|sonnet-(?:[5-9]\b|\d\d)|fable|mythos)/i.test(
+    model,
+  );
+}
+
 // Action keywords → MotebitState field deltas
 const ACTION_RULES: { pattern: RegExp; updates: Partial<MotebitState> }[] = [
   // Movement / proximity (allow words between verb and direction)
@@ -997,11 +1017,16 @@ export class AnthropicProvider implements StreamingProvider {
     const body: Record<string, unknown> = {
       model: this.config.model,
       max_tokens: this.config.max_tokens ?? 4096,
-      // Only send temperature when the user explicitly configured it. Claude
-      // Opus 4.7+ deprecates the parameter entirely and returns HTTP 400 when
-      // it's present. Omitting it lets each model use its own default; users
-      // who want to tune sampling still can via `config.temperature`.
-      ...(this.config.temperature !== undefined && { temperature: this.config.temperature }),
+      // Only send temperature when the user explicitly configured it AND the
+      // model still accepts it — the Opus 4.7+/Claude-5 family returns HTTP
+      // 400 when the parameter is present at all (witnessed live 2026-07-29:
+      // the CLI's personality default 0.7 400'd every claude-opus-5 turn).
+      // Omitting it lets each model use its own default; users on models
+      // that accept sampling still tune via `config.temperature`.
+      ...(this.config.temperature !== undefined &&
+        !modelRejectsSamplingParams(this.config.model) && {
+          temperature: this.config.temperature,
+        }),
       // Cacheable system blocks (see buildSystemBlocks) — the static prefix
       // caches at 1/10th input cost, the lever for cost on the agentic loop.
       system: this.buildSystemBlocks(contextPack),
@@ -1080,11 +1105,16 @@ export class AnthropicProvider implements StreamingProvider {
     const body: Record<string, unknown> = {
       model: this.config.model,
       max_tokens: this.config.max_tokens ?? 4096,
-      // Only send temperature when the user explicitly configured it. Claude
-      // Opus 4.7+ deprecates the parameter entirely and returns HTTP 400 when
-      // it's present. Omitting it lets each model use its own default; users
-      // who want to tune sampling still can via `config.temperature`.
-      ...(this.config.temperature !== undefined && { temperature: this.config.temperature }),
+      // Only send temperature when the user explicitly configured it AND the
+      // model still accepts it — the Opus 4.7+/Claude-5 family returns HTTP
+      // 400 when the parameter is present at all (witnessed live 2026-07-29:
+      // the CLI's personality default 0.7 400'd every claude-opus-5 turn).
+      // Omitting it lets each model use its own default; users on models
+      // that accept sampling still tune via `config.temperature`.
+      ...(this.config.temperature !== undefined &&
+        !modelRejectsSamplingParams(this.config.model) && {
+          temperature: this.config.temperature,
+        }),
       // Cacheable system blocks (see buildSystemBlocks) — same caching lever as
       // generate(); the streaming path is the one the chat surface actually uses.
       system: this.buildSystemBlocks(contextPack),
@@ -1290,7 +1320,14 @@ export class AnthropicProvider implements StreamingProvider {
     const et = this.config.extendedThinking;
     if (!et || !modelSupportsExtendedThinking(this.config.model)) return;
     const budget = Math.max(1024, Math.floor(et.budgetTokens));
-    body.thinking = { type: "enabled", budget_tokens: budget };
+    // The Opus 4.7+/Claude-5 family removed `budget_tokens` (HTTP 400) —
+    // adaptive thinking is the only on-mode there. The budget shape survives
+    // on the older models that still require it. The budget still sizes the
+    // max_tokens headroom either way: adaptive thinking spends from the same
+    // output allowance.
+    body.thinking = modelRejectsSamplingParams(this.config.model)
+      ? { type: "adaptive" }
+      : { type: "enabled", budget_tokens: budget };
     const configured = typeof body.max_tokens === "number" ? body.max_tokens : 4096;
     body.max_tokens = Math.max(configured, budget + 4096);
     delete body.temperature;


### PR DESCRIPTION
Third find of the night's API-drift archaeology, witnessed live minutes after the model-id fix: with a real `claude-opus-5` id in place, **every turn 400'd** — `temperature is deprecated for this model`. The CLI always configures a personality temperature (default 0.7), the provider sends whatever is configured, and Anthropic **removed** sampling params (`temperature`/`top_p`/`top_k`) on Opus 4.7/4.8/5, Sonnet 5, and Fable/Mythos — presence alone is a 400.

The task router already knew this class (the 2026-04-18 motebit.com incident is recorded in `ResolvedTaskConfig`'s docstring, with careful undefined-propagation) — but any caller that *does* configure a temperature bypassed that care. Per runtime-invariants-over-prompt-rules, the guard now lives where it cannot be bypassed: **`modelRejectsSamplingParams()` at the request-body build** omits `temperature` for the removed family regardless of config. Models that still accept sampling (Opus 4.6, Sonnet 4.6/4.5, Haiku 4.5, non-Claude) are untouched.

Same pass, same class: `applyExtendedThinking` emitted `{type:"enabled", budget_tokens}` for every thinking-capable model — that shape is **also** removed on the same family (latent 400 in an off-by-default feature). It now emits `{type:"adaptive"}` there; the budget shape survives on older models that require it, and the budget still sizes `max_tokens` headroom either way.

Five new tests: family membership both directions; opus-5 body omits a configured temperature; opus-4-6 keeps it; opus-5 thinking is adaptive with no `budget_tokens`. ai-core 563 green; typecheck/lint/build clean; runtime + cli typecheck clean against the rebuilt dist.

Ships with #474 (real model ids) — the two are one story: #474 makes `/model opus` resolve to a real model, this makes the requests to that model valid. Refs #471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)