### PR TITLE
fix(runtime): strip <narration> from display text — the typed chunk is the tag's only carrier

### DIFF
--- a/.changeset/narration-tag-display-strip.md
+++ b/.changeset/narration-tag-display-strip.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+The `<narration>` tag no longer leaks into visible chat text (witnessed on the first live Opus round: the raw tag rendered above its own dim echo). The narration contract promises the typed `task_step_narration` chunk is the tag's only carrier; the display-strip now keeps that promise, including holding back partially streamed tags.

--- a/packages/runtime/src/__tests__/streaming.test.ts
+++ b/packages/runtime/src/__tests__/streaming.test.ts
@@ -898,6 +898,54 @@ describe("processStream side effects", () => {
     expect(chunks[1]).toMatchObject({ type: "tool_status", name: "read_file", status: "done" });
   });
 
+  it("strips <narration> tags from display text — the typed chunk is the only carrier", async () => {
+    // Witnessed 2026-07-29 (first live Opus round): the tag leaked verbatim
+    // into the mote> text while the task_step_narration chunk ALSO rendered
+    // its echo. The prompt contract (prompt.ts) promises the tag never
+    // reaches the chat register; stripDisplayTags is where that promise
+    // is kept.
+    const result = makeTurnResult();
+    mockRunTurnStreaming.mockReturnValue(
+      yieldChunks(
+        {
+          type: "text",
+          text: "<narration>Checking npm registry</narration>The live version is 1.11.0.",
+        },
+        { type: "result", result },
+      ),
+    );
+
+    const chunks = await collectChunks(runtime.sendMessageStreaming("what version is live?"));
+    const text = chunks
+      .filter((c): c is { type: "text"; text: string } => c.type === "text")
+      .map((c) => c.text)
+      .join("");
+    expect(text).not.toContain("<narration>");
+    expect(text).not.toContain("Checking npm registry");
+    expect(text).toContain("The live version is 1.11.0.");
+  });
+
+  it("holds back a partially streamed <narration tag instead of flashing it", async () => {
+    const result = makeTurnResult();
+    mockRunTurnStreaming.mockReturnValue(
+      yieldChunks(
+        { type: "text", text: "Done. <narrat" },
+        { type: "text", text: "ion>Reading the page</narration> All set." },
+        { type: "result", result },
+      ),
+    );
+
+    const chunks = await collectChunks(runtime.sendMessageStreaming("go"));
+    const text = chunks
+      .filter((c): c is { type: "text"; text: string } => c.type === "text")
+      .map((c) => c.text)
+      .join("");
+    expect(text).not.toContain("<narrat");
+    expect(text).not.toContain("Reading the page");
+    expect(text).toContain("Done.");
+    expect(text).toContain("All set.");
+  });
+
   it("captures pending approval on approval_request", async () => {
     const result = makeTurnResult();
     mockRunTurnStreaming.mockReturnValue(

--- a/packages/runtime/src/streaming.ts
+++ b/packages/runtime/src/streaming.ts
@@ -45,6 +45,11 @@ function stripDisplayTags(text: string): { clean: string; pending: string } {
   const clean = text
     .replace(/<memory\s+[^>]*>[\s\S]*?<\/memory>/g, "")
     .replace(/<thinking>[\s\S]*?<\/thinking>/g, "")
+    // The narration contract (prompt.ts, task_step_narration) PROMISES the
+    // tag never leaks into the chat register — the typed chunk is its only
+    // carrier. Witnessed leaking verbatim 2026-07-29 on the first live
+    // Opus round: promised in the prompt, missing from this list.
+    .replace(/<narration>[\s\S]*?<\/narration>/g, "")
     .replace(/<state\s+[^>]*\/>/g, "")
     .replace(/<parameter\s+[^>]*>[\s\S]*?<\/parameter>/g, "")
     .replace(/<\/?(?:artifact|function_calls|invoke|antml)[^>]*>/g, "")
@@ -57,7 +62,7 @@ function stripDisplayTags(text: string): { clean: string; pending: string } {
     .replace(/\*{1,3}/g, "")
     .replace(/ {2,}/g, " ");
 
-  for (const tag of ["<memory", "<thinking", "<parameter"]) {
+  for (const tag of ["<memory", "<thinking", "<parameter", "<narration"]) {
     const lastOpen = clean.lastIndexOf(tag);
     if (lastOpen !== -1) {
       const closeTag = `</${tag.slice(1)}>`;


### PR DESCRIPTION
Witnessed 2026-07-29 on the first successful live Opus round of the #456 validation — the moment the rendering arc finally got a competent model, it also revealed this:

```
mote> <narration>Checking npm registry for the latest motebit version</narration>
    · Checking npm registry for the latest motebit version
```

The raw tag rendered verbatim in chat text, directly above the dim echo the `task_step_narration` chunk correctly produced. The prompt contract (`prompt.ts`, task-step-narration clause) explicitly promises *"the `<narration>` tag is stripped from the visible text so it doesn't leak into the chat register"* — promised in the prompt, absent from `stripDisplayTags`. Typed-truth doctrine: wire field + prompt clause + dispatch enforcement ship together; the third leg was never built.

Fix: `stripDisplayTags` strips `<narration>…</narration>` and holds back a partially streamed opening tag (same pending mechanism as memory/thinking/parameter). One chokepoint covers every surface. Two tests: full strip with the typed-chunk echo intact, and split-across-chunks hold-back. Runtime 1260 green; typecheck/lint clean.

Should ride 1.11.1 with #474/#476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)