### PR TITLE
feat(cli): wrapped multi-row input display — the full line stays visible, no h-scroll window (#480)

### DIFF
--- a/.changeset/cli-wrapped-input.md
+++ b/.changeset/cli-wrapped-input.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+REPL input now wraps across rows instead of h-scrolling behind an ellipsis — the full line stays visible while typing or editing (#480, first queued #456 increment). The input row is one logical row of arbitrary width; clearing and cursor parking both derive from the same reflow math, so repaints, resize, and mid-line edits stay exact at any width.

--- a/apps/cli/src/__tests__/terminal-render.test.ts
+++ b/apps/cli/src/__tests__/terminal-render.test.ts
@@ -44,8 +44,8 @@ describe("terminal renderer — owned bottom region", () => {
     vt.resize(12);
     r.repaint();
     expect(vt.count("you>")).toBe(1);
-    // Repainted for the new width: still a single non-wrapped row
-    expect(vt.screen().split("\n").length).toBe(1);
+    // Repainted for the new width: the input wraps, nothing is lost
+    expect(vt.screen().replace(/\n/g, "")).toBe("you> a somewhat longer input");
   });
 
   it("writeOutput during active input lands above the prompt", () => {
@@ -60,16 +60,101 @@ describe("terminal renderer — owned bottom region", () => {
     expect(vt.screen().endsWith("you> typing more")).toBe(true);
   });
 
-  it("long input h-scrolls in a single region row instead of wrapping", () => {
+  it("long input wraps across rows with the full text visible (#480)", () => {
     const { vt, r } = setup(20);
     void r.readInput("you> ");
     type(r, "abcdefghijklmnopqrstuvwxyz");
-    const lines = vt.screen().split("\n");
-    expect(lines.length).toBe(1);
-    expect(lines[0]!.length).toBeLessThan(20);
-    expect(lines[0]).toContain("…");
-    // Cursor stays on the only row, at the end of the window
-    expect(vt.cursor().row).toBe(0);
+    // 5 (prompt) + 26 = 31 visible chars → two visual rows at 20 cols
+    expect(vt.screen()).toBe("you> abcdefghijklmno\npqrstuvwxyz");
+    expect(vt.count("…")).toBe(0);
+    // Cursor sits at the end of the second visual row
+    expect(vt.cursor()).toEqual({ row: 1, col: 11 });
+  });
+
+  it("wrapped input: typing repaints cleanly, never stacks rows", () => {
+    const { vt, r } = setup(20);
+    void r.readInput("you> ");
+    type(r, "abcdefghijklmnopqrstuvwxyz");
+    type(r, "0123456789");
+    expect(vt.count("you>")).toBe(1);
+    expect(vt.screen()).toBe("you> abcdefghijklmno\npqrstuvwxyz012345678\n9");
+  });
+
+  it("wrapped input: editing mid-line parks the cursor on the right visual row", () => {
+    const { vt, r } = setup(20);
+    void r.readInput("you> ");
+    type(r, "abcdefghijklmnopqrstuvwxyz");
+    r.handleEvent({ type: "key", key: "home", ctrl: false });
+    expect(vt.cursor()).toEqual({ row: 0, col: 5 });
+    type(r, "X");
+    expect(vt.screen()).toBe("you> Xabcdefghijklmn\nopqrstuvwxyz");
+    expect(vt.cursor()).toEqual({ row: 0, col: 6 });
+  });
+
+  it("wrapped input: backspace across the wrap boundary shrinks back to one row", () => {
+    const { vt, r } = setup(20);
+    void r.readInput("you> ");
+    type(r, "abcdefghijklmnopq"); // 5 + 17 = 22 → wraps
+    expect(vt.screen().split("\n").length).toBe(2);
+    for (let i = 0; i < 10; i++) r.handleEvent({ type: "key", key: "backspace", ctrl: false });
+    expect(vt.screen()).toBe("you> abcdefg");
+    expect(vt.count("you>")).toBe(1);
+  });
+
+  it("writeOutput during wrapped input lands above and leaves the input intact", () => {
+    const { vt, r } = setup(20);
+    void r.readInput("you> ");
+    type(r, "abcdefghijklmnopqrstuvwxyz");
+    r.writeOutput("  · a step happened\n");
+    expect(vt.screen()).toBe("  · a step happened\nyou> abcdefghijklmno\npqrstuvwxyz");
+    expect(vt.count("you>")).toBe(1);
+    type(r, "!");
+    expect(vt.screen().endsWith("pqrstuvwxyz!")).toBe(true);
+  });
+
+  it("status row stays single above a wrapped input", () => {
+    const { vt, r } = setup(20);
+    r.setStatusRow("  · thinking · 2s");
+    void r.readInput("you> ");
+    type(r, "abcdefghijklmnopqrstuvwxyz");
+    expect(vt.screen()).toBe("  · thinking · 2s\nyou> abcdefghijklmno\npqrstuvwxyz");
+    r.setStatusRow(null);
+    expect(vt.screen()).toBe("you> abcdefghijklmno\npqrstuvwxyz");
+  });
+
+  it("resize while the input is wrapped repaints one prompt with all text (#455)", () => {
+    const { vt, r } = setup(20);
+    void r.readInput("you> ");
+    type(r, "abcdefghijklmnopqrstuvwxyz");
+    for (const cols of [16, 12, 24, 40]) {
+      vt.resize(cols);
+      r.repaint();
+    }
+    expect(vt.count("you>")).toBe(1);
+    expect(vt.screen()).toBe("you> abcdefghijklmnopqrstuvwxyz");
+  });
+
+  it("submitting a wrapped input echoes the full line to scrollback", async () => {
+    const { vt, r } = setup(20);
+    const p = r.readInput("you> ");
+    type(r, "abcdefghijklmnopqrstuvwxyz");
+    r.handleEvent({ type: "key", key: "return", ctrl: false });
+    await expect(p).resolves.toBe("abcdefghijklmnopqrstuvwxyz");
+    r.writeOutput("mote> ok\n");
+    expect(vt.screen()).toBe("you> abcdefghijklmno\npqrstuvwxyz\nmote> ok");
+    expect(vt.count("you>")).toBe(1);
+  });
+
+  it("input filling the width exactly still clears without residue", () => {
+    const { vt, r } = setup(10);
+    void r.readInput("you> ");
+    type(r, "abcde"); // 5 + 5 = exactly 10
+    expect(vt.screen()).toBe("you> abcde");
+    type(r, "f"); // 11 → wraps
+    expect(vt.screen()).toBe("you> abcde\nf");
+    r.handleEvent({ type: "key", key: "backspace", ctrl: false });
+    expect(vt.screen()).toBe("you> abcde");
+    expect(vt.count("you>")).toBe(1);
   });
 
   it("status row sits above the input row and updates in place", () => {

--- a/apps/cli/src/terminal.ts
+++ b/apps/cli/src/terminal.ts
@@ -3,17 +3,21 @@
  *
  * The screen splits into two regions:
  *   - scrollback (above): append-only, plain prints, never edited
- *   - the owned bottom region: up to three non-wrapping rows —
- *     a pending partial output line, a status row, and the input row
+ *   - the owned bottom region: a pending partial output line, a status row,
+ *     and the input row
  *
  * Every mutation goes through one `commit()`: clear the previously painted
  * region, append any completed scrollback, repaint the region rows, park the
- * cursor. Because region rows are truncated/h-scrolled to the terminal width
- * they NEVER soft-wrap, so "how many rows do I move up to clear" has an exact
- * answer — including across a resize, where the clear recomputes row heights
- * at the new width under the macOS reflow model (#455: resize is a repaint,
- * never a fresh print). Repaints are wrapped in synchronized-output markers
- * (ESC[?2026) so a repaint is never seen half-done.
+ * cursor. The tail and status rows are truncated to the terminal width and
+ * never soft-wrap; the input row is one LOGICAL row of arbitrary width that
+ * the terminal soft-wraps across as many visual rows as it needs (#480:
+ * wrapped display replaced the h-scroll window). Clearing stays exact
+ * because visual height is recomputable — `rowsAt(width, cols)` — and the
+ * cursor parks via the same math (`cursorVisRow`), including across a
+ * resize, where the clear recomputes row heights at the new width under the
+ * macOS reflow model (#455: resize is a repaint, never a fresh print).
+ * Repaints are wrapped in synchronized-output markers (ESC[?2026) so a
+ * repaint is never seen half-done.
  *
  * stream.ts, the scheduler, and the injected runtime logger all write through
  * writeOutput() so output and input never collide (#456).
@@ -131,27 +135,14 @@ export function createTerminalRenderer(io: TerminalIO): TerminalRenderer {
   // widths; cursorCol is where the cursor was parked on the last row).
   let painted: { widths: number[]; cursorCol: number } = { widths: [], cursorCol: 0 };
 
-  function buildInputRow(cols: number): { row: string; width: number; cursorCol: number } {
-    const avail = Math.max(1, cols - 1 - inputState.promptWidth);
-    if (inputState.line.length <= avail) {
-      return {
-        row: inputState.prompt + inputState.line,
-        width: inputState.promptWidth + inputState.line.length,
-        cursorCol: inputState.promptWidth + inputState.cursor,
-      };
-    }
-    // Horizontal scroll: window the line around the cursor. Never wrap —
-    // the non-wrapping region row is what makes clearing (and resize) exact.
-    const start = Math.max(
-      0,
-      Math.min(inputState.cursor - Math.floor(avail / 2), inputState.line.length - avail),
-    );
-    const windowText = inputState.line.slice(start, start + avail);
-    const shown = start > 0 ? "…" + windowText.slice(1) : windowText;
+  function buildInputRow(): { row: string; width: number; cursorCol: number } {
+    // The full line, always. The terminal soft-wraps it; clearing and cursor
+    // parking recompute its visual height from the width, so nothing is
+    // hidden behind an h-scroll window (#480).
     return {
-      row: inputState.prompt + shown,
-      width: inputState.promptWidth + shown.length,
-      cursorCol: inputState.promptWidth + (inputState.cursor - start),
+      row: inputState.prompt + inputState.line,
+      width: inputState.promptWidth + inputState.line.length,
+      cursorCol: inputState.promptWidth + inputState.cursor,
     };
   }
 
@@ -193,7 +184,7 @@ export function createTerminalRenderer(io: TerminalIO): TerminalRenderer {
     }
     let cursorCol = 0;
     if (inputActive) {
-      const built = buildInputRow(cols);
+      const built = buildInputRow();
       rows.push(built.row);
       widths.push(built.width);
       cursorCol = built.cursorCol;
@@ -203,8 +194,16 @@ export function createTerminalRenderer(io: TerminalIO): TerminalRenderer {
 
     if (rows.length > 0) {
       out += rows.join("\n");
+      // Park the cursor at cursorCol WITHIN the last logical row. After the
+      // write above the terminal cursor sits at the end of that row's last
+      // visual row; the target may be on an earlier visual row when the
+      // input has wrapped and the edit point is mid-line.
+      const lastWidth = widths[widths.length - 1]!;
+      const upWithin = cursorVisRow(lastWidth, cols) - cursorVisRow(cursorCol, cols);
+      if (upWithin > 0) out += `\x1b[${upWithin}A`;
       out += "\r";
-      if (cursorCol > 0) out += `\x1b[${cursorCol}C`;
+      const colInRow = cursorCol - cursorVisRow(cursorCol, cols) * cols;
+      if (colInRow > 0) out += `\x1b[${colInRow}C`;
     }
 
     const hadOrHasRegion = painted.widths.length > 0 || rows.length > 0;
@@ -259,7 +258,7 @@ export function createTerminalRenderer(io: TerminalIO): TerminalRenderer {
   function submit(): void {
     const line = inputState.line;
     inputActive = false;
-    // Durable echo of the full typed line (even if it was h-scrolled).
+    // Durable echo of the full typed line.
     commit(inputState.prompt + line + "\n");
     if (inputResolver) {
       const resolve = inputResolver;


### PR DESCRIPTION
First queued #456 increment, folded into the #480 polish arc.

The REPL input row becomes one **logical** row of arbitrary width that the terminal soft-wraps, replacing the h-scroll window (`…refix hidden`). The owned-region invariant shifts from "region rows never wrap" to "region geometry is always recomputable": tail and status rows stay single-row truncated; the input row's visual height is `rowsAt(width, cols)` — the same two functions that already drive the clear math now also drive cursor parking, so there is no second geometry to drift.

- `buildInputRow` returns the full line; the windowing/ellipsis path is gone.
- `commit()` parks the cursor vertically within the wrapped row (`cursorVisRow`), so mid-line edits land on the correct visual row.
- Resize repaints all text at the new width (the #455 reflow model, now exercised by multi-row input).

9 new golden-screen VT tests: wrap rendering, no-stack typing, mid-line cursor parking, backspace across the wrap boundary, output-above-wrapped-input, status-row ordering, resize reflow, full-line submit echo, exact-width edge.

Part of #480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)