### PR TITLE
feat(cli): thinking-status row during model latency — the blank mote> gap gets a pulse (#480)

### DIFF
--- a/.changeset/cli-thinking-status.md
+++ b/.changeset/cli-thinking-status.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+A thinking-status row now covers model latency in the REPL (#480, second queued #456 increment): the gap between your Enter and the first token, and between a tool's done-line and the model's next words, shows a calm `· thinking · 3s` pulse instead of a blank `mote>`. Streamed text is its own progress indicator, so the row yields the moment tokens flow. Same treatment on the attached REPL.

--- a/apps/cli/src/__tests__/stream.test.ts
+++ b/apps/cli/src/__tests__/stream.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Event log shared across mocks — tests assert on the ORDER of status
+// transitions relative to rendered output, the register the user feels.
+const events: Array<[string, string]> = [];
+
+const { startStatus } = vi.hoisted(() => {
+  const startStatus = (verb: string, subject?: string) => {
+    events.push(["status", subject ? `${verb} ${subject}` : verb]);
+    let stopped = false;
+    return {
+      step: (text: string) => events.push(["step", text]),
+      note: () => {},
+      stop: () => {
+        if (stopped) return 0;
+        stopped = true;
+        events.push(["stop", subject ? `${verb} ${subject}` : verb]);
+        return 1000;
+      },
+    };
+  };
+  return { startStatus };
+});
+
+vi.mock("../statusline.js", () => ({ startStatus }));
+vi.mock("../terminal.js", () => ({
+  writeOutput: (s: string) => events.push(["out", s]),
+  writeLine: (s: string) => events.push(["line", s]),
+  askQuestion: async () => "n",
+}));
+vi.mock("../receipt.js", () => ({
+  archiveReceipt: () => {},
+  renderReceipt: async () => {},
+}));
+
+import { consumeStream } from "../stream.js";
+import type { MotebitRuntime, StreamChunk } from "@motebit/runtime";
+
+async function* chunks(...list: Partial<StreamChunk>[]): AsyncGenerator<StreamChunk> {
+  for (const c of list) yield c as StreamChunk;
+}
+
+const runtime = {} as MotebitRuntime;
+
+/** The status-transition trace, ignoring rendered text/lines. */
+function statusTrace(): string[] {
+  return events.filter(([k]) => k === "status" || k === "stop").map(([k, v]) => `${k}:${v}`);
+}
+
+const resultChunk = {
+  type: "result",
+  result: {
+    memoriesFormed: [],
+    stateAfter: { attention: 0.5, confidence: 0.5, affect_valence: 0, curiosity: 0.5 },
+    cues: [],
+  },
+} as unknown as StreamChunk;
+
+describe("consumeStream — thinking-status row during model latency (#480)", () => {
+  beforeEach(() => {
+    events.length = 0;
+  });
+
+  it("shows thinking from stream start until the first text chunk", async () => {
+    await consumeStream(chunks({ type: "text", text: "hello" }, resultChunk), runtime);
+    const textIdx = events.findIndex(([k, v]) => k === "out" && v === "hello");
+    const stopIdx = events.findIndex(([k, v]) => k === "stop" && v === "thinking");
+    expect(events[0]).toEqual(["status", "thinking"]);
+    expect(stopIdx).toBeGreaterThan(-1);
+    expect(stopIdx).toBeLessThan(textIdx);
+  });
+
+  it("restarts thinking after a tool finishes — the inter-act latency gap", async () => {
+    await consumeStream(
+      chunks(
+        { type: "text", text: "let me look" },
+        { type: "tool_status", name: "web_search", status: "calling" },
+        { type: "tool_status", name: "web_search", status: "done" },
+        { type: "text", text: "found it" },
+        resultChunk,
+      ),
+      runtime,
+    );
+    expect(statusTrace()).toEqual([
+      "status:thinking",
+      "stop:thinking",
+      "status:running web_search",
+      "stop:running web_search",
+      "status:thinking",
+      "stop:thinking",
+    ]);
+  });
+
+  it("delegation_start replaces thinking instead of being skipped by it", async () => {
+    await consumeStream(
+      chunks(
+        { type: "delegation_start", tool: "research" } as unknown as StreamChunk,
+        { type: "delegation_complete", tool: "research" } as unknown as StreamChunk,
+        resultChunk,
+      ),
+      runtime,
+    );
+    expect(statusTrace()).toEqual([
+      "status:thinking",
+      "stop:thinking",
+      "status:delegating research",
+      "stop:delegating research",
+      "status:thinking",
+      "stop:thinking",
+    ]);
+    // The delegation done-line rendered (the guard did not mistake thinking
+    // for an already-running delegation status)
+    expect(events.some(([k, v]) => k === "line" && v.includes("research"))).toBe(true);
+  });
+
+  it("a stream ending in an approval request leaves no status running", async () => {
+    // resolveApprovalVote yields nothing — the #457 backstop line renders.
+    const rt = {
+      motebitId: "m-1",
+      resolveApprovalVote: () => chunks(),
+    } as unknown as MotebitRuntime;
+    await consumeStream(
+      chunks({ type: "text", text: "I need approval" }, {
+        type: "approval_request",
+        tool_call_id: "t1",
+        name: "delegate_to_agent",
+        args: {},
+      } as unknown as StreamChunk),
+      rt,
+    );
+    const starts = events.filter(([k]) => k === "status").length;
+    const stops = events.filter(([k]) => k === "stop").length;
+    expect(starts).toBe(stops);
+    // Every status started before the approval band was stopped before it —
+    // no pulsing row above a waiting y/n prompt. (The resumed stream after
+    // the "n" answer runs its own thinking cycle; that's the tail pair.)
+    const bandIdx = events.findIndex(([k]) => k === "line");
+    expect(bandIdx).toBeGreaterThan(-1);
+    const before = events.slice(0, bandIdx);
+    expect(before.filter(([k]) => k === "status").length).toBe(
+      before.filter(([k]) => k === "stop").length,
+    );
+  });
+
+  it("a stray tool done with no work status does not mint a done-line from thinking", async () => {
+    await consumeStream(
+      chunks({ type: "tool_status", name: "delegate_to_agent", status: "done" }, resultChunk),
+      runtime,
+    );
+    expect(events.filter(([k, v]) => k === "line" && v.includes("done")).length).toBe(0);
+  });
+
+  it("result chunk stops thinking even when no text ever arrived", async () => {
+    await consumeStream(chunks(resultChunk), runtime);
+    const starts = events.filter(([k]) => k === "status").length;
+    const stops = events.filter(([k]) => k === "stop").length;
+    expect(starts).toBe(stops);
+  });
+
+  it("a throwing stream still tears the thinking row down (finally path)", async () => {
+    async function* boom(): AsyncGenerator<StreamChunk> {
+      yield { type: "text", text: "so" } as StreamChunk;
+      throw new Error("provider fell over");
+    }
+    await expect(consumeStream(boom(), runtime)).rejects.toThrow("provider fell over");
+    const starts = events.filter(([k]) => k === "status").length;
+    const stops = events.filter(([k]) => k === "stop").length;
+    expect(starts).toBe(stops);
+  });
+});

--- a/apps/cli/src/attached-repl.ts
+++ b/apps/cli/src/attached-repl.ts
@@ -43,22 +43,34 @@ async function renderStream(
   // (sibling boundary rule): in-flight state lives on the status row,
   // scrollback gets one durable line per completed act.
   let status: StatusHandle | null = null;
+  // Model-latency cover (#480) — same two-row split as stream.ts: `thinking`
+  // fills the gaps before the first token and between a tool's done-line and
+  // the model's next words; `status` is real in-flight work.
+  let thinking: StatusHandle | null = null;
+  const stopThinking = (): void => {
+    thinking?.stop();
+    thinking = null;
+  };
   const stopStatus = (): number => {
+    stopThinking();
     const elapsed = status?.stop() ?? 0;
     status = null;
     return elapsed;
   };
+  thinking = startStatus("thinking");
   try {
     for await (const raw of stream) {
       const chunk = raw as WireChunk;
       switch (chunk.type) {
         case "text":
+          stopThinking();
           if (typeof chunk.text === "string") writeOutput(chunk.text);
           break;
         case "tool_status": {
           const name = chunk.name ?? "tool";
           if (chunk.status === "calling") {
             if (name === "delegate_to_agent" && status) break;
+            stopThinking();
             status =
               name === "delegate_to_agent"
                 ? startStatus("delegating")
@@ -69,6 +81,7 @@ async function renderStream(
             writeLine(
               `  ${action("●")} ${action(name)} ${meta(`· done · ${formatElapsed(0, stopStatus())}`)}`,
             );
+            thinking = startStatus("thinking");
           }
           break;
         }
@@ -81,6 +94,7 @@ async function renderStream(
           break;
         case "delegation_start":
           if (status) break;
+          stopThinking();
           status = startStatus("delegating", chunk.tool ?? "task");
           break;
         case "delegation_complete":
@@ -90,6 +104,7 @@ async function renderStream(
               dim(`[receipt ${chunk.receipt.task_id.slice(0, 8)} · ${chunk.receipt.status ?? ""}]`),
             );
           }
+          thinking = startStatus("thinking");
           break;
         case "injection_warning":
           writeLine(`${warn("⚠")} suspicious content in ${chunk.tool_name ?? "tool"} output`);

--- a/apps/cli/src/stream.ts
+++ b/apps/cli/src/stream.ts
@@ -31,11 +31,25 @@ export async function consumeStream(
     risk_level?: number;
   } | null = null;
   let status: StatusHandle | null = null;
+  // Model-latency cover (#480): the row that answers "is anything happening?"
+  // between the user's Enter and the first token, and again between a tool's
+  // done-line and the model's next words. Kept separate from `status` so the
+  // work-status guards (delegation_start vs tool_status races) never mistake
+  // "thinking" for an in-flight tool.
+  let thinking: StatusHandle | null = null;
+  const stopThinking = (): void => {
+    thinking?.stop();
+    thinking = null;
+  };
+  // Every terminal-outcome path stops both rows — a thrown provider error or
+  // a result chunk must never leave a pulsing "thinking" above the prompt.
   const stopStatus = (): number => {
+    stopThinking();
     const elapsed = status?.stop() ?? 0;
     status = null;
     return elapsed;
   };
+  thinking = startStatus("thinking");
   let lastCompletedReceiptResult: string | null = null;
   // #457: whether ANY chunk arrived — the caller uses this to guarantee an
   // approval answer never ends in pure silence. Returns true once a chunk
@@ -47,6 +61,8 @@ export async function consumeStream(
       sawAnyChunk = true;
       switch (chunk.type) {
         case "text":
+          // The streamed text is its own progress indicator.
+          stopThinking();
           writeOutput(chunk.text);
           break;
 
@@ -59,6 +75,7 @@ export async function consumeStream(
             for (const line of renderAuthorityDelta(chunk.name, chunk.missing_authority)) {
               writeLine(meta(line));
             }
+            thinking = startStatus("thinking");
             break;
           }
           // Delegation normally announces itself via delegation_start/complete,
@@ -72,6 +89,7 @@ export async function consumeStream(
             break;
           }
           if (chunk.status === "calling") {
+            stopThinking();
             status =
               chunk.name === "delegate_to_agent"
                 ? startStatus("delegating")
@@ -82,6 +100,9 @@ export async function consumeStream(
             // status in flight is the redundant twin of a delegation_complete
             // that already rendered — old code printed a stray " done" here.
             writeLine(toolDoneLine(chunk.name, stopStatus()));
+            // The model reads the result before its next words — cover that
+            // gap too, same as the pre-first-token gap.
+            thinking = startStatus("thinking");
           }
           break;
 
@@ -101,6 +122,7 @@ export async function consumeStream(
           // Guard against a second status when tool_status already started
           // one (the post-approval path emits tool_status first).
           if (status) break;
+          stopThinking();
           status = startStatus("delegating", chunk.tool);
           break;
 
@@ -115,7 +137,10 @@ export async function consumeStream(
           break;
 
         case "delegation_complete":
-          if (status) writeLine(toolDoneLine(chunk.tool, stopStatus()));
+          if (status) {
+            writeLine(toolDoneLine(chunk.tool, stopStatus()));
+            thinking = startStatus("thinking");
+          }
           // Archive the signed receipt so `/receipt <task-id>` can re-render
           // it, and emerge a CLI-native rendering right here — the "oh" beat
           // that proves the delegation actually happened and the signature


### PR DESCRIPTION
Second queued #456 increment, folded into the #480 polish arc.

`consumeStream` starts a `thinking` status at stream entry, yields it to the first text token (streamed text is its own progress indicator), and restarts it after each tool/delegation done-line — the two gaps where the screen previously showed a bare `mote>` with nothing moving: pre-first-token latency and the model-reads-the-result gap between acts.

- Kept as a **separate handle** from the work status so the `delegation_start` / `tool_status` race guards never mistake "thinking" for an in-flight tool (a thinking row must not suppress the delegation status, and a stray `tool_status done` must not mint a done-line from it).
- Every terminal-outcome path — result, approval expired/voided, invoke_error, thrown stream — tears it down through the shared `stopStatus`, so a provider error can never leave a forever-pulsing row above the prompt.
- Post-approval resume gets the same cover (the recursive stream starts its own cycle).
- Sibling: `attached-repl.ts` identical treatment.

New `stream.test.ts` (7 tests) asserts the status-transition **order** at the module seam: thinking→text handoff, inter-act restart, delegation-guard non-shadowing, no-status-after-approval-band, stray-done guard, teardown on result and on a throwing stream.

Part of #480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)