### PR TITLE
fix(cli): state-vector telemetry out of the product register — /state keeps the readout (#480)

### DIFF
--- a/.changeset/cli-telemetry-register.md
+++ b/.changeset/cli-telemetry-register.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+The per-turn `[state: attention=…]` and `[Body]` lines no longer render after every REPL turn (#480). They were operation-level readouts in the product register; the felt-interior unit is the durable mutation, so `[memories: …]` still renders when a memory forms, and the full state vector remains available behind `/state`. Same treatment on the non-streaming path.

--- a/apps/cli/src/__tests__/stream.test.ts
+++ b/apps/cli/src/__tests__/stream.test.ts
@@ -157,6 +157,32 @@ describe("consumeStream — thinking-status row during model latency (#480)", ()
     expect(starts).toBe(stops);
   });
 
+  it("the result chunk renders no state-vector or body telemetry (#480)", async () => {
+    await consumeStream(chunks({ type: "text", text: "done." }, resultChunk), runtime);
+    const rendered = events
+      .filter(([k]) => k === "out" || k === "line")
+      .map(([, v]) => v)
+      .join("");
+    expect(rendered).not.toContain("[state:");
+    expect(rendered).not.toContain("attention=");
+    expect(rendered).not.toContain("[Body");
+  });
+
+  it("memories formed — the durable mutation — still render after the turn", async () => {
+    const withMemories = {
+      ...(resultChunk as unknown as { result: Record<string, unknown> }),
+      result: {
+        memoriesFormed: [{ content: "Daniel prefers calm software" }],
+        stateAfter: { attention: 0.5, confidence: 0.5, affect_valence: 0, curiosity: 0.5 },
+        cues: [],
+      },
+    } as unknown as StreamChunk;
+    await consumeStream(chunks({ type: "text", text: "noted." }, withMemories), runtime);
+    const rendered = events.map(([, v]) => v).join("");
+    expect(rendered).toContain("[memories: Daniel prefers calm software]");
+    expect(rendered).not.toContain("[state:");
+  });
+
   it("a throwing stream still tears the thinking row down (finally path)", async () => {
     async function* boom(): AsyncGenerator<StreamChunk> {
       yield { type: "text", text: "so" } as StreamChunk;

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -2,7 +2,6 @@ import { DEFAULT_CONFIG } from "@motebit/ai-core";
 import type { MotebitPersonalityConfig } from "@motebit/ai-core";
 import { deriveSyncEncryptionKey, mintAudienceToken } from "@motebit/encryption";
 import { connectMcpServers } from "@motebit/mcp-client";
-import { formatBodyAwareness } from "@motebit/ai-core";
 import { providerAcceptsModel } from "@motebit/sdk";
 import { createSolanaWalletRail } from "@motebit/wallet-solana";
 import { preflightGrant, renderPreflight } from "./grant-preflight.js";
@@ -1090,21 +1089,14 @@ async function main(): Promise<void> {
 
         console.log(`\n${promptColor("mote>")} ${result.response}\n`);
 
+        // Same register as the streaming path (#480): the durable mutation
+        // renders; the state vector lives behind `/state`.
         if (result.memoriesFormed.length > 0) {
           console.log(
             meta(`  [memories: ${result.memoriesFormed.map((m) => m.content).join(", ")}]`),
           );
+          console.log();
         }
-
-        const s = result.stateAfter;
-        console.log(
-          meta(
-            `  [state: attention=${s.attention.toFixed(2)} confidence=${s.confidence.toFixed(2)} valence=${s.affect_valence.toFixed(2)} curiosity=${s.curiosity.toFixed(2)}]`,
-          ),
-        );
-        const bodyLine = formatBodyAwareness(result.cues);
-        if (bodyLine) console.log(meta(`  ${bodyLine}`));
-        console.log();
       } else {
         writeOutput("\n" + promptColor("mote>") + " ");
         const grantOptions = grantPresenter?.delegationForTurn() ?? undefined;

--- a/apps/cli/src/stream.ts
+++ b/apps/cli/src/stream.ts
@@ -1,7 +1,6 @@
 // --- Streaming consumer and approval flow ---
 
 import type { MotebitRuntime, StreamChunk } from "@motebit/runtime";
-import { formatBodyAwareness } from "@motebit/ai-core";
 import { action, meta, warn, dim, prompt as promptColor } from "./colors.js";
 import { writeOutput, writeLine, askQuestion } from "./terminal.js";
 import { startStatus, type StatusHandle } from "./statusline.js";
@@ -192,23 +191,17 @@ export async function consumeStream(
           stopStatus();
           writeOutput("\n\n");
 
+          // Felt-interior: the per-turn record is the durable mutation
+          // (memories formed), not the operation-level readout. The raw
+          // state vector and body cues read as debug output in the product
+          // register (#480) — `/state` remains the deliberate readout.
           if (result.memoriesFormed.length > 0) {
             writeOutput(
               meta(
                 `  [memories: ${result.memoriesFormed.map((m: { content: string }) => m.content).join(", ")}]`,
-              ) + "\n",
+              ) + "\n\n",
             );
           }
-
-          const s = result.stateAfter;
-          writeOutput(
-            meta(
-              `  [state: attention=${s.attention.toFixed(2)} confidence=${s.confidence.toFixed(2)} valence=${s.affect_valence.toFixed(2)} curiosity=${s.curiosity.toFixed(2)}]`,
-            ) + "\n",
-          );
-          const bodyLine = formatBodyAwareness(result.cues);
-          if (bodyLine) writeOutput(meta(`  ${bodyLine}`) + "\n");
-          writeOutput("\n");
           break;
         }
       }


### PR DESCRIPTION
Item 1 of the #480 polish arc.

The per-turn `[state: attention=…]` and `[Body]` lines after every REPL turn read as debug output — operation-level readouts in the product register. Felt-interior's unit is the **durable mutation**, so:

- `[memories: …]` still renders when a memory forms (and now closes its own spacing — no orphan blank rows when nothing formed).
- The raw state vector stays available behind the existing `/state` slash — the deliberate readout, not an every-turn broadcast.
- `[Body]` cues no longer render per turn (sensorium: proprioception is for the model's prompt, not the owner's scrollback).
- Sibling: the `--no-stream` path gets identical treatment.

Two new `stream.test.ts` assertions: no `[state:`/`attention=`/`[Body` in a rendered turn; memories still render.

Part of #480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)