### PR TITLE
fix(cli): designed sentences for known logger events — route_degraded speaks the product register (#480)

### DIFF
--- a/.changeset/cli-logger-sentences.md
+++ b/.changeset/cli-logger-sentences.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+Known runtime events now render as designed sentences in the REPL instead of `key=value` dumps (#480): route degrade (`direct payment route unavailable — this task goes through the relay; no onchain payment leaves the wallet`), the volatile grant-spend-store warning, and relay key-pin rotation/mismatch. The compact context form remains the fallback for unknown events — and for a known event whose context doesn't match the shape its sentence was written for.

--- a/apps/cli/src/__tests__/cli-logger.test.ts
+++ b/apps/cli/src/__tests__/cli-logger.test.ts
@@ -48,13 +48,48 @@ describe("createCliLogger", () => {
     expect(note).toHaveBeenLastCalledWith("relay hiccup, still waiting (attempt 1)");
   });
 
-  it("renders other warnings as a calm line with compact context", () => {
+  it("renders unknown warnings as a calm line with compact context", () => {
     const logger = createCliLogger();
-    logger.warn("delegation.route_degraded", { from: "p2p", to: "relay" });
+    logger.warn("trust bump failed", { peer: "abc123" });
     const line = plain(writeLine.mock.calls[0]![0] as string);
-    expect(line).toContain("delegation.route_degraded");
-    expect(line).toContain("from=p2p");
-    expect(line).toContain("to=relay");
+    expect(line).toContain("trust bump failed");
+    expect(line).toContain("peer=abc123");
+  });
+
+  it("route_degraded renders as a designed sentence, not a key=value dump (#480)", () => {
+    const logger = createCliLogger();
+    logger.warn("delegation.route_degraded", {
+      from: "p2p",
+      to: "relay",
+      code: "p2p_ineligible",
+      message: "peer lacks p2p eligibility",
+    });
+    const line = plain(writeLine.mock.calls[0]![0] as string);
+    expect(line).toContain("direct payment route unavailable (p2p_ineligible)");
+    expect(line).toContain("no onchain payment leaves the wallet");
+    expect(line).not.toContain("from=");
+    expect(line).not.toContain("to=");
+  });
+
+  it("route_degraded with an unexpected shape falls back to the honest context form", () => {
+    const logger = createCliLogger();
+    logger.warn("delegation.route_degraded", { from: "relay", to: "p2p" });
+    const line = plain(writeLine.mock.calls[0]![0] as string);
+    // The p2p→relay sentence must not lie about a shape it wasn't written for
+    expect(line).not.toContain("no onchain payment");
+    expect(line).toContain("from=relay");
+  });
+
+  it("volatile spend store and key-pin events get designed sentences", () => {
+    const logger = createCliLogger();
+    logger.warn("money_meter.volatile_spend_store", { detail: "long injected detail" });
+    logger.warn("relay_key_pin.mismatch", { pinnedKeyPrefix: "aaa", fetchedKeyPrefix: "bbb" });
+    const first = plain(writeLine.mock.calls[0]![0] as string);
+    const second = plain(writeLine.mock.calls[1]![0] as string);
+    expect(first).toContain("re-arms on restart");
+    expect(first).not.toContain("detail=");
+    expect(second).toContain("does not match the pinned key");
+    expect(second).not.toContain("pinnedKeyPrefix=");
   });
 });
 

--- a/apps/cli/src/cli-logger.ts
+++ b/apps/cli/src/cli-logger.ts
@@ -34,6 +34,33 @@ export function formatContext(context: Record<string, unknown> | undefined): str
   return parts.length > 0 ? ` (${parts.join(" · ")})` : "";
 }
 
+/**
+ * Designed sentences for logger events with product meaning (#480): a known
+ * event renders as one calm sentence in the product register — the
+ * `key=value` context form is the fallback for unknown events, never the
+ * norm. Return null when the context doesn't match the shape the sentence
+ * was written for; the honest fallback is the compact context form, not a
+ * sentence that might lie.
+ */
+const DESIGNED_SENTENCES: Record<
+  string,
+  (ctx: Record<string, unknown> | undefined) => string | null
+> = {
+  "delegation.route_degraded": (ctx) => {
+    if (ctx?.from !== "p2p" || ctx?.to !== "relay") return null;
+    const code = typeof ctx.code === "string" ? ` (${ctx.code})` : "";
+    return `direct payment route unavailable${code} — this task goes through the relay; no onchain payment leaves the wallet`;
+  },
+  "money_meter.volatile_spend_store": () =>
+    "grant spending is metered in memory this session — the lifetime ceiling re-arms on restart",
+  "relay_key_pin.rotated": (ctx) => {
+    const to = typeof ctx?.toKeyPrefix === "string" ? ` (now ${ctx.toKeyPrefix}…)` : "";
+    return `the relay's signing key rotated${to} — the new key is pinned`;
+  },
+  "relay_key_pin.mismatch": () =>
+    "the relay's signing key does not match the pinned key — refusing to trust it",
+};
+
 export function createCliLogger(): RuntimeLogger {
   // Poll-failure attempts per task, session-scoped. Delegations are few;
   // the cap is a leak guard, not a policy.
@@ -56,6 +83,12 @@ export function createCliLogger(): RuntimeLogger {
         } else {
           writeLine(meta(`  · ${note} — task ${taskId.slice(0, 8)}`));
         }
+        return;
+      }
+
+      const designed = DESIGNED_SENTENCES[message]?.(context);
+      if (designed != null) {
+        writeLine(`  ${warn("·")} ${meta(designed)}`);
         return;
       }
 


### PR DESCRIPTION
Item 2 of the #480 polish arc — the `route_degraded` double-speak from the soak-test transcript.

The cli-logger's `key=value` context form becomes the **fallback** for unknown events, never the norm. Known events with product meaning render as one calm sentence:

- `delegation.route_degraded` → `direct payment route unavailable (p2p_ineligible) — this task goes through the relay; no onchain payment leaves the wallet`. Silence was considered (the tool result carries the fact) and rejected: this line is the only *guaranteed* user-facing render of #468's route honesty — the model relaying the tool result is compliance, not enforcement.
- `money_meter.volatile_spend_store` → the re-arms-on-restart warning in plain words.
- `relay_key_pin.rotated` / `relay_key_pin.mismatch` → pin state in plain words.

Shape-honesty rule: a designed sentence returns null when the context doesn't match the shape it was written for (e.g. a future non-p2p→relay degrade), falling back to the compact context form — a sentence must never lie about a shape it wasn't written for. Locked by a negative test.

Part of #480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)