### PR TITLE
fix(cli): one vertical rhythm, one indentation grammar — writeGap() makes blank rows idempotent (#480)

### DIFF
--- a/.changeset/cli-rhythm.md
+++ b/.changeset/cli-rhythm.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+One vertical rhythm and one indentation grammar for the REPL (#480): a new idempotent `writeGap()` renderer primitive guarantees exactly one blank row at every boundary (receipt blocks, end-of-turn) however many writers ask — the double/triple blank-line class is gone. Indentation now encodes nesting: 2-space records at act level, 4-space detail under a live act (logger lines included). Sub-second tools read `<1s` instead of a suspicious `0s`.

--- a/apps/cli/src/__tests__/cli-logger.test.ts
+++ b/apps/cli/src/__tests__/cli-logger.test.ts
@@ -80,6 +80,19 @@ describe("createCliLogger", () => {
     expect(line).toContain("from=relay");
   });
 
+  it("a logger line during a live act nests at 4 spaces; at rest it sits at 2 (#480)", () => {
+    const logger = createCliLogger();
+    activeStatus.mockReturnValue({ note: vi.fn(), step: vi.fn(), stop: vi.fn() });
+    logger.warn("delegation.route_degraded", { from: "p2p", to: "relay" });
+    activeStatus.mockReturnValue(null);
+    logger.warn("trust bump failed", { peer: "abc" });
+    const inAct = plain(writeLine.mock.calls[0]![0] as string);
+    const atRest = plain(writeLine.mock.calls[1]![0] as string);
+    expect(inAct.startsWith("    ·")).toBe(true);
+    expect(atRest.startsWith("  ·")).toBe(true);
+    expect(atRest.startsWith("    ")).toBe(false);
+  });
+
   it("volatile spend store and key-pin events get designed sentences", () => {
     const logger = createCliLogger();
     logger.warn("money_meter.volatile_spend_store", { detail: "long injected detail" });

--- a/apps/cli/src/__tests__/status-render.test.ts
+++ b/apps/cli/src/__tests__/status-render.test.ts
@@ -79,8 +79,14 @@ describe("formatElapsed", () => {
     expect(formatElapsed(0, 92_000)).toBe("1m 32s");
   });
 
+  it("sub-second reads as an instant, not a suspicious 0s (#480)", () => {
+    expect(formatElapsed(0, 400)).toBe("<1s");
+    expect(formatElapsed(0, 999)).toBe("<1s");
+    expect(formatElapsed(0, 1_000)).toBe("1s");
+  });
+
   it("never goes negative on clock skew", () => {
-    expect(formatElapsed(10_000, 5_000)).toBe("0s");
+    expect(formatElapsed(10_000, 5_000)).toBe("<1s");
   });
 });
 

--- a/apps/cli/src/__tests__/stream.test.ts
+++ b/apps/cli/src/__tests__/stream.test.ts
@@ -26,6 +26,7 @@ vi.mock("../statusline.js", () => ({ startStatus }));
 vi.mock("../terminal.js", () => ({
   writeOutput: (s: string) => events.push(["out", s]),
   writeLine: (s: string) => events.push(["line", s]),
+  writeGap: () => events.push(["gap", ""]),
   askQuestion: async () => "n",
 }));
 vi.mock("../receipt.js", () => ({

--- a/apps/cli/src/__tests__/terminal-render.test.ts
+++ b/apps/cli/src/__tests__/terminal-render.test.ts
@@ -233,6 +233,61 @@ describe("terminal renderer — owned bottom region", () => {
     expect(vt.count("you>")).toBe(1);
   });
 
+  it("writeGap is idempotent — exactly one blank row, however many callers ask (#480)", () => {
+    const { vt, r } = setup();
+    r.writeOutput("a line\n");
+    r.writeGap();
+    r.writeGap();
+    r.writeGap();
+    r.writeOutput("next line\n");
+    expect(vt.screen()).toBe("a line\n\nnext line");
+  });
+
+  it("writeGap completes a partial line before opening the gap", () => {
+    const { vt, r } = setup();
+    r.writeOutput("streamed text without newline");
+    r.writeGap();
+    r.writeOutput("after\n");
+    expect(vt.screen()).toBe("streamed text without newline\n\nafter");
+  });
+
+  it("writeGap after an already-blank row adds nothing", () => {
+    const { vt, r } = setup();
+    r.writeOutput("done line\n\n");
+    r.writeGap();
+    r.writeOutput("next\n");
+    expect(vt.screen()).toBe("done line\n\nnext");
+  });
+
+  it("writeGap at the top of the screen opens with no blank", () => {
+    const { vt, r } = setup();
+    r.writeGap();
+    r.writeOutput("first\n");
+    expect(vt.screen()).toBe("first");
+  });
+
+  it("writeGap after a submitted input leaves one blank above the reply", () => {
+    const { vt, r } = setup();
+    const p = r.readInput("you> ");
+    for (const ch of "hi") r.handleEvent({ type: "key", key: ch, ctrl: false });
+    r.handleEvent({ type: "key", key: "return", ctrl: false });
+    void p;
+    r.writeGap();
+    r.writeOutput("mote> hello\n");
+    expect(vt.screen()).toBe("you> hi\n\nmote> hello");
+  });
+
+  it("writeGap folds above an active status row and input", () => {
+    const { vt, r } = setup();
+    r.writeOutput("record\n");
+    r.setStatusRow("  · thinking · 1s");
+    void r.readInput("you> ");
+    r.writeGap();
+    r.writeGap();
+    r.writeOutput("next record\n");
+    expect(vt.screen()).toBe("record\n\nnext record\n  · thinking · 1s\nyou>");
+  });
+
   it("paste inserts at the cursor without corrupting the region", () => {
     const { vt, r } = setup();
     void r.readInput("you> ");

--- a/apps/cli/src/cli-logger.ts
+++ b/apps/cli/src/cli-logger.ts
@@ -86,15 +86,20 @@ export function createCliLogger(): RuntimeLogger {
         return;
       }
 
+      // One indentation grammar (#480): 2-space records at act level,
+      // 4-space detail nested under a live act — a logger line that fires
+      // while a status is running is detail of that act.
+      const indent = activeStatus() ? "    " : "  ";
+
       const designed = DESIGNED_SENTENCES[message]?.(context);
       if (designed != null) {
-        writeLine(`  ${warn("·")} ${meta(designed)}`);
+        writeLine(`${indent}${warn("·")} ${meta(designed)}`);
         return;
       }
 
       // Everything else: one calm dim line through the renderer — full
       // information, never raw JSON into the input line.
-      writeLine(`  ${warn("·")} ${meta(message + formatContext(context))}`);
+      writeLine(`${indent}${warn("·")} ${meta(message + formatContext(context))}`);
     },
   };
 }

--- a/apps/cli/src/commands/invoke.ts
+++ b/apps/cli/src/commands/invoke.ts
@@ -86,7 +86,11 @@ export async function handleReceiptCommand(
     out(warn(`No archived receipt for task_id=${taskId}`));
     return;
   }
+  // renderReceipt no longer emits its own blank bracket (#480) — spacing
+  // belongs to the caller.
+  out("");
   await renderReceipt(receipt, out);
+  out("");
 }
 
 /**
@@ -114,7 +118,9 @@ async function drainInvokeStream(
         if (textBuf.trim()) out(textBuf.trim());
         if (chunk.full_receipt) {
           archiveReceipt(chunk.full_receipt);
+          out("");
           await renderReceipt(chunk.full_receipt, out);
+          out("");
           // Voice speaks only on explicit opt-in + only for completed tasks.
           if (voice && chunk.full_receipt.status === "completed") {
             const spoken = chunk.full_receipt.result ?? "Task complete.";

--- a/apps/cli/src/receipt.ts
+++ b/apps/cli/src/receipt.ts
@@ -160,9 +160,11 @@ export async function renderReceipt(
   out: (line: string) => void = (s) => console.log(s),
   trustedAnchor?: Map<string, Uint8Array>,
 ): Promise<{ verified: boolean; error?: string }> {
+  // Vertical rhythm is the CALLER's: the stream consumer brackets with
+  // writeGap(), the /receipt command with its own spacing (#480). Emitting
+  // blanks here doubled up with the callers' spacing.
   const lines = renderReceiptLine(receipt, 0, true);
   const header = `${dim("─ receipt ")}${dim("·")} ${cyan(shortHash(receipt.task_id))}`;
-  out("");
   out(header);
   for (const line of lines) out(line);
 
@@ -201,7 +203,6 @@ export async function renderReceipt(
       )}${errorMsg ? dim(" · " + errorMsg) : ""}`,
     );
   }
-  out("");
 
   const ret: { verified: boolean; error?: string } = { verified: verifiedFlag };
   if (errorMsg !== undefined) ret.error = errorMsg;

--- a/apps/cli/src/status-render.ts
+++ b/apps/cli/src/status-render.ts
@@ -39,6 +39,8 @@ export function spinnerFrame(frame: number): string {
 
 export function formatElapsed(startedAt: number, nowMs: number): string {
   const totalSec = Math.max(0, Math.floor((nowMs - startedAt) / 1000));
+  // Sub-second acts read as instants, not a suspicious "0s" (#480).
+  if (totalSec === 0) return "<1s";
   if (totalSec < 60) return `${totalSec}s`;
   const min = Math.floor(totalSec / 60);
   const sec = totalSec % 60;

--- a/apps/cli/src/stream.ts
+++ b/apps/cli/src/stream.ts
@@ -2,7 +2,7 @@
 
 import type { MotebitRuntime, StreamChunk } from "@motebit/runtime";
 import { action, meta, warn, dim, prompt as promptColor } from "./colors.js";
-import { writeOutput, writeLine, askQuestion } from "./terminal.js";
+import { writeOutput, writeLine, writeGap, askQuestion } from "./terminal.js";
 import { startStatus, type StatusHandle } from "./statusline.js";
 import { formatElapsed } from "./status-render.js";
 import { archiveReceipt, renderReceipt } from "./receipt.js";
@@ -146,7 +146,9 @@ export async function consumeStream(
           // checks out locally. Mirrors the web receipt-artifact.
           if (chunk.full_receipt) {
             archiveReceipt(chunk.full_receipt);
+            writeGap();
             await renderReceipt(chunk.full_receipt, (line) => writeOutput(line + "\n"));
+            writeGap();
             if (chunk.full_receipt.status === "completed" && chunk.full_receipt.result) {
               lastCompletedReceiptResult = chunk.full_receipt.result;
             }
@@ -189,18 +191,19 @@ export async function consumeStream(
         case "result": {
           const result = chunk.result;
           stopStatus();
-          writeOutput("\n\n");
+          writeGap();
 
           // Felt-interior: the per-turn record is the durable mutation
           // (memories formed), not the operation-level readout. The raw
           // state vector and body cues read as debug output in the product
           // register (#480) — `/state` remains the deliberate readout.
           if (result.memoriesFormed.length > 0) {
-            writeOutput(
+            writeLine(
               meta(
                 `  [memories: ${result.memoriesFormed.map((m: { content: string }) => m.content).join(", ")}]`,
-              ) + "\n\n",
+              ),
             );
+            writeGap();
           }
           break;
         }

--- a/apps/cli/src/terminal.ts
+++ b/apps/cli/src/terminal.ts
@@ -111,6 +111,10 @@ export interface TerminalRenderer {
    * appends a newline. For line-shaped records (status echoes, tool
    * completion lines) that must never glue onto streamed text. */
   writeLine(text: string): void;
+  /** Ensure exactly one blank row above the next write. Idempotent — the
+   * vertical-rhythm primitive (#480): callers say "a gap belongs here"
+   * without knowing whether the previous writer already left one. */
+  writeGap(): void;
   readInput(promptText: string): Promise<string>;
   setStatusRow(row: string | null): void;
   handleEvent(event: TerminalEvent): void;
@@ -215,9 +219,26 @@ export function createTerminalRenderer(io: TerminalIO): TerminalRenderer {
   /** Whether raw passthrough output (non-TTY path) is at a line start. */
   let atLineStart = true;
 
+  /** Consecutive newlines ending the scrollback so far, saturated at 2.
+   * Top-of-screen counts as gapped so writeGap never opens with a blank. */
+  let trailing = 2;
+
+  function noteScrollback(flushed: string, tailAfter: string): void {
+    if (tailAfter !== "") {
+      trailing = 0;
+      return;
+    }
+    if (flushed === "") return;
+    let n = 0;
+    for (let i = flushed.length - 1; i >= 0 && flushed[i] === "\n" && n < 2; i--) n++;
+    // A flush that is nothing but newlines extends the existing run.
+    trailing = n === flushed.length ? Math.min(2, trailing + n) : n;
+  }
+
   function writeOutput(text: string): void {
     if (!io.isTTY && statusRow === null && !inputActive && tail === "") {
       if (text.length > 0) atLineStart = text.endsWith("\n");
+      noteScrollback(text, "");
       io.write(text);
       return;
     }
@@ -240,12 +261,18 @@ export function createTerminalRenderer(io: TerminalIO): TerminalRenderer {
       buffer = sliceVisible(buffer, cols, Number.MAX_SAFE_INTEGER);
     }
     tail = buffer;
+    noteScrollback(scrollback, tail);
     commit(scrollback);
   }
 
   function writeLine(text: string): void {
     const midLine = io.isTTY ? tail !== "" : !atLineStart;
     writeOutput((midLine ? "\n" : "") + text + "\n");
+  }
+
+  function writeGap(): void {
+    const need = tail !== "" ? 2 : Math.max(0, 2 - trailing);
+    if (need > 0) writeOutput("\n".repeat(need));
   }
 
   function setStatusRow(row: string | null): void {
@@ -259,6 +286,7 @@ export function createTerminalRenderer(io: TerminalIO): TerminalRenderer {
     const line = inputState.line;
     inputActive = false;
     // Durable echo of the full typed line.
+    trailing = 1;
     commit(inputState.prompt + line + "\n");
     if (inputResolver) {
       const resolve = inputResolver;
@@ -321,6 +349,7 @@ export function createTerminalRenderer(io: TerminalIO): TerminalRenderer {
   return {
     writeOutput,
     writeLine,
+    writeGap,
     readInput,
     setStatusRow,
     handleEvent,
@@ -662,6 +691,15 @@ export function readInput(promptText: string): Promise<string> {
  */
 export function askQuestion(promptText: string): Promise<string> {
   return readInput(promptText);
+}
+
+/**
+ * Ensure exactly one blank row above the next write — the idempotent
+ * vertical-rhythm primitive (#480). Callers mark where a gap belongs
+ * without knowing whether the previous writer already left one.
+ */
+export function writeGap(): void {
+  renderer.writeGap();
 }
 
 /**


### PR DESCRIPTION
Item 3 of the #480 polish arc.

**The double-blank class had one cause:** every writer added its own spacing without knowing what the previous writer left — `renderReceipt`'s blank bracket + the result case's `\n\n` composed into 2–3 blank rows after a delegation. The fix is a primitive, not a sweep:

- `writeGap()` on the renderer: *"exactly one blank row belongs here"* — idempotent, tracks trailing newlines through the tail and both TTY/passthrough paths, no-ops at top-of-screen. Callers state intent; the renderer owns the rhythm.
- `renderReceipt` drops its self-owned blanks (spacing belongs to the caller); the stream consumer brackets receipts with gaps; deterministic `/receipt` + `/invoke` call sites keep explicit brackets.
- **Indentation encodes nesting**: 2-space records at act level (`●` done-lines, at-rest logger notes), 4-space detail under a live act (step narration — and now logger lines too, via the `activeStatus()` seam the poll-trouble branch already used). One grammar, stated in one place.
- Sub-second acts read `<1s` instead of a suspicious `0s`.

6 new writeGap golden-screen VT tests (idempotence, partial-line completion, pre-gapped no-op, top-of-screen, post-submit, folding above status+input), a logger nesting test, and `<1s` coverage.

Part of #480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)