### PR TITLE
feat(cli): persistent mode row — current-truth chrome above the input, banner stays history (#480)

### DIFF
--- a/.changeset/cli-mode-row.md
+++ b/.changeset/cli-mode-row.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+A persistent mode row now sits above the REPL input (#480): `── claude-opus-4-6 · anthropic`, one dim rule line of current-truth chrome. The launch banner stays scrollback history; a `/model` switch updates the row in place, closing the stale-banner tension. The attached REPL shows its own truth (`── attached · coordinator pid N`). No box-drawing frames — the surface reads as an application because its state is legible, not because it is boxed.

--- a/apps/cli/src/__tests__/mode-render.test.ts
+++ b/apps/cli/src/__tests__/mode-render.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { renderModeRow } from "../mode-render.js";
+
+// eslint-disable-next-line no-control-regex -- stripping ANSI is the point
+const plain = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+describe("renderModeRow", () => {
+  it("renders model · provider as one dim rule line", () => {
+    const row = plain(renderModeRow({ model: "claude-opus-4-6", provider: "anthropic" }));
+    expect(row).toBe("  ── claude-opus-4-6 · anthropic");
+  });
+
+  it("attached mode names the coordinator", () => {
+    const row = plain(renderModeRow({ attachedPid: 4211 }));
+    expect(row).toBe("  ── attached · coordinator pid 4211");
+  });
+
+  it("omits missing parts without stray separators", () => {
+    const row = plain(renderModeRow({ model: "llama3.2" }));
+    expect(row).toBe("  ── llama3.2");
+  });
+});

--- a/apps/cli/src/__tests__/terminal-render.test.ts
+++ b/apps/cli/src/__tests__/terminal-render.test.ts
@@ -288,6 +288,40 @@ describe("terminal renderer — owned bottom region", () => {
     expect(vt.screen()).toBe("record\n\nnext record\n  · thinking · 1s\nyou>");
   });
 
+  it("mode row sits between status and input, updates in place (#480)", () => {
+    const { vt, r } = setup(60);
+    r.setModeRow("  ── claude-opus-4-6 · anthropic");
+    r.setStatusRow("  · thinking · 2s");
+    void r.readInput("you> ");
+    type(r, "hi");
+    expect(vt.screen()).toBe("  · thinking · 2s\n  ── claude-opus-4-6 · anthropic\nyou> hi");
+    r.setModeRow("  ── claude-haiku-4-5 · anthropic");
+    expect(vt.count("──")).toBe(1);
+    expect(vt.screen()).toContain("claude-haiku-4-5");
+    expect(vt.screen()).not.toContain("opus");
+  });
+
+  it("mode row truncates to the width, never wraps", () => {
+    const { vt, r } = setup(20);
+    r.setModeRow("  ── a-very-long-model-identifier · some-provider");
+    expect(vt.screen().split("\n").length).toBe(1);
+  });
+
+  it("output and resize keep a single mode row", () => {
+    const { vt, r } = setup(40);
+    r.setModeRow("  ── model-x · anthropic");
+    void r.readInput("you> ");
+    r.writeOutput("a reply line\n");
+    for (const cols of [30, 24, 40]) {
+      vt.resize(cols);
+      r.repaint();
+    }
+    expect(vt.count("model-x")).toBe(1);
+    expect(vt.count("you>")).toBe(1);
+    const rows = vt.screen().split("\n");
+    expect(rows[0]).toBe("a reply line");
+  });
+
   it("paste inserts at the cursor without corrupting the region", () => {
     const { vt, r } = setup();
     void r.readInput("you> ");

--- a/apps/cli/src/attached-repl.ts
+++ b/apps/cli/src/attached-repl.ts
@@ -7,7 +7,15 @@
 
 import type { RuntimeHostClient } from "@motebit/runtime-host";
 import { action, dim, warn, meta, prompt as promptColor } from "./colors.js";
-import { askQuestion, destroyTerminal, readInput, writeLine, writeOutput } from "./terminal.js";
+import {
+  askQuestion,
+  destroyTerminal,
+  readInput,
+  setModeRow,
+  writeLine,
+  writeOutput,
+} from "./terminal.js";
+import { renderModeRow } from "./mode-render.js";
 import { startStatus, type StatusHandle } from "./statusline.js";
 import { formatElapsed } from "./status-render.js";
 import { renderApprovalRequest } from "./approval-render.js";
@@ -193,6 +201,9 @@ export async function runAttachedRepl(client: RuntimeHostClient, motebitId: stri
     `\n  ${dim("Attached to the machine's coordinator runtime")} ${dim(`(pid ${client.coordinatorPid})`)}\n` +
       `  ${dim("This terminal renders; the coordinator acts. /help for what's available.")}\n\n`,
   );
+  // Sibling of the coordinator REPL's mode row (#480): the attached truth
+  // stays visible as chrome, not just as a scrolled-away banner line.
+  setModeRow(renderModeRow({ attachedPid: client.coordinatorPid }));
 
   let closed = false;
   client.onClose(() => {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -23,7 +23,8 @@ import {
   openMotebitDatabase,
 } from "./runtime-factory.js";
 import { consumeStream } from "./stream.js";
-import { readInput, writeOutput, initTerminal, destroyTerminal } from "./terminal.js";
+import { readInput, writeOutput, setModeRow, initTerminal, destroyTerminal } from "./terminal.js";
+import { renderModeRow } from "./mode-render.js";
 import { electCliRuntimeHost } from "./runtime-host.js";
 import { runAttachedRepl } from "./attached-repl.js";
 import type { ElectionOutcome } from "@motebit/runtime-host";
@@ -1033,6 +1034,14 @@ async function main(): Promise<void> {
   }
 
   const prompt = (): void => {
+    // Refresh the current-truth chrome each cycle — a `/model` switch mid-
+    // session updates the row in place; the banner stays history (#480).
+    setModeRow(
+      renderModeRow({
+        model: runtime.currentModel ?? config.model,
+        provider: config.provider,
+      }),
+    );
     readInput(promptColor("you>") + " ").then(
       (line) => void handleLine(line),
       () => {}, // Ignore errors (e.g. stdin closed)

--- a/apps/cli/src/mode-render.ts
+++ b/apps/cli/src/mode-render.ts
@@ -1,0 +1,30 @@
+/**
+ * Pure render for the mode row — the persistent current-truth line that
+ * gives the banner's launch-time facts a live home (#480). The banner is
+ * scrollback (history, correct as written); the mode row is chrome:
+ * render(controlState), updated in place when `/model` switches.
+ *
+ * Register: one dim line, no box-drawing frame — the surface reads as an
+ * application because its state is legible, not because it is boxed.
+ *   ── claude-opus-4-6 · anthropic
+ *   ── attached · coordinator pid 4211
+ */
+
+import { meta } from "./colors.js";
+
+export interface ModeState {
+  /** The model actually serving turns right now (runtime.currentModel). */
+  model?: string;
+  /** The provider the runtime was started against. */
+  provider?: string;
+  /** Attached mode: this terminal renders, the coordinator acts. */
+  attachedPid?: number;
+}
+
+export function renderModeRow(state: ModeState): string {
+  const parts: string[] = [];
+  if (state.attachedPid != null) parts.push(`attached · coordinator pid ${state.attachedPid}`);
+  if (state.model) parts.push(state.model);
+  if (state.provider) parts.push(state.provider);
+  return meta(`  ── ${parts.join(" · ")}`);
+}

--- a/apps/cli/src/terminal.ts
+++ b/apps/cli/src/terminal.ts
@@ -117,6 +117,9 @@ export interface TerminalRenderer {
   writeGap(): void;
   readInput(promptText: string): Promise<string>;
   setStatusRow(row: string | null): void;
+  /** Set (or clear with null) the persistent mode row — current-truth
+   * chrome (model · provider) painted directly above the input row. */
+  setModeRow(row: string | null): void;
   handleEvent(event: TerminalEvent): void;
   /** Repaint in place — the resize path. Idempotent. */
   repaint(): void;
@@ -134,6 +137,9 @@ export function createTerminalRenderer(io: TerminalIO): TerminalRenderer {
    * top row so streamed text and the status/input rows never collide. */
   let tail = "";
   let statusRow: string | null = null;
+  /** Persistent current-truth chrome (model · provider), painted directly
+   * above the input row (#480). The banner stays history; this stays live. */
+  let modeRow: string | null = null;
 
   // What the last commit painted, for exact clearing (widths are VISIBLE
   // widths; cursorCol is where the cursor was parked on the last row).
@@ -183,6 +189,11 @@ export function createTerminalRenderer(io: TerminalIO): TerminalRenderer {
     }
     if (statusRow !== null) {
       const truncated = sliceVisible(statusRow, 0, cols - 1);
+      rows.push(truncated + (io.isTTY ? RESET : ""));
+      widths.push(visibleLength(truncated));
+    }
+    if (modeRow !== null) {
+      const truncated = sliceVisible(modeRow, 0, cols - 1);
       rows.push(truncated + (io.isTTY ? RESET : ""));
       widths.push(visibleLength(truncated));
     }
@@ -282,6 +293,13 @@ export function createTerminalRenderer(io: TerminalIO): TerminalRenderer {
     commit("");
   }
 
+  function setModeRow(row: string | null): void {
+    if (!io.isTTY) return;
+    if (row === modeRow) return;
+    modeRow = row;
+    commit("");
+  }
+
   function submit(): void {
     const line = inputState.line;
     inputActive = false;
@@ -352,6 +370,7 @@ export function createTerminalRenderer(io: TerminalIO): TerminalRenderer {
     writeGap,
     readInput,
     setStatusRow,
+    setModeRow,
     handleEvent,
     repaint: () => commit(""),
     detach,
@@ -710,4 +729,14 @@ export function writeGap(): void {
  */
 export function setStatusRow(row: string | null): void {
   renderer.setStatusRow(row);
+}
+
+/**
+ * Set (or clear, with null) the persistent mode row above the input line —
+ * the live current-truth chrome (model · provider). The banner remains
+ * scrollback history; a `/model` switch updates this row in place (#480).
+ * Content is pre-rendered by mode-render.ts; truncated, never wraps.
+ */
+export function setModeRow(row: string | null): void {
+  renderer.setModeRow(row);
 }


### PR DESCRIPTION
Items 4 (chrome) + 5 (banner live-truth) of the #480 polish arc — the last two.

A new owned-region row between status and input: `── claude-opus-4-6 · anthropic`, one dim rule line rendered from `runtime.currentModel` each prompt cycle — a `/model` switch updates it **in place**, closing the observed tension where the launch banner kept showing the launch-time model (correct as scrollback history; it now has a live counterpart).

- Pure `mode-render.ts` core (same precedent as status-render/approval-render); the renderer truncates it like the status row, never wraps.
- Attached REPL renders its own truth: `── attached · coordinator pid N` — the attach banner scrolls away, the chrome stays.
- Deliberately **no box-drawing input frame**: the register target is composed, not busy — the surface reads as an application because its state is legible, not because it is boxed. (If the founder's live pass wants more frame, the region machinery now makes it a one-row change.)

3 golden-screen VT tests (placement between status and input, in-place update with no duplicates, truncation, resize/output stability) + pure render tests.

Part of #480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)