### PR TITLE
fix(cli): admit and persist the provider+model PAIR — /model refuses unservable switches with the repair (#471)

### DIFF
--- a/.changeset/model-provider-pair.md
+++ b/.changeset/model-provider-pair.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+`/model` is no longer provider-blind (#471): the list names each model's provider and dims rows the active provider can't serve; switching to an unservable model refuses with the repair (`claude-opus-5 is a hosted anthropic model — restart with --provider anthropic, or pick a local model`) instead of renaming the model, moving the marker, and persisting a broken default. An admitted switch now persists the provider+model PAIR, so a later bare `motebit` launch restores the provider the model was chosen on. Launch-side admission gains the same CLI strictness — a persisted hosted-vendor id no longer rides onto local-server to 404 at the first message.

--- a/apps/cli/src/__tests__/model-admission.test.ts
+++ b/apps/cli/src/__tests__/model-admission.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { admitModelForProvider } from "../model-admission.js";
+
+describe("admitModelForProvider — the provider+model pair gate (#471)", () => {
+  it("refuses a hosted Claude id on local-server (witnessed direction 2)", () => {
+    const a = admitModelForProvider("local-server", "claude-opus-5");
+    expect(a.admissible).toBe(false);
+    expect(a.teach).toContain("--provider anthropic");
+    expect(a.teach).toContain("local server can't serve it");
+  });
+
+  it("refuses a hosted OpenAI id on local-server with its repair", () => {
+    const a = admitModelForProvider("local-server", "gpt-5.4");
+    expect(a.admissible).toBe(false);
+    expect(a.teach).toContain("--provider openai");
+  });
+
+  it("refuses a local model on anthropic (witnessed direction 1 mirror)", () => {
+    const a = admitModelForProvider("anthropic", "llama3.2");
+    expect(a.admissible).toBe(false);
+    expect(a.teach).toContain("anthropic");
+  });
+
+  it("admits matching pairs", () => {
+    expect(admitModelForProvider("anthropic", "claude-opus-5").admissible).toBe(true);
+    expect(admitModelForProvider("openai", "gpt-5.4").admissible).toBe(true);
+    expect(admitModelForProvider("local-server", "llama3.2").admissible).toBe(true);
+    expect(admitModelForProvider("local-server", "qwen2.5:7b").admissible).toBe(true);
+  });
+
+  it("stays permissive on unknown ids — registry lag must not brick a switch", () => {
+    expect(admitModelForProvider("local-server", "some-future-model").admissible).toBe(true);
+    expect(admitModelForProvider("anthropic", "some-future-model").admissible).toBe(true);
+  });
+
+  it("the ollama legacy alias gets the same strictness as local-server", () => {
+    expect(admitModelForProvider("ollama", "claude-opus-5").admissible).toBe(false);
+  });
+});

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -2,7 +2,7 @@ import { DEFAULT_CONFIG } from "@motebit/ai-core";
 import type { MotebitPersonalityConfig } from "@motebit/ai-core";
 import { deriveSyncEncryptionKey, mintAudienceToken } from "@motebit/encryption";
 import { connectMcpServers } from "@motebit/mcp-client";
-import { providerAcceptsModel } from "@motebit/sdk";
+import { admitModelForProvider } from "./model-admission.js";
 import { createSolanaWalletRail } from "@motebit/wallet-solana";
 import { preflightGrant, renderPreflight } from "./grant-preflight.js";
 import { parseCliArgs, printHelp, printVersion, printBanner, trimHistory } from "./args.js";
@@ -475,9 +475,12 @@ async function main(): Promise<void> {
     // Config residue yields politely: a default_model from a previous
     // provider era must not ride along onto a different provider (the
     // 2026-07-06 "anthropic · llama3.2:latest" pairing — pre-flight
-    // admission per intelligence-pluggability-contract). The per-provider
-    // parse-time default already sits on config.model; keep it and say so.
-    if (providerAcceptsModel(config.provider, personalityConfig.default_model)) {
+    // admission per intelligence-pluggability-contract). The CLI-strict
+    // check also refuses a hosted-vendor id on local-server (#471: a bare
+    // launch with a persisted claude-* default 404'd against ollama — the
+    // sdk primitive is deliberately permissive there, the affordance isn't).
+    // The per-provider parse-time default already sits on config.model.
+    if (admitModelForProvider(config.provider, personalityConfig.default_model).admissible) {
       config.model = personalityConfig.default_model;
     } else {
       console.log(
@@ -489,13 +492,14 @@ async function main(): Promise<void> {
   }
   // An EXPLICIT contradiction fails loud at startup, naming both — never
   // deferred to an opaque first-call API error.
-  if (process.argv.includes("--model") && !providerAcceptsModel(config.provider, config.model)) {
-    console.error(
-      `Model "${config.model}" does not belong to provider "${config.provider}" — ` +
-        `pick a matching pair (e.g. --provider anthropic --model claude-sonnet-4-6), ` +
-        `or drop --model to use the provider's default.`,
-    );
-    process.exit(1);
+  if (process.argv.includes("--model")) {
+    const admission = admitModelForProvider(config.provider, config.model);
+    if (!admission.admissible) {
+      console.error(
+        `Model "${config.model}" does not belong to provider "${config.provider}" — ${admission.teach ?? "pick a matching pair, or drop --model to use the provider's default."}`,
+      );
+      process.exit(1);
+    }
   }
   if (fullConfig.max_tokens != null && !process.argv.includes("--max-tokens")) {
     config.maxTokens = fullConfig.max_tokens;

--- a/apps/cli/src/model-admission.ts
+++ b/apps/cli/src/model-admission.ts
@@ -1,0 +1,60 @@
+/**
+ * CLI-side pre-flight admission for a provider+model pair (#471).
+ *
+ * `@motebit/sdk`'s `providerAcceptsModel` is deliberately permissive for
+ * local-server — "hosts whatever the user's server hosts" is correct at the
+ * protocol layer. But the CLI affordance KNOWS that a `claude-*` / `gpt-*` /
+ * `gemini-*` id names a hosted vendor's model: selecting one against a local
+ * server is the witnessed 404 footgun (both live directions on the issue).
+ * The affordance refuses the known mismatch and teaches the pair repair
+ * (gate-repair-instructions applied to the product); unknown ids stay
+ * admissible — registry lag must never brick a switch.
+ */
+
+import { modelVendorHint, providerAcceptsModel } from "@motebit/sdk";
+
+/** Vendors whose models are served by a hosted API, never a local server. */
+const HOSTED_VENDORS = new Set(["anthropic", "openai", "google", "deepseek"]);
+
+/** Vendor hint → the CLI `--provider` flag that serves it, when one exists. */
+const VENDOR_PROVIDER_FLAG: Record<string, string> = {
+  anthropic: "anthropic",
+  openai: "openai",
+  google: "google",
+};
+
+export interface ModelAdmission {
+  admissible: boolean;
+  /** One-line repair when refused: what to run instead, never just "no". */
+  teach?: string;
+}
+
+export function admitModelForProvider(provider: string, model: string): ModelAdmission {
+  const hint = modelVendorHint(model);
+
+  if ((provider === "local-server" || provider === "ollama") && HOSTED_VENDORS.has(hint)) {
+    const flag = VENDOR_PROVIDER_FLAG[hint];
+    return {
+      admissible: false,
+      teach:
+        `${model} is a hosted ${hint} model — a local server can't serve it. ` +
+        (flag != null
+          ? `Restart with --provider ${flag}, or pick a local model (e.g. /model llama3.2).`
+          : `Pick a local model instead (e.g. /model llama3.2).`),
+    };
+  }
+
+  if (!providerAcceptsModel(provider, model)) {
+    const flag = VENDOR_PROVIDER_FLAG[hint];
+    return {
+      admissible: false,
+      teach:
+        `${model} belongs to ${hint === "unknown" ? "another provider" : hint} — the active provider is ${provider}. ` +
+        (flag != null
+          ? `Restart with --provider ${flag} to use it.`
+          : `Pick a ${provider} model instead.`),
+    };
+  }
+
+  return { admissible: true };
+}

--- a/apps/cli/src/slash-commands.ts
+++ b/apps/cli/src/slash-commands.ts
@@ -2,7 +2,8 @@
 
 import type { MotebitRuntime, ReflectionResult, RelayConfig } from "@motebit/runtime";
 import type { TokenAudience } from "@motebit/sdk";
-import { isTokenAudience, fromMicro } from "@motebit/sdk";
+import { isTokenAudience, fromMicro, modelVendorHint } from "@motebit/sdk";
+import { admitModelForProvider } from "./model-admission.js";
 import { createSolanaWalletRail } from "@motebit/wallet-solana";
 import { renderIdentityCard } from "./subcommands/id.js";
 import { DEFAULT_SOLANA_RPC_URL, WALLET_GUIDANCE_LINES } from "./subcommands/wallet.js";
@@ -573,13 +574,31 @@ export async function handleSlashCommand(
         mistral: "mistral",
       };
 
+      // Provider-aware list (#471): every row names its provider; rows the
+      // ACTIVE provider can't serve render dim with the repair spelled out —
+      // the affordance must not offer a switch that cannot work.
+      const providerLabel = (modelId: string): string => {
+        const hint = modelVendorHint(modelId);
+        return hint === "local" ? "local-server" : hint;
+      };
       const showModelList = (current: string) => {
         const col = Math.max(...Object.keys(MODEL_ALIASES).map((k) => k.length)) + 2;
         for (const [alias, modelId] of Object.entries(MODEL_ALIASES)) {
           const active = modelId === current || alias === current;
+          const servable = admitModelForProvider(config.provider, modelId).admissible;
           const marker = active ? green(" ●") : "  ";
           const gap = " ".repeat(Math.max(1, col - alias.length));
-          console.log(`${marker} ${cyan(alias)}${gap}${dim(modelId)}`);
+          if (servable) {
+            console.log(
+              `${marker} ${cyan(alias)}${gap}${dim(modelId + " · " + providerLabel(modelId))}`,
+            );
+          } else {
+            console.log(
+              dim(
+                `${marker} ${alias}${gap}${modelId} · needs --provider ${providerLabel(modelId)}`,
+              ),
+            );
+          }
         }
       };
 
@@ -600,9 +619,27 @@ export async function handleSlashCommand(
         break;
       }
       const modelId = resolved ?? args;
+      // Pre-flight admission (#471, intelligence-pluggability commitment #1):
+      // a switch the active provider can't serve refuses with the repair —
+      // it must not rename the model, move the marker, or persist a default
+      // that bricks the next launch.
+      const admission = admitModelForProvider(config.provider, modelId);
+      if (!admission.admissible) {
+        console.log(`\n  ${warn(admission.teach ?? "model not servable on this provider")}\n`);
+        break;
+      }
       runtime.setModel(modelId);
       if (fullConfig) {
         fullConfig.default_model = modelId;
+        // Persist the PAIR: a model default with no memory of its provider is
+        // the #471 footgun — a later bare `motebit` launch (provider default:
+        // local-server) would 404 on a hosted model id. groq/deepseek aren't
+        // in the persisted-provider union; for them the model alone persists,
+        // and the launch-side admission still yields politely.
+        const persistable = ["anthropic", "openai", "google", "local-server", "proxy"];
+        if (persistable.includes(config.provider)) {
+          fullConfig.default_provider = config.provider as FullConfig["default_provider"];
+        }
         saveFullConfig(fullConfig);
       }
       console.log();


### PR DESCRIPTION
Closes #471. Both live directions (fabricated-id-on-anthropic, claude-id-on-ollama) had the same cause: config persists a MODEL with no memory of its PROVIDER, and `providerAcceptsModel` is deliberately permissive for local-server (a local server can host anything — correct at the sdk layer).

**New CLI-strict `admitModelForProvider`** (`model-admission.ts`): refuses the KNOWN mismatch — a hosted-vendor id (`claude-*`/`gpt-*`/`gemini-*`/`deepseek-*`) on a local server — while staying permissive on unknown ids (registry lag must never brick a switch). Every refusal carries the repair (gate-repair-instructions applied to the product): `claude-opus-5 is a hosted anthropic model — a local server can't serve it. Restart with --provider anthropic, or pick a local model (e.g. /model llama3.2).`

Applied at all three seams:
1. **`/model` switch** — refuses with the teach line; nothing mutates (no `setModel`, no marker move, no persist). The list now names each model's provider and dims unservable rows with `needs --provider X`.
2. **Launch-side default yield** — the persisted `default_model: claude-opus-5` + bare-launch case now yields politely to the provider default instead of 404ing at the first message (heals the founder's live config with no action needed).
3. **Explicit `--model` contradiction** — still fails loud, now with the same teach.

**Pair persistence**: an admitted `/model` switch persists `default_provider` alongside `default_model` (narrowed to the persistable provider union; groq/deepseek persist model-only and the launch admission still guards). A bare `motebit` then restores the provider the model was chosen on — intelligence-pluggability commitment #1 (pre-flight admission), surface-determinism (affordances degrade honestly).

Sibling audit: attached REPL has no `/model` (slash needs the runtime in-process); daemon has no model switch; the web surface's picker is a separate surface — not touched here.

6 pure admission tests, both witnessed directions locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)