### PR TITLE
fix(research): refuse to complete an empty report body — retry synthesis once, then fail honestly (#479)

### DIFF
--- a/scripts/archetype-conformance.ts
+++ b/scripts/archetype-conformance.ts
@@ -318,12 +318,22 @@ async function checkResearcher(
   // and run the structural provenance discipline.
   try {
     const payload = JSON.parse(String(receipt["result"] ?? "{}")) as {
+      report?: string;
       citations?: Array<{
         receipt_task_id?: string;
         excerpt?: string;
         provenance?: { digest?: { algorithm?: string; value?: string }; span?: string };
       }>;
     };
+    // #479: a completed receipt over an empty report body is worse than an
+    // honest failure — the purchased artifact is the report; citations alone
+    // are scaffolding. Non-empty body is a Researcher conformance criterion.
+    const reportChars = (payload.report ?? "").trim().length;
+    record(
+      "research: report body non-empty",
+      reportChars > 0 ? "PASS" : "FAIL",
+      `${reportChars} chars`,
+    );
     const nested = (receipt["delegation_receipts"] ?? []) as Array<{ task_id?: string }>;
     const nestedIds = new Set(nested.map((r) => r.task_id).filter(Boolean));
     const citations = payload.citations ?? [];

--- a/services/research/src/__tests__/research.test.ts
+++ b/services/research/src/__tests__/research.test.ts
@@ -1294,3 +1294,123 @@ describe("research — cryptographic citation chain (via mcp-client)", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });
+
+describe("research — empty-report guard (#479)", () => {
+  beforeEach(() => {
+    mockCreate.mockReset();
+  });
+
+  const factory = () =>
+    makeFactory(
+      new Map([
+        ["web-search", new StubAtomAdapter([])],
+        ["read-url", new StubAtomAdapter([])],
+      ]),
+    );
+
+  it("an empty synthesis response triggers one tool-free re-synthesis", async () => {
+    mockCreate
+      .mockResolvedValueOnce({ content: [] }) // end_turn with zero text blocks — the live shape
+      .mockResolvedValueOnce({ content: [{ type: "text", text: "Recovered report." }] });
+
+    const result = await research("q", { ...baseConfig, adapterFactory: factory() });
+    expect(result.report).toBe("Recovered report.");
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+    // The retry is synthesis-only: no tools offered, explicit no-tools nudge
+    const retryParams = mockCreate.mock.calls[1]![0] as {
+      tools?: unknown;
+      messages: Array<{ role: string; content: unknown }>;
+    };
+    expect(retryParams.tools).toBeUndefined();
+    expect(retryParams.messages[retryParams.messages.length - 1]!.content).toContain(
+      "no report text",
+    );
+  });
+
+  it("a still-empty retry throws instead of completing an empty artifact", async () => {
+    mockCreate
+      .mockResolvedValueOnce({ content: [{ type: "text", text: "   " }] }) // whitespace-only counts as empty
+      .mockResolvedValueOnce({ content: [] });
+
+    await expect(research("q", { ...baseConfig, adapterFactory: factory() })).rejects.toThrow(
+      "empty report body",
+    );
+  });
+
+  it("a normal report never triggers the retry", async () => {
+    mockCreate.mockResolvedValueOnce({ content: [{ type: "text", text: "Fine." }] });
+    const result = await research("q", { ...baseConfig, adapterFactory: factory() });
+    expect(result.report).toBe("Fine.");
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("the cap-hit forced synthesis is guarded too, and retry usage is billed", async () => {
+    const receipt = makeReceipt({
+      task_id: "search-cap",
+      motebit_id: "web-search-agent",
+      result: "results",
+      signature: "sig-cap",
+    });
+    const ws = new StubAtomAdapter([receipt]);
+    const ru = new StubAtomAdapter([]);
+    mockCreate
+      .mockResolvedValueOnce({
+        content: [
+          { type: "tool_use", id: "tu-1", name: "motebit_web_search", input: { query: "q" } },
+        ],
+      })
+      // Tool budget (1) exhausted → forced synthesis comes back EMPTY…
+      .mockResolvedValueOnce({ content: [], usage: { input_tokens: 3, output_tokens: 0 } })
+      // …and the guard's tool-free retry recovers, with billable usage.
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "Capped but recovered." }],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      });
+
+    const result = await research("q", {
+      ...baseConfig,
+      maxToolCalls: 1,
+      adapterFactory: makeFactory(
+        new Map([
+          ["web-search", ws],
+          ["read-url", ru],
+        ]),
+      ),
+    });
+    expect(result.report).toBe("Capped but recovered.");
+    expect(mockCreate).toHaveBeenCalledTimes(3);
+    // Retry tokens flow into the operator cost estimate
+    expect(result.cost_estimate_usd).toBeGreaterThan(0);
+  });
+
+  it("a usage-less retry response (mock shape) still recovers on the cap-hit path", async () => {
+    const receipt = makeReceipt({
+      task_id: "search-cap2",
+      motebit_id: "web-search-agent",
+      result: "results",
+      signature: "sig-cap2",
+    });
+    const ws = new StubAtomAdapter([receipt]);
+    const ru = new StubAtomAdapter([]);
+    mockCreate
+      .mockResolvedValueOnce({
+        content: [
+          { type: "tool_use", id: "tu-1", name: "motebit_web_search", input: { query: "q" } },
+        ],
+      })
+      .mockResolvedValueOnce({ content: [] })
+      .mockResolvedValueOnce({ content: [{ type: "text", text: "Recovered, no usage." }] });
+
+    const result = await research("q", {
+      ...baseConfig,
+      maxToolCalls: 1,
+      adapterFactory: makeFactory(
+        new Map([
+          ["web-search", ws],
+          ["read-url", ru],
+        ]),
+      ),
+    });
+    expect(result.report).toBe("Recovered, no usage.");
+  });
+});

--- a/services/research/src/index.ts
+++ b/services/research/src/index.ts
@@ -205,6 +205,15 @@ async function main(): Promise<void> {
         let delegationReceipts: Record<string, unknown>[] = [];
         try {
           const r = await research(prompt, researchConfig);
+          // #479 backstop at the signing seam: research() already refuses an
+          // empty synthesis, but the receipt is signed HERE — a completed
+          // receipt over an empty body must be structurally impossible, not
+          // a library courtesy (composition-preserves-enforcement).
+          if (r.report.trim() === "") {
+            throw new Error(
+              "empty report body — refusing to sign a completed receipt over an empty artifact",
+            );
+          }
           log(
             `research complete: ${r.report.length} chars, ${r.recall_self_count} interior, ${r.search_count} searches, ${r.fetch_count} fetches, ${r.citations.length} citations`,
           );

--- a/services/research/src/research.ts
+++ b/services/research/src/research.ts
@@ -354,6 +354,60 @@ function receiptResultText(receipt: SignedReceipt): string {
   return JSON.stringify(r ?? null);
 }
 
+/** The joined text of a response's text blocks. */
+function responseText(content: Anthropic.ContentBlock[]): string {
+  return content
+    .filter((b): b is Anthropic.TextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("\n");
+}
+
+/**
+ * #479: a completed research turn whose report body is EMPTY is a worse
+ * artifact than an honest failure — witnessed live on a paid hire (citations
+ * delivered, findings blank, receipt signed "completed"). A synthesis
+ * response can legally carry zero text blocks (an end_turn with empty
+ * content, a max_tokens cut) and nothing guarded it. When that happens,
+ * force ONE tool-free re-synthesis; if the retry is still empty, throw —
+ * the molecule then signs a failed receipt, never a completed-empty one.
+ */
+async function ensureReport(params: {
+  client: Anthropic;
+  messages: Anthropic.MessageParam[];
+  lastContent: Anthropic.ContentBlock[];
+  report: string;
+  sourceCount: number;
+  addUsage: (r: Anthropic.Message) => void;
+}): Promise<string> {
+  if (params.report.trim() !== "") return params.report;
+  const retry = await params.client.messages.create({
+    model: "claude-sonnet-4-6",
+    max_tokens: 4096,
+    system: SYSTEM_PROMPT,
+    messages: [
+      ...params.messages,
+      // Echo the empty response only when it had content blocks — an empty
+      // assistant content array is not a valid turn on the wire.
+      ...(params.lastContent.length > 0
+        ? [{ role: "assistant" as const, content: params.lastContent }]
+        : []),
+      {
+        role: "user" as const,
+        content:
+          "Your previous reply contained no report text. Write the full report NOW from the sources you already gathered, following the report format. Do not call any tools.",
+      },
+    ],
+  });
+  params.addUsage(retry);
+  const retried = responseText(retry.content);
+  if (retried.trim() === "") {
+    throw new Error(
+      `research synthesis returned an empty report body (${params.sourceCount} source(s) gathered) — refusing to complete an empty artifact`,
+    );
+  }
+  return retried;
+}
+
 // === The research turn ===
 
 /**
@@ -638,10 +692,17 @@ export async function research(question: string, config: ResearchConfig): Promis
       );
 
       if (toolUses.length === 0) {
-        const report = response.content
-          .filter((b): b is Anthropic.TextBlock => b.type === "text")
-          .map((b) => b.text)
-          .join("\n");
+        const report = await ensureReport({
+          client,
+          messages,
+          lastContent: response.content,
+          report: responseText(response.content),
+          sourceCount: citations.length,
+          addUsage: (r) => {
+            inputTokens += r.usage?.input_tokens ?? 0;
+            outputTokens += r.usage?.output_tokens ?? 0;
+          },
+        });
         return {
           report,
           cost_estimate_usd:
@@ -675,10 +736,17 @@ export async function research(question: string, config: ResearchConfig): Promis
     });
     inputTokens += finalResponse.usage?.input_tokens ?? 0;
     outputTokens += finalResponse.usage?.output_tokens ?? 0;
-    const report = finalResponse.content
-      .filter((b): b is Anthropic.TextBlock => b.type === "text")
-      .map((b) => b.text)
-      .join("\n");
+    const report = await ensureReport({
+      client,
+      messages,
+      lastContent: finalResponse.content,
+      report: responseText(finalResponse.content),
+      sourceCount: citations.length,
+      addUsage: (r) => {
+        inputTokens += r.usage?.input_tokens ?? 0;
+        outputTokens += r.usage?.output_tokens ?? 0;
+      },
+    });
 
     return {
       report,


### PR DESCRIPTION
Closes the primary finding of #479 (the secondary receipt-beat finding is answered on the issue and gets its own increment).

**The witnessed shape:** a synthesis response can legally carry zero text blocks (an `end_turn` with empty content, a `max_tokens` cut mid-thought), and nothing guarded it — `report: ""` flowed through `ok: true` into a signed **completed** receipt while citations existed. A completed receipt over an empty purchased artifact is worse than an honest failure.

Three layers:
1. **`research()`** — both return sites route through `ensureReport`: an empty/whitespace report triggers ONE tool-free re-synthesis; a still-empty retry **throws**, so the molecule signs a failed receipt. Retry usage counts into `cost_estimate_usd`; the empty response is echoed as an assistant turn only when it has content blocks (an empty content array is not a valid wire turn).
2. **The signing seam** — `handleAgentTask` independently refuses to sign a completed receipt over an empty body (composition-preserves-enforcement: the guarantee holds where the receipt is minted, not as a library courtesy).
3. **Living conformance** — `archetype-conformance.ts` gains `research: report body non-empty` (agent-archetypes doctrine: a checkable Researcher criterion), so a regression goes red on the scheduled adversarial hire instead of a paid founder hire.

5 new tests hold the package's 100% coverage threshold: empty→retry recovers (retry is tool-free with the explicit nudge), empty→empty throws, normal report never retries, and both cap-hit variants (with and without usage on the retry — the billing closure's both branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)