### PR TITLE
feat(ai-core,cli): live model-catalog discovery — the list shown is the list served (#475 inc 1)

### DIFF
--- a/.changeset/model-catalog-live.md
+++ b/.changeset/model-catalog-live.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+`/model` now lists the ACTIVE provider's live catalog (#475): Anthropic and OpenAI via their models endpoints, local servers via ollama's `/api/tags` (with the OpenAI-compatible `/v1/models` as second shot). The list shown is the list served — a live id outside the static alias table is admissible, and an aliased id the provider no longer serves is refused with the reason. The static table demotes to name resolution plus a clearly marked offline fallback (`offline list — live catalog unavailable (…)`); any fetch failure degrades softly, never blocks the command.

--- a/apps/cli/src/slash-commands.ts
+++ b/apps/cli/src/slash-commands.ts
@@ -3,6 +3,7 @@
 import type { MotebitRuntime, ReflectionResult, RelayConfig } from "@motebit/runtime";
 import type { TokenAudience } from "@motebit/sdk";
 import { isTokenAudience, fromMicro, modelVendorHint } from "@motebit/sdk";
+import { discoverModels } from "@motebit/ai-core";
 import { admitModelForProvider } from "./model-admission.js";
 import { createSolanaWalletRail } from "@motebit/wallet-solana";
 import { renderIdentityCard } from "./subcommands/id.js";
@@ -574,6 +575,22 @@ export async function handleSlashCommand(
         mistral: "mistral",
       };
 
+      // Live catalog (#475): the canonical model list lives OUTSIDE the repo
+      // — fetch it from the active provider so the list shown IS the list
+      // served. The static alias table demotes to name resolution + offline
+      // fallback, clearly marked. Soft key read: a missing key means the
+      // catalog falls back, never a hard exit.
+      const envKey =
+        config.provider === "openai"
+          ? process.env["OPENAI_API_KEY"]
+          : process.env["ANTHROPIC_API_KEY"];
+      const catalog = await discoverModels({
+        provider: config.provider,
+        ...(envKey != null && envKey !== "" ? { apiKey: envKey } : {}),
+        ...(config.provider === "local-server" ? { baseUrl: "http://127.0.0.1:11434" } : {}),
+      });
+      const liveIds = catalog.source === "live" ? new Set(catalog.models.map((m) => m.id)) : null;
+
       // Provider-aware list (#471): every row names its provider; rows the
       // ACTIVE provider can't serve render dim with the repair spelled out —
       // the affordance must not offer a switch that cannot work.
@@ -582,6 +599,17 @@ export async function handleSlashCommand(
         return hint === "local" ? "local-server" : hint;
       };
       const showModelList = (current: string) => {
+        if (catalog.source === "live") {
+          const col = Math.max(...catalog.models.map((m) => m.id.length)) + 2;
+          for (const m of catalog.models) {
+            const active = m.id === current;
+            const marker = active ? green(" ●") : "  ";
+            const gap = " ".repeat(Math.max(1, col - m.id.length));
+            console.log(`${marker} ${cyan(m.id)}${gap}${dim(m.displayName ?? "")}`);
+          }
+          console.log(dim(`\n  live from ${config.provider}`));
+          return;
+        }
         const col = Math.max(...Object.keys(MODEL_ALIASES).map((k) => k.length)) + 2;
         for (const [alias, modelId] of Object.entries(MODEL_ALIASES)) {
           const active = modelId === current || alias === current;
@@ -600,6 +628,9 @@ export async function handleSlashCommand(
             );
           }
         }
+        console.log(
+          dim(`\n  offline list — live catalog unavailable (${catalog.fallbackReason ?? "?"})`),
+        );
       };
 
       if (!args) {
@@ -611,7 +642,8 @@ export async function handleSlashCommand(
       }
       const input = args.toLowerCase();
       const resolved = MODEL_ALIASES[input];
-      const isFullId = Object.values(MODEL_ALIASES).includes(args);
+      // A live catalog admits full ids the alias table never knew about.
+      const isFullId = Object.values(MODEL_ALIASES).includes(args) || (liveIds?.has(args) ?? false);
       if (!resolved && !isFullId) {
         console.log(`\nUnknown model: ${cyan(args)}\n`);
         showModelList(runtime.currentModel ?? "");
@@ -619,10 +651,17 @@ export async function handleSlashCommand(
         break;
       }
       const modelId = resolved ?? args;
+      // Live-membership admission first (#475): the provider just told us
+      // what it serves — an id outside that list cannot work, whatever the
+      // offline heuristic thinks.
+      if (liveIds != null && !liveIds.has(modelId)) {
+        console.log(
+          `\n  ${warn(`${modelId} is not served by ${config.provider} right now — /model lists what is`)}\n`,
+        );
+        break;
+      }
       // Pre-flight admission (#471, intelligence-pluggability commitment #1):
-      // a switch the active provider can't serve refuses with the repair —
-      // it must not rename the model, move the marker, or persist a default
-      // that bricks the next launch.
+      // the offline heuristic — load-bearing when the catalog fell back.
       const admission = admitModelForProvider(config.provider, modelId);
       if (!admission.admissible) {
         console.log(`\n  ${warn(admission.teach ?? "model not servable on this provider")}\n`);

--- a/packages/ai-core/src/__tests__/model-catalog.test.ts
+++ b/packages/ai-core/src/__tests__/model-catalog.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from "vitest";
+import { discoverModels } from "../model-catalog.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe("discoverModels — live catalog with honest fallback (#475)", () => {
+  it("anthropic: fetches /v1/models with key + version headers", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: [
+          { id: "claude-opus-5", display_name: "Claude Opus 5" },
+          { id: "claude-sonnet-4-6", display_name: "Claude Sonnet 4.6" },
+        ],
+      }),
+    );
+    const catalog = await discoverModels({ provider: "anthropic", apiKey: "sk-test", fetchFn });
+    expect(catalog.source).toBe("live");
+    expect(catalog.models.map((m) => m.id)).toEqual(["claude-opus-5", "claude-sonnet-4-6"]);
+    expect(catalog.models[0]!.displayName).toBe("Claude Opus 5");
+    const [url, init] = fetchFn.mock.calls[0]! as [string, RequestInit];
+    expect(url).toContain("api.anthropic.com/v1/models");
+    expect((init.headers as Record<string, string>)["x-api-key"]).toBe("sk-test");
+    expect((init.headers as Record<string, string>)["anthropic-version"]).toBe("2023-06-01");
+  });
+
+  it("anthropic without a key degrades to the marked fallback, never a throw", async () => {
+    const fetchFn = vi.fn();
+    const catalog = await discoverModels({ provider: "anthropic", fetchFn });
+    expect(catalog.source).toBe("fallback");
+    expect(catalog.fallbackReason).toContain("no API key");
+    expect(catalog.models.length).toBeGreaterThan(0);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("a network error degrades to fallback carrying the reason", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error("getaddrinfo ENOTFOUND"));
+    const catalog = await discoverModels({ provider: "anthropic", apiKey: "sk-test", fetchFn });
+    expect(catalog.source).toBe("fallback");
+    expect(catalog.fallbackReason).toContain("ENOTFOUND");
+  });
+
+  it("a non-2xx response degrades to fallback, not a throw", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({}, 401));
+    const catalog = await discoverModels({ provider: "anthropic", apiKey: "bad", fetchFn });
+    expect(catalog.source).toBe("fallback");
+    expect(catalog.fallbackReason).toContain("401");
+  });
+
+  it("an empty live list is treated as drift, not truth", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ data: [] }));
+    const catalog = await discoverModels({ provider: "anthropic", apiKey: "sk-test", fetchFn });
+    expect(catalog.source).toBe("fallback");
+    expect(catalog.fallbackReason).toContain("empty");
+  });
+
+  it("openai: keeps chat families, drops embeddings/audio rows", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: [
+          { id: "gpt-5.4" },
+          { id: "o3" },
+          { id: "text-embedding-3-small" },
+          { id: "whisper-1" },
+        ],
+      }),
+    );
+    const catalog = await discoverModels({ provider: "openai", apiKey: "sk-test", fetchFn });
+    expect(catalog.source).toBe("live");
+    expect(catalog.models.map((m) => m.id)).toEqual(["gpt-5.4", "o3"]);
+  });
+
+  it("local-server: reads ollama /api/tags without any key", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ models: [{ name: "llama3.2" }, { name: "qwen2.5:7b" }] }));
+    const catalog = await discoverModels({ provider: "local-server", fetchFn });
+    expect(catalog.source).toBe("live");
+    expect(catalog.models.map((m) => m.id)).toEqual(["llama3.2", "qwen2.5:7b"]);
+    expect(String(fetchFn.mock.calls[0]![0])).toBe("http://localhost:11434/api/tags");
+  });
+
+  it("local-server: falls through to the OpenAI-compatible /v1/models shape", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("404")) // no /api/tags (LM Studio, llama.cpp)
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: "local-model" }] }));
+    const catalog = await discoverModels({
+      provider: "local-server",
+      baseUrl: "http://localhost:1234/",
+      fetchFn,
+    });
+    expect(catalog.source).toBe("live");
+    expect(catalog.models.map((m) => m.id)).toEqual(["local-model"]);
+    expect(String(fetchFn.mock.calls[1]![0])).toBe("http://localhost:1234/v1/models");
+  });
+
+  it("providers without a live adapter fall back honestly", async () => {
+    const catalog = await discoverModels({ provider: "google", fetchFn: vi.fn() });
+    expect(catalog.source).toBe("fallback");
+    expect(catalog.fallbackReason).toContain("no live catalog adapter");
+  });
+});

--- a/packages/ai-core/src/index.ts
+++ b/packages/ai-core/src/index.ts
@@ -10,6 +10,10 @@ export * from "./core.js";
 export { OpenAIProvider } from "./openai-provider.js";
 export type { OpenAIProviderConfig, OpenAIStreamChunk } from "./openai-provider.js";
 
+// Live model-catalog discovery — pluggability contract at the provider seam (#475)
+export { discoverModels } from "./model-catalog.js";
+export type { CatalogModel, ModelCatalog, DiscoverModelsParams } from "./model-catalog.js";
+
 // Loop: agentic turn execution (requires memory-graph → onnxruntime-node)
 export { runTurn, runTurnStreaming, projectProviderClearance } from "./loop.js";
 // The live-state boundary clause — exported so evals outside ai-core can

--- a/packages/ai-core/src/model-catalog.ts
+++ b/packages/ai-core/src/model-catalog.ts
@@ -1,0 +1,153 @@
+/**
+ * Live model-catalog discovery — the pluggability contract enforced at the
+ * provider seam (#475). The catalog's canonical truth lives OUTSIDE the
+ * repo (the provider's live models endpoint); every static table in
+ * `@motebit/sdk` is a snapshot that drifts — the 2026-07-29 night found
+ * three layers of that drift live (fabricated ids, removed sampling
+ * params, removed budget_tokens). Metabolic principle: absorb the catalog
+ * through an adapter with an offline fallback, never hardcode it as truth.
+ *
+ * Fail-soft by construction: any fetch failure (offline, bad key, timeout)
+ * degrades to the static fallback tables, clearly marked
+ * `source: "fallback"` with the reason — `/model` must render on an
+ * airplane, and a provider outage must never brick a session.
+ */
+
+import { ANTHROPIC_MODELS, OPENAI_MODELS, LOCAL_SERVER_SUGGESTED_MODELS } from "@motebit/sdk";
+
+export interface CatalogModel {
+  id: string;
+  displayName?: string;
+}
+
+export interface ModelCatalog {
+  provider: string;
+  /** "live" = fetched from the provider's models endpoint just now;
+   * "fallback" = the committed snapshot tables (drift-prone, marked). */
+  source: "live" | "fallback";
+  models: CatalogModel[];
+  /** Why the live fetch degraded, when it did. */
+  fallbackReason?: string;
+}
+
+export interface DiscoverModelsParams {
+  provider: string;
+  apiKey?: string;
+  /** Provider base URL (local-server / proxy); defaults per provider. */
+  baseUrl?: string;
+  timeoutMs?: number;
+  /** Test seam. Defaults to global fetch. */
+  fetchFn?: typeof fetch;
+}
+
+const DEFAULT_TIMEOUT_MS = 4000;
+
+function fallbackFor(provider: string, reason: string): ModelCatalog {
+  const table =
+    provider === "anthropic"
+      ? ANTHROPIC_MODELS
+      : provider === "openai"
+        ? OPENAI_MODELS
+        : provider === "local-server" || provider === "ollama"
+          ? LOCAL_SERVER_SUGGESTED_MODELS
+          : [];
+  return {
+    provider,
+    source: "fallback",
+    models: (table as readonly string[]).map((id) => ({ id })),
+    fallbackReason: reason,
+  };
+}
+
+async function fetchJson(
+  url: string,
+  headers: Record<string, string>,
+  timeoutMs: number,
+  fetchFn: typeof fetch,
+): Promise<unknown> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const resp = await fetchFn(url, { headers, signal: controller.signal });
+    if (!resp.ok) throw new Error(`${resp.status} from ${url}`);
+    return (await resp.json()) as unknown;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Discover the ACTIVE provider's servable models, live. The list shown to a
+ * user IS the list the provider serves — the static alias table demotes to
+ * name resolution and offline fallback (#471's provider-blind list, second
+ * half).
+ */
+export async function discoverModels(params: DiscoverModelsParams): Promise<ModelCatalog> {
+  const { provider } = params;
+  const timeoutMs = params.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchFn = params.fetchFn ?? fetch;
+
+  try {
+    if (provider === "anthropic") {
+      if (!params.apiKey) return fallbackFor(provider, "no API key for live catalog");
+      const body = (await fetchJson(
+        "https://api.anthropic.com/v1/models?limit=100",
+        { "x-api-key": params.apiKey, "anthropic-version": "2023-06-01" },
+        timeoutMs,
+        fetchFn,
+      )) as { data?: Array<{ id?: string; display_name?: string }> };
+      const models = (body.data ?? [])
+        .filter((m): m is { id: string; display_name?: string } => typeof m.id === "string")
+        .map((m) => ({ id: m.id, ...(m.display_name ? { displayName: m.display_name } : {}) }));
+      if (models.length === 0) return fallbackFor(provider, "live catalog came back empty");
+      return { provider, source: "live", models };
+    }
+
+    if (provider === "openai") {
+      if (!params.apiKey) return fallbackFor(provider, "no API key for live catalog");
+      const body = (await fetchJson(
+        "https://api.openai.com/v1/models",
+        { Authorization: `Bearer ${params.apiKey}` },
+        timeoutMs,
+        fetchFn,
+      )) as { data?: Array<{ id?: string }> };
+      // The raw list carries embeddings/audio/etc — keep the chat families.
+      const models = (body.data ?? [])
+        .filter((m): m is { id: string } => typeof m.id === "string")
+        .filter((m) => /^(gpt-|o[0-9]|chatgpt)/.test(m.id))
+        .map((m) => ({ id: m.id }));
+      if (models.length === 0) return fallbackFor(provider, "live catalog came back empty");
+      return { provider, source: "live", models };
+    }
+
+    if (provider === "local-server" || provider === "ollama") {
+      const base = (params.baseUrl ?? "http://localhost:11434").replace(/\/$/, "");
+      // Ollama-native listing first; OpenAI-compatible /v1/models as the
+      // second shot (LM Studio, llama.cpp servers).
+      try {
+        const body = (await fetchJson(`${base}/api/tags`, {}, timeoutMs, fetchFn)) as {
+          models?: Array<{ name?: string }>;
+        };
+        const models = (body.models ?? [])
+          .filter((m): m is { name: string } => typeof m.name === "string")
+          .map((m) => ({ id: m.name }));
+        if (models.length > 0) return { provider, source: "live", models };
+      } catch {
+        // fall through to the OpenAI-compatible shape
+      }
+      const body = (await fetchJson(`${base}/v1/models`, {}, timeoutMs, fetchFn)) as {
+        data?: Array<{ id?: string }>;
+      };
+      const models = (body.data ?? [])
+        .filter((m): m is { id: string } => typeof m.id === "string")
+        .map((m) => ({ id: m.id }));
+      if (models.length === 0) return fallbackFor(provider, "local server lists no models");
+      return { provider, source: "live", models };
+    }
+
+    // google / proxy / groq / deepseek: no live adapter yet — honest fallback.
+    return fallbackFor(provider, `no live catalog adapter for ${provider}`);
+  } catch (err) {
+    return fallbackFor(provider, err instanceof Error ? err.message : String(err));
+  }
+}


### PR DESCRIPTION
Increment 1 of the #475 staged arc (live catalog → external drift gate → capability-keyed shaping).

**The catalog's canonical truth lives outside the repo** — the provider's live models endpoint — and the 2026-07-29 night found three layers of snapshot drift live (fabricated ids #474, removed sampling params #476, removed budget_tokens). Metabolic principle applied: absorb the catalog through an adapter with an offline fallback, never hardcode it as truth.

- **New `discoverModels` in `@motebit/ai-core`** (ai-core already owns provider I/O): Anthropic `GET /v1/models` (id + display_name), OpenAI `/v1/models` (chat families kept, embeddings/audio dropped), local servers via ollama `/api/tags` with the OpenAI-compatible `/v1/models` as second shot (LM Studio, llama.cpp). Static sdk tables are the **marked** fallback (`source: "fallback"` + reason); every failure path — no key, network error, non-2xx, empty list — degrades softly under a 4s timeout. An empty live list is treated as drift, not truth.
- **`/model` renders the live catalog**: the list shown IS the list the active provider serves (`live from anthropic` footer), the alias table demotes to name resolution + offline fallback (`offline list — live catalog unavailable (reason)`). **Live-membership admission outranks the offline heuristic**: an id the provider doesn't serve refuses with the reason, and a live id the static table never knew about becomes switchable. #488's pair-admission + persist path unchanged beneath it.
- Soft key read (env) — a missing key means fallback, never the hard exit `getApiKey` does.

9 catalog tests (header shapes, both fallback directions, empty-list-as-drift, family filtering, ollama→OpenAI-compat fall-through). Next increments: the scheduled external drift gate (first drift defense pointed outside the repo), then capability-keyed request shaping.

Part of #475.

🤖 Generated with [Claude Code](https://claude.com/claude-code)