### PR TITLE
fix(relay): liveness decay on the default discovery projection — the shelf decays, the ledger doesn't (#473)

### DIFF
--- a/services/relay/src/__tests__/discover-marketplace.test.ts
+++ b/services/relay/src/__tests__/discover-marketplace.test.ts
@@ -372,6 +372,90 @@ describe("GET /api/v1/agents/discover — marketplace enrichment", () => {
     expect(target!.freshness).toBe("cold");
   });
 
+  // ── #473: liveness decay on the DEFAULT projection ─────────────────────
+  // The default browse shelf decays; the ledger doesn't. Registration stays
+  // open — this is projection hygiene, never a gate.
+
+  it("agent unheard-of past a week drops out of the default browse projection", async () => {
+    const kp = await generateKeypair();
+    await registerAgent(relay, "ghost-week-agent", bytesToHex(kp.publicKey));
+    const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    relay.moteDb.db
+      .prepare(
+        "UPDATE agent_registry SET last_heartbeat = ?, registered_at = ? WHERE motebit_id = ?",
+      )
+      .run(eightDaysAgo, eightDaysAgo, "ghost-week-agent");
+
+    const res = await relay.app.request("/api/v1/agents/discover");
+    const { agents } = (await res.json()) as { agents: DiscoveredAgent[] };
+    expect(agents.find((a) => a.motebit_id === "ghost-week-agent")).toBeUndefined();
+  });
+
+  it("include=all restores delisted rows — off the shelf, never out of the ledger", async () => {
+    const kp = await generateKeypair();
+    await registerAgent(relay, "ghost-week-agent-2", bytesToHex(kp.publicKey));
+    const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    relay.moteDb.db
+      .prepare(
+        "UPDATE agent_registry SET last_heartbeat = ?, registered_at = ? WHERE motebit_id = ?",
+      )
+      .run(eightDaysAgo, eightDaysAgo, "ghost-week-agent-2");
+
+    const res = await relay.app.request("/api/v1/agents/discover?include=all");
+    const { agents } = (await res.json()) as { agents: DiscoveredAgent[] };
+    const target = agents.find((a) => a.motebit_id === "ghost-week-agent-2");
+    expect(target).toBeDefined();
+    expect(target!.freshness).toBe("cold");
+  });
+
+  it("a directed motebit_id lookup still finds a delisted row", async () => {
+    const kp = await generateKeypair();
+    await registerAgent(relay, "ghost-week-agent-3", bytesToHex(kp.publicKey));
+    const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    relay.moteDb.db
+      .prepare(
+        "UPDATE agent_registry SET last_heartbeat = ?, registered_at = ? WHERE motebit_id = ?",
+      )
+      .run(eightDaysAgo, eightDaysAgo, "ghost-week-agent-3");
+
+    const res = await relay.app.request("/api/v1/agents/discover?motebit_id=ghost-week-agent-3");
+    const { agents } = (await res.json()) as { agents: DiscoveredAgent[] };
+    expect(agents.find((a) => a.motebit_id === "ghost-week-agent-3")).toBeDefined();
+  });
+
+  it("probe residue that never heartbeated ages out via registration time", async () => {
+    const kp = await generateKeypair();
+    await registerAgent(relay, "probe-residue-agent", bytesToHex(kp.publicKey));
+    const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    relay.moteDb.db
+      .prepare(
+        "UPDATE agent_registry SET last_heartbeat = 0, registered_at = ? WHERE motebit_id = ?",
+      )
+      .run(eightDaysAgo, "probe-residue-agent");
+
+    const res = await relay.app.request("/api/v1/agents/discover");
+    const { agents } = (await res.json()) as { agents: DiscoveredAgent[] };
+    expect(agents.find((a) => a.motebit_id === "probe-residue-agent")).toBeUndefined();
+  });
+
+  it("the relay's own registration is excluded from the default agent listing", async () => {
+    const relayId = relay.relayIdentity.relayMotebitId;
+    const kp = await generateKeypair();
+    await registerAgent(relay, relayId, bytesToHex(kp.publicKey));
+
+    const defaultRes = await relay.app.request("/api/v1/agents/discover");
+    const defaultBody = (await defaultRes.json()) as { agents: DiscoveredAgent[] };
+    expect(defaultBody.agents.find((a) => a.motebit_id === relayId)).toBeUndefined();
+
+    const allRes = await relay.app.request("/api/v1/agents/discover?include=all");
+    const allBody = (await allRes.json()) as {
+      agents: Array<DiscoveredAgent & { role?: string }>;
+    };
+    const selfRow = allBody.agents.find((a) => a.motebit_id === relayId);
+    expect(selfRow).toBeDefined();
+    expect(selfRow!.role).toBe("relay");
+  });
+
   it("fresh agent (just registered) has freshness='awake'", async () => {
     const kp = await generateKeypair();
     await registerAgent(relay, "fresh-agent-freshness", bytesToHex(kp.publicKey));

--- a/services/relay/src/agents.ts
+++ b/services/relay/src/agents.ts
@@ -1506,17 +1506,22 @@ export function registerAgentRoutes(deps: AgentsDeps): void {
     const motebitId = c.req.query("motebit_id");
     const limitParam = Number(c.req.query("limit") ?? "20");
     const limit = Math.min(Math.max(1, limitParam), 100);
+    // #473: the DEFAULT projection decays (rows unheard-of past
+    // FRESHNESS_DELISTED_MS drop out; the relay's own row is chrome, not a
+    // market participant). `include=all` restores the raw registry view —
+    // the record is never erased, only the default shelf is curated.
+    const includeAll = c.req.query("include") === "all";
 
-    // Local results (existing behavior, unchanged)
-    const localAgents = taskRouter.queryLocalAgents(
-      capability ?? undefined,
-      motebitId ?? undefined,
-      limit,
-    );
+    const localAgents = taskRouter
+      .queryLocalAgents(capability ?? undefined, motebitId ?? undefined, limit, false, includeAll)
+      .filter((a) => includeAll || a.motebit_id !== relayIdentity.relayMotebitId);
 
     // Add source_relay metadata to local results
     const localResults = localAgents.map((a) => ({
       ...a,
+      // The relay's own registration reads as a zero-capability ghost in the
+      // agent listing — mark its role when the full view includes it.
+      ...(a.motebit_id === relayIdentity.relayMotebitId ? { role: "relay" as const } : {}),
       source_relay: relayIdentity.relayMotebitId,
       relay_name: federationConfig?.displayName ?? null,
       hop_distance: 0,

--- a/services/relay/src/task-routing.ts
+++ b/services/relay/src/task-routing.ts
@@ -43,6 +43,20 @@ export const FRESHNESS_AWAKE_MS = 6 * 60 * 1000; // one heartbeat cycle (5m) + s
 export const FRESHNESS_RECENT_MS = 30 * 60 * 1000; // missed a cycle, still likely reachable
 export const FRESHNESS_DORMANT_MS = 24 * 60 * 60 * 1000; // asleep but wakeable
 
+/**
+ * Liveness decay on the DEFAULT discovery projection (#473). A row whose
+ * last sign of life (heartbeat, else registration) is older than this drops
+ * out of BROWSE results — probe residue (`probe.invalid`), dead tunnel
+ * endpoints, and abandoned registrations stop being the marketplace's first
+ * impression. The RECORD persists (dissolution-spectrum: the default
+ * projection decays, the ledger doesn't — the 90-day janitor is the only
+ * remover), a directed `motebit_id` lookup still finds the row, and
+ * `include=all` on /discover restores the full view. NEVER a registration
+ * gate — open registration is by-design; sybil resistance lives at the
+ * first-person trust layer (agents-as-first-person-trust-graph).
+ */
+export const FRESHNESS_DELISTED_MS = 7 * 24 * 60 * 60 * 1000; // a week unheard-of ⇒ off the default shelf
+
 export type AgentFreshness = "awake" | "recently_seen" | "dormant" | "cold";
 
 export /**
@@ -136,6 +150,7 @@ export interface TaskRouter {
     motebitId?: string,
     limit?: number,
     federatedOnly?: boolean,
+    includeDelisted?: boolean,
   ): Array<{
     motebit_id: string;
     public_key: string;
@@ -682,6 +697,10 @@ export function createTaskRouter(deps: TaskRouterDeps): TaskRouter {
     limit = 20,
     /** When true, exclude agents with federation_visible = 0 (cross-relay privacy opt-out). */
     federatedOnly = false,
+    /** When true, browse results include rows past FRESHNESS_DELISTED_MS
+     * (the `include=all` escape hatch — #473). Directed motebit_id lookups
+     * always see the full record regardless. */
+    includeDelisted = false,
   ): Array<{
     motebit_id: string;
     public_key: string;
@@ -728,6 +747,15 @@ export function createTaskRouter(deps: TaskRouterDeps): TaskRouter {
     const fedFilter = federatedOnly
       ? " AND (federation_visible IS NULL OR federation_visible != 0)"
       : "";
+    // Liveness decay on BROWSE queries only (#473): the default projection
+    // hides rows unheard-of for FRESHNESS_DELISTED_MS — last heartbeat, or
+    // registration time for rows that never heartbeated (probe residue).
+    // Directed motebit_id lookups below never carry this filter: the ghost
+    // problem is the browse shelf, not the record.
+    const delistCutoff = Math.floor(now - FRESHNESS_DELISTED_MS);
+    const staleFilter = includeDelisted
+      ? ""
+      : ` AND COALESCE(NULLIF(last_heartbeat, 0), registered_at, 0) >= ${delistCutoff}`;
 
     let rows: Array<Record<string, unknown>>;
 
@@ -747,7 +775,7 @@ export function createTaskRouter(deps: TaskRouterDeps): TaskRouter {
         .prepare(
           `
         SELECT * FROM agent_registry
-        WHERE EXISTS (SELECT 1 FROM json_each(capabilities) WHERE value = ?)${revokedFilter}${fedFilter}
+        WHERE EXISTS (SELECT 1 FROM json_each(capabilities) WHERE value = ?)${revokedFilter}${fedFilter}${staleFilter}
         LIMIT ?
       `,
         )
@@ -764,7 +792,7 @@ export function createTaskRouter(deps: TaskRouterDeps): TaskRouter {
       rows = db
         .prepare(
           `
-        SELECT * FROM agent_registry WHERE 1=1${revokedFilter}${fedFilter} LIMIT ?
+        SELECT * FROM agent_registry WHERE 1=1${revokedFilter}${fedFilter}${staleFilter} LIMIT ?
       `,
         )
         .all(limit) as Array<Record<string, unknown>>;


### PR DESCRIPTION
Closes #473. The marketplace's first `/discover` impression was one-third ghosts: `probe.invalid` residue, a dead localtunnel endpoint, the relay's own zero-capability row.

**What this is NOT** (per the issue): registration gating. Open registration stays by-design; sybil resistance lives at the first-person trust layer. This is projection hygiene — dissolution-spectrum applied to discovery: **the default shelf decays, the ledger doesn't**.

- **`FRESHNESS_DELISTED_MS` (7 days)** joins the existing freshness-band constants: browse queries hide rows whose last sign of life — `COALESCE(last_heartbeat, registered_at)` — is older, so probe residue that *never* heartbeated ages out via registration time. The record persists (the 90-day janitor stays the only remover).
- **Directed `motebit_id` lookups never carry the filter** — the ghost problem is the browse shelf, not the record.
- **`?include=all`** restores the raw registry view (delisted rows come back with their honest `cold` freshness).
- **The relay's own row** is excluded from the default agent listing; under `include=all` it carries `role: "relay"`.
- **Federation inherits the default** — ghosts are not exported to peers (all three `queryLocalAgents` callers are discovery projections; routing's `buildCandidateProfiles` is untouched, so wake-on-delegation semantics stand).
- **Sibling surfaces free**: web Discover, runtime `discover_agents`, CLI `/discover` all consume this endpoint — the projection propagates with no per-surface work.

5 new tests: week-old row hidden from default browse, `include=all` restores it, directed lookup still finds it, never-heartbeated probe residue ages out, self-row excluded by default + role-marked under `include=all`. The existing `dormant`/`cold`-remain-discoverable tests (24–48h) pass unchanged — the bands are untouched, only the >7d tail falls off the default shelf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)