### PR TITLE
feat(runtime,cli): the receipt beat lands on the delegate_to_agent path — a hire ends with its signed receipt (#493)

### DIFF
--- a/.changeset/receipt-beat-delegate-path.md
+++ b/.changeset/receipt-beat-delegate-path.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+A conversational hire now ends with its receipt (#493): the runtime emits `delegation_complete` with the worker's signed `full_receipt` on the `delegate_to_agent` path — both routes, including post-approval execution — so the CLI archives and renders the offline-verified receipt block (`/receipt <task-id>` now works for AI-loop hires), the same beat `/invoke` users already had. The streaming layer peeks the receipt stash without draining it, so the parent receipt's `delegation_receipts` chain is untouched.

--- a/apps/cli/src/__tests__/stream.test.ts
+++ b/apps/cli/src/__tests__/stream.test.ts
@@ -30,8 +30,8 @@ vi.mock("../terminal.js", () => ({
   askQuestion: async () => "n",
 }));
 vi.mock("../receipt.js", () => ({
-  archiveReceipt: () => {},
-  renderReceipt: async () => {},
+  archiveReceipt: (r: { task_id?: string }) => events.push(["archive", r.task_id ?? ""]),
+  renderReceipt: async (r: { task_id?: string }) => events.push(["receipt", r.task_id ?? ""]),
 }));
 
 import { consumeStream } from "../stream.js";
@@ -182,6 +182,52 @@ describe("consumeStream — thinking-status row during model latency (#480)", ()
     const rendered = events.map(([, v]) => v).join("");
     expect(rendered).toContain("[memories: Daniel prefers calm software]");
     expect(rendered).not.toContain("[state:");
+  });
+
+  it("the #493 receipt beat composes: delegation_complete + stray done = one done-line, one receipt", async () => {
+    // The runtime now emits delegation_complete (with full_receipt) before
+    // the tool_status done twin on the delegate_to_agent path. The CLI must
+    // render ONE done-line, archive + render the receipt, and swallow the
+    // stray done — the same guard the MCP path exercised.
+    const fullReceipt = {
+      task_id: "task-493",
+      motebit_id: "worker-1",
+      status: "completed",
+      tools_used: ["research"],
+      result: "the report",
+      signature: "sig",
+    };
+    await consumeStream(
+      chunks(
+        { type: "tool_status", name: "delegate_to_agent", status: "calling" },
+        {
+          type: "delegation_complete",
+          server: "relay",
+          tool: "research",
+          receipt: { task_id: "task-493", status: "completed", tools_used: ["research"] },
+          full_receipt: fullReceipt,
+        } as unknown as StreamChunk,
+        { type: "tool_status", name: "delegate_to_agent", status: "done", result: "ok" },
+        resultChunk,
+      ),
+      runtime,
+    );
+    // Exactly one done-line (the delegation_complete's), labeled by capability
+    const doneLines = events.filter(([k, v]) => k === "line" && v.includes("done"));
+    expect(doneLines).toHaveLength(1);
+    expect(doneLines[0]![1]).toContain("research");
+    // The receipt beat fired: archived + rendered
+    expect(events).toContainEqual(["archive", "task-493"]);
+    expect(events).toContainEqual(["receipt", "task-493"]);
+    // Status discipline held: delegating stopped once, thinking restarted after
+    expect(statusTrace()).toEqual([
+      "status:thinking",
+      "stop:thinking",
+      "status:delegating",
+      "stop:delegating",
+      "status:thinking",
+      "stop:thinking",
+    ]);
   });
 
   it("a throwing stream still tears the thinking row down (finally path)", async () => {

--- a/packages/runtime/src/__tests__/streaming.test.ts
+++ b/packages/runtime/src/__tests__/streaming.test.ts
@@ -3322,3 +3322,213 @@ describe("approval lifecycle single-writer (#462)", () => {
     expect(runtime.pendingApprovalInfo?.toolName).toBe("send_payment");
   });
 });
+
+// === #493: the delegate_to_agent receipt beat ===
+//
+// The AI-loop hire path returns its result as plain tool output and stashes
+// the worker's signed receipt only for parent-chain composition — nothing
+// emitted delegation_complete, so the one path a human uses to HIRE never
+// rendered the receipt (both routes). The streaming layer now peeks (never
+// drains) the stash and emits the beat before the tool_status done twin.
+
+describe("delegate_to_agent receipt beat (#493)", () => {
+  let runtime: MotebitRuntime;
+
+  function stashOf(rt: MotebitRuntime): {
+    pushReceipt(r: unknown): void;
+    stashedReceiptCount: number;
+  } {
+    return (
+      rt as unknown as {
+        interactiveDelegation: { pushReceipt(r: unknown): void; stashedReceiptCount: number };
+      }
+    ).interactiveDelegation;
+  }
+
+  function makeDelegationReceipt(taskId: string): Record<string, unknown> {
+    return {
+      task_id: taskId,
+      motebit_id: "worker-1",
+      status: "completed",
+      tools_used: ["research"],
+      result: "the purchased report",
+      signature: "sig-" + taskId,
+      public_key: "aa".repeat(32),
+      prompt_hash: "",
+      result_hash: "",
+      submitted_at: Date.now(),
+      completed_at: Date.now(),
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runtime = new MotebitRuntime(
+      { motebitId: "receipt-beat-test", tickRateHz: 0 },
+      createAdapters(createMockProvider()),
+    );
+  });
+
+  it("emits delegation_complete with the stashed full_receipt, BEFORE the tool_status done twin", async () => {
+    mockRunTurnStreaming.mockReturnValueOnce(
+      (async function* () {
+        yield {
+          type: "tool_status" as const,
+          name: "delegate_to_agent",
+          status: "calling" as const,
+        };
+        // The tool handler stashes the worker's signed receipt mid-call.
+        stashOf(runtime).pushReceipt(makeDelegationReceipt("task-beat-1"));
+        yield {
+          type: "tool_status" as const,
+          name: "delegate_to_agent",
+          status: "done" as const,
+          result: "Task completed",
+        };
+        yield { type: "result" as const, result: makeTurnResult() };
+      })(),
+    );
+
+    const chunks = await collectChunks(runtime.sendMessageStreaming("hire a researcher"));
+    const types = chunks.map((c) => c.type);
+    const beatIdx = types.indexOf("delegation_complete");
+    const doneIdx = chunks.findIndex(
+      (c) => c.type === "tool_status" && (c as { status?: string }).status === "done",
+    );
+    expect(beatIdx).toBeGreaterThan(-1);
+    expect(beatIdx).toBeLessThan(doneIdx);
+
+    const beat = chunks[beatIdx] as {
+      tool: string;
+      receipt?: { task_id: string; status: string };
+      full_receipt?: { signature: string };
+    };
+    expect(beat.tool).toBe("research"); // labeled by the worker's capability
+    expect(beat.receipt?.task_id).toBe("task-beat-1");
+    expect(beat.full_receipt?.signature).toBe("sig-task-beat-1");
+  });
+
+  it("PEEKS, never drains — the parent receipt chain still gets the receipt", async () => {
+    mockRunTurnStreaming.mockReturnValueOnce(
+      (async function* () {
+        yield {
+          type: "tool_status" as const,
+          name: "delegate_to_agent",
+          status: "calling" as const,
+        };
+        stashOf(runtime).pushReceipt(makeDelegationReceipt("task-beat-2"));
+        yield {
+          type: "tool_status" as const,
+          name: "delegate_to_agent",
+          status: "done" as const,
+          result: "ok",
+        };
+        yield { type: "result" as const, result: makeTurnResult() };
+      })(),
+    );
+    await collectChunks(runtime.sendMessageStreaming("hire"));
+
+    // The composition drain (handleAgentTask's path) must still see it.
+    const drained = runtime.getAndResetInteractiveDelegationReceipts();
+    expect(drained).toHaveLength(1);
+    expect(drained[0]!.task_id).toBe("task-beat-2");
+  });
+
+  it("a delegate call that stashes nothing (failed/refused) emits no beat", async () => {
+    mockRunTurnStreaming.mockReturnValueOnce(
+      (async function* () {
+        yield {
+          type: "tool_status" as const,
+          name: "delegate_to_agent",
+          status: "calling" as const,
+        };
+        yield {
+          type: "tool_status" as const,
+          name: "delegate_to_agent",
+          status: "done" as const,
+          result: "delegation failed (worker_unreachable)",
+        };
+        yield { type: "result" as const, result: makeTurnResult() };
+      })(),
+    );
+    const chunks = await collectChunks(runtime.sendMessageStreaming("hire"));
+    expect(chunks.some((c) => c.type === "delegation_complete")).toBe(false);
+  });
+
+  it("pre-existing stash entries are not re-emitted — only receipts from THIS call", async () => {
+    stashOf(runtime).pushReceipt(makeDelegationReceipt("task-earlier"));
+    mockRunTurnStreaming.mockReturnValueOnce(
+      (async function* () {
+        yield {
+          type: "tool_status" as const,
+          name: "delegate_to_agent",
+          status: "calling" as const,
+        };
+        stashOf(runtime).pushReceipt(makeDelegationReceipt("task-fresh"));
+        yield {
+          type: "tool_status" as const,
+          name: "delegate_to_agent",
+          status: "done" as const,
+          result: "ok",
+        };
+        yield { type: "result" as const, result: makeTurnResult() };
+      })(),
+    );
+    const chunks = await collectChunks(runtime.sendMessageStreaming("hire"));
+    const beats = chunks.filter((c) => c.type === "delegation_complete") as Array<{
+      receipt?: { task_id: string };
+    }>;
+    expect(beats).toHaveLength(1);
+    expect(beats[0]!.receipt?.task_id).toBe("task-fresh");
+  });
+
+  it("post-approval direct execution emits the beat too — the highest-stakes render", async () => {
+    // Register a delegate_to_agent tool whose handler stashes the receipt
+    // (the real handler's shape, minus the relay).
+    (
+      runtime as unknown as {
+        toolRegistry: {
+          register(
+            d: { name: string; description: string; parameters: Record<string, never> },
+            h: () => Promise<{ ok: boolean; data: string }>,
+          ): void;
+        };
+      }
+    ).toolRegistry.register(
+      { name: "delegate_to_agent", description: "hire", parameters: {} },
+      async () => {
+        stashOf(runtime).pushReceipt(makeDelegationReceipt("task-approved"));
+        return { ok: true, data: "Task completed by worker-1" };
+      },
+    );
+
+    mockRunTurnStreaming.mockReturnValueOnce(
+      yieldChunks(
+        {
+          type: "approval_request",
+          tool_call_id: "tc-beat",
+          name: "delegate_to_agent",
+          args: { capability: "research", prompt: "go" },
+          risk_level: 4,
+        },
+        { type: "result", result: makeTurnResult() },
+      ),
+    );
+    await collectChunks(runtime.sendMessageStreaming("hire someone"));
+    expect(runtime.hasPendingApproval).toBe(true);
+
+    mockRunTurnStreaming.mockReturnValueOnce(
+      yieldChunks({ type: "result", result: makeTurnResult() }),
+    );
+    const resumed = await collectChunks(runtime.resumeAfterApproval(true));
+    const types = resumed.map((c) => c.type);
+    const beatIdx = types.indexOf("delegation_complete");
+    const doneIdx = resumed.findIndex(
+      (c) => c.type === "tool_status" && (c as { status?: string }).status === "done",
+    );
+    expect(beatIdx).toBeGreaterThan(-1);
+    expect(beatIdx).toBeLessThan(doneIdx);
+    const beat = resumed[beatIdx] as { full_receipt?: { task_id?: string } };
+    expect(beat.full_receipt?.task_id).toBe("task-approved");
+  });
+});

--- a/packages/runtime/src/interactive-delegation.ts
+++ b/packages/runtime/src/interactive-delegation.ts
@@ -514,4 +514,21 @@ export class InteractiveDelegationManager {
   pushReceipt(receipt: ExecutionReceipt): void {
     this.receipts.push(receipt);
   }
+
+  /**
+   * Non-draining view of the stash for the streaming layer's
+   * `delegation_complete` emission (#493): mark the count before a
+   * `delegate_to_agent` call, peek what arrived after it. MUST NOT drain —
+   * `getAndResetReceipts` composes the same bucket into the parent
+   * receipt's `delegation_receipts` chain, and a draining reader here
+   * would silently sever that chain (composition-preserves-enforcement).
+   */
+  get stashedReceiptCount(): number {
+    return this.receipts.length;
+  }
+
+  /** See {@link stashedReceiptCount} — the peek half of the pair. */
+  peekReceiptsSince(count: number): ExecutionReceipt[] {
+    return this.receipts.slice(count);
+  }
 }

--- a/packages/runtime/src/motebit-runtime.ts
+++ b/packages/runtime/src/motebit-runtime.ts
@@ -1223,6 +1223,14 @@ export class MotebitRuntime {
         this.assertSensitivityPermitsAiCall(entry, toolName),
       getLatestCues: () => this.latestCues,
       getApprovalStore: () => this.approvalStore,
+      // #493: non-draining stash view for the delegate_to_agent receipt
+      // beat. Lazy closures — interactiveDelegation is constructed before
+      // the StreamingManager, but the indirection keeps that ordering a
+      // non-constraint.
+      delegationReceiptStash: {
+        count: () => this.interactiveDelegation.stashedReceiptCount,
+        peekSince: (n) => this.interactiveDelegation.peekReceiptsSince(n),
+      },
       redactText: (text) => {
         if (typeof this.policy.redact === "function") {
           return this.policy.redact(text);

--- a/packages/runtime/src/streaming.ts
+++ b/packages/runtime/src/streaming.ts
@@ -131,6 +131,21 @@ export interface StreamingDeps {
   approvalTimeoutMs: number;
   /** Redact secrets from arbitrary text (defense-in-depth at the streaming boundary). */
   redactText(text: string): string;
+  /**
+   * #493: non-draining view of the interactive-delegation receipt stash,
+   * so the streaming layer can emit `delegation_complete` (+ the signed
+   * `full_receipt`) when a `delegate_to_agent` tool completes — the
+   * AI-loop hire path's receipt beat, absent on both routes until now
+   * (the tool returns its result as plain output and stashes the receipt
+   * only for parent-chain composition). PEEK, never drain: draining here
+   * would sever the parent receipt's `delegation_receipts` chain
+   * (composition-preserves-enforcement). Optional for source-compat;
+   * absent deps simply don't emit the beat.
+   */
+  delegationReceiptStash?: {
+    count(): number;
+    peekSince(count: number): import("@motebit/sdk").ExecutionReceipt[];
+  };
   /** Motebit ID. */
   motebitId: string;
   /**
@@ -404,6 +419,12 @@ export class StreamingManager {
       { toolName: string; args: Record<string, unknown>; startedAt: number }
     >();
 
+    // #493: stash watermark for the in-flight delegate_to_agent call.
+    // Tool calls execute sequentially within a stream, so a single mark
+    // (set on "calling", read+cleared on "done") is sufficient and does
+    // not depend on tool_call_id being present.
+    let delegateStashMark: number | null = null;
+
     for await (let chunk of stream) {
       // Deferred memory-formation chunks are an internal runtime
       // protocol handled by `MotebitRuntime._catchDeferredFormationChunks`
@@ -444,6 +465,11 @@ export class StreamingManager {
           if (motebitServer) {
             this.deps.setDelegating(true);
             yield { type: "delegation_start", server: motebitServer, tool: chunk.name };
+          }
+          // #493: watermark the receipt stash before a delegate_to_agent
+          // call so the matching "done" can peek exactly what it stashed.
+          if (chunk.name === "delegate_to_agent") {
+            delegateStashMark = this.deps.delegationReceiptStash?.count() ?? null;
           }
         } else if (chunk.status === "done") {
           // Defense-in-depth: redact secrets from tool results at the
@@ -538,6 +564,38 @@ export class StreamingManager {
               receipt: receiptSummary,
               full_receipt: fullReceipt,
             };
+          }
+          // #493: the AI-loop hire path's receipt beat. delegate_to_agent
+          // returns its result as plain tool output and stashes the
+          // worker's signed receipt only for parent-chain composition —
+          // no producer ever emitted delegation_complete here, so the one
+          // path a human uses to HIRE never rendered the receipt (both
+          // routes; witnessed on the 1.11.1 soak, #479). Peek (never
+          // drain) the receipts stashed during THIS call and forward
+          // them; this yields BEFORE the tool_status done chunk below,
+          // the same ordering the MCP path produces, so consumers' guard
+          // for the stray-done twin already composes.
+          if (chunk.name === "delegate_to_agent" && delegateStashMark != null) {
+            const mark = delegateStashMark;
+            delegateStashMark = null;
+            const stashed = this.deps.delegationReceiptStash?.peekSince(mark) ?? [];
+            for (const receipt of stashed) {
+              yield {
+                type: "delegation_complete",
+                server: "relay",
+                tool: receipt.tools_used?.[0] ?? "delegate_to_agent",
+                ...(typeof receipt.task_id === "string" && typeof receipt.status === "string"
+                  ? {
+                      receipt: {
+                        task_id: receipt.task_id,
+                        status: receipt.status,
+                        tools_used: receipt.tools_used ?? [],
+                      },
+                    }
+                  : {}),
+                full_receipt: receipt,
+              };
+            }
           }
         }
       }
@@ -730,6 +788,13 @@ export class StreamingManager {
       if (approved) {
         // Execute the tool directly
         yield { type: "tool_status" as const, name: pending.toolName, status: "calling" as const };
+        // #493: watermark the receipt stash — the post-approval path is the
+        // highest-stakes render of the receipt beat (a human just approved
+        // a spend; the signed receipt is the outcome #457 promised them).
+        const approvedStashMark =
+          pending.toolName === "delegate_to_agent"
+            ? (this.deps.delegationReceiptStash?.count() ?? null)
+            : null;
         const toolRegistry = this.deps.getToolRegistry();
         const result = await toolRegistry.execute(pending.toolName, pending.args);
 
@@ -742,6 +807,31 @@ export class StreamingManager {
             tool_name: pending.toolName,
             patterns: check.injectionPatterns!,
           };
+        }
+
+        // #493: emit the receipt beat BEFORE the done chunk — the same
+        // delegation_complete-then-stray-done ordering the MCP path
+        // produces, which every consumer's twin guard already handles.
+        // Peek, never drain (parent-chain composition owns the drain).
+        if (approvedStashMark != null) {
+          const stashed = this.deps.delegationReceiptStash?.peekSince(approvedStashMark) ?? [];
+          for (const receipt of stashed) {
+            yield {
+              type: "delegation_complete" as const,
+              server: "relay",
+              tool: receipt.tools_used?.[0] ?? "delegate_to_agent",
+              ...(typeof receipt.task_id === "string" && typeof receipt.status === "string"
+                ? {
+                    receipt: {
+                      task_id: receipt.task_id,
+                      status: receipt.status,
+                      tools_used: receipt.tools_used ?? [],
+                    },
+                  }
+                : {}),
+              full_receipt: receipt,
+            };
+          }
         }
 
         yield {


### PR DESCRIPTION
Closes #493. The AI-loop hire — the one path a human actually uses to hire — returned its result as plain tool output and stashed the worker's signed receipt only for parent-chain composition. No producer emitted `delegation_complete`, so the receipt beat (the offline-verify "oh" moment) never rendered, on either route (witnessed on the 1.11.1 soak, #479).

**Mechanism** — the streaming layer watermarks the receipt stash when a `delegate_to_agent` call starts and **peeks** (never drains) what the call stashed when it completes, yielding `delegation_complete` + the signed `full_receipt` **before** the `tool_status done` twin:
- **Peek-not-drain is the load-bearing constraint**: `getAndResetReceipts` composes the same bucket into the parent receipt's `delegation_receipts` chain — a draining reader would silently sever it (composition-preserves-enforcement). Locked by a test that drains AFTER the beat and still finds the receipt.
- **Ordering is the MCP path's exact shape** (`delegation_complete` then stray `done`), so every consumer's existing twin guard composes unchanged.
- **Post-approval direct execution gets the same treatment** — the highest-stakes render: a human just approved a spend; the receipt is the outcome #457's terminal-outcome contract promised.
- Watermark isolation: pre-existing stash entries (a concurrent `invokeCapability` tap) are not re-emitted; a failed/refused delegation stashes nothing and emits no beat.

**All four sibling consumers verified**:
- CLI: one done-line labeled by the worker's capability + the archived, offline-verified receipt block; `/receipt <task-id>` now works for AI-loop hires (`archiveReceipt` finally fires). Twin-composition golden test.
- Attached REPL: existing `delegation_complete` case renders the receipt line.
- Slab: `toolItemIds.get(chunk.tool)` finds no item for the beat (no `delegation_start` under the capability name) — guard no-ops cleanly; the generic tool-item lifecycle is untouched.
- Web chat: `capturedReceipt = chunk.full_receipt` — AI-loop hires now emerge the receipt artifact bubble, free.

5 runtime tests + 1 CLI golden test; runtime 1265 pass, CLI 390 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)