### PR TITLE
feat(cli): update nudge — one dim line when a newer motebit is on npm

### DIFF
--- a/.changeset/cli-update-nudge.md
+++ b/.changeset/cli-update-nudge.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+The REPL now nudges when a newer motebit is on npm — one dim line in the seed-nudge register (`motebit 1.11.2 available — npm i -g motebit`), because a global npm install never self-updates and the gap was invisible. The registry check is cached for a day and refreshed in the background for the NEXT launch: startup never blocks on the network, offline is silent, and `MOTEBIT_NO_UPDATE_CHECK=1` opts out entirely.

--- a/apps/cli/etc/cli-surface.json
+++ b/apps/cli/etc/cli-surface.json
@@ -355,6 +355,7 @@
     "relay",
     "relay/relay.db",
     "smoke-x402-buyer-eoa.txt",
-    "smoke-x402-worker-eoa.txt"
+    "smoke-x402-worker-eoa.txt",
+    "update-check.json"
   ]
 }

--- a/apps/cli/src/__tests__/update-nudge.test.ts
+++ b/apps/cli/src/__tests__/update-nudge.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+  isNewerVersion,
+  readUpdateState,
+  renderUpdateNudge,
+  refreshUpdateCheckInBackground,
+} from "../update-nudge.js";
+
+function tmpStatePath(): string {
+  return path.join(fs.mkdtempSync(path.join(os.tmpdir(), "nudge-")), "update-check.json");
+}
+
+async function settle(): Promise<void> {
+  // The refresh is fire-and-forget; give its microtasks a beat.
+  await new Promise((r) => setTimeout(r, 10));
+}
+
+describe("isNewerVersion — fails to silence, never to noise", () => {
+  it("compares numeric triples", () => {
+    expect(isNewerVersion("1.11.2", "1.11.1")).toBe(true);
+    expect(isNewerVersion("1.11.1", "1.11.1")).toBe(false);
+    expect(isNewerVersion("1.11.1", "1.11.2")).toBe(false);
+    expect(isNewerVersion("2.0.0", "1.99.99")).toBe(true);
+    expect(isNewerVersion("1.12.0", "1.11.9")).toBe(true);
+  });
+
+  it("malformed or prerelease versions are silent", () => {
+    expect(isNewerVersion("1.12.0-beta.1", "1.11.1")).toBe(false);
+    expect(isNewerVersion("garbage", "1.11.1")).toBe(false);
+    expect(isNewerVersion("1.12", "1.11.1")).toBe(false);
+    expect(isNewerVersion("1.12.0", "unknown")).toBe(false);
+  });
+});
+
+describe("renderUpdateNudge", () => {
+  it("nudges only when the cache knows a newer version", () => {
+    expect(
+      renderUpdateNudge({
+        currentVersion: "1.11.1",
+        state: { last_checked_at: 1, latest: "1.11.2" },
+      }),
+    ).toBe("motebit 1.11.2 available — npm i -g motebit");
+    expect(
+      renderUpdateNudge({
+        currentVersion: "1.11.2",
+        state: { last_checked_at: 1, latest: "1.11.2" },
+      }),
+    ).toBeNull();
+    expect(renderUpdateNudge({ currentVersion: "1.11.1", state: null })).toBeNull();
+    expect(
+      renderUpdateNudge({ currentVersion: "1.11.1", state: { last_checked_at: 1 } }),
+    ).toBeNull();
+  });
+});
+
+describe("refreshUpdateCheckInBackground", () => {
+  it("writes the cache from the registry response", async () => {
+    const statePath = tmpStatePath();
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "1.11.2" }),
+    } as unknown as Response);
+
+    refreshUpdateCheckInBackground({ statePath, nowMs: 1000, fetchFn });
+    await settle();
+
+    expect(readUpdateState(statePath)).toEqual({ last_checked_at: 1000, latest: "1.11.2" });
+    expect(String(fetchFn.mock.calls[0]![0])).toContain("registry.npmjs.org/motebit/latest");
+  });
+
+  it("a fresh cache skips the network entirely", async () => {
+    const statePath = tmpStatePath();
+    fs.writeFileSync(statePath, JSON.stringify({ last_checked_at: 1000, latest: "1.11.2" }));
+    const fetchFn = vi.fn();
+
+    refreshUpdateCheckInBackground({ statePath, nowMs: 2000, ttlMs: 10_000, fetchFn });
+    await settle();
+
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("a stale cache refreshes", async () => {
+    const statePath = tmpStatePath();
+    fs.writeFileSync(statePath, JSON.stringify({ last_checked_at: 1000, latest: "1.11.1" }));
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "1.11.3" }),
+    } as unknown as Response);
+
+    refreshUpdateCheckInBackground({ statePath, nowMs: 999_999_999, fetchFn });
+    await settle();
+
+    expect(readUpdateState(statePath)?.latest).toBe("1.11.3");
+  });
+
+  it("offline / error paths write nothing and stay silent (retry next launch)", async () => {
+    const statePath = tmpStatePath();
+    const rejecting = vi.fn().mockRejectedValue(new Error("ENOTFOUND"));
+    refreshUpdateCheckInBackground({ statePath, nowMs: 1000, fetchFn: rejecting });
+    await settle();
+    expect(readUpdateState(statePath)).toBeNull();
+
+    const badStatus = vi.fn().mockResolvedValue({ ok: false } as unknown as Response);
+    refreshUpdateCheckInBackground({ statePath, nowMs: 1000, fetchFn: badStatus });
+    await settle();
+    expect(readUpdateState(statePath)).toBeNull();
+
+    const badBody = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ nope: true }),
+    } as unknown as Response);
+    refreshUpdateCheckInBackground({ statePath, nowMs: 1000, fetchFn: badBody });
+    await settle();
+    expect(readUpdateState(statePath)).toBeNull();
+  });
+
+  it("a corrupt cache file reads as null and refresh recovers it", async () => {
+    const statePath = tmpStatePath();
+    fs.writeFileSync(statePath, "not json{");
+    expect(readUpdateState(statePath)).toBeNull();
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "1.11.2" }),
+    } as unknown as Response);
+    refreshUpdateCheckInBackground({ statePath, nowMs: 5000, fetchFn });
+    await settle();
+    expect(readUpdateState(statePath)?.latest).toBe("1.11.2");
+  });
+});

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -7,7 +7,12 @@ import { createSolanaWalletRail } from "@motebit/wallet-solana";
 import { preflightGrant, renderPreflight } from "./grant-preflight.js";
 import { parseCliArgs, printHelp, printVersion, printBanner, trimHistory } from "./args.js";
 import type { CliConfig } from "./args.js";
-import { loadFullConfig, extractPersonality, persistMotebitPublicKeys } from "./config.js";
+import { loadFullConfig, extractPersonality, persistMotebitPublicKeys, VERSION } from "./config.js";
+import {
+  renderUpdateNudge,
+  readUpdateState,
+  refreshUpdateCheckInBackground,
+} from "./update-nudge.js";
 import {
   promptPassphrase,
   resolveUnlockPassphrase,
@@ -985,6 +990,19 @@ async function main(): Promise<void> {
   if (seedBackupStatus(loadFullConfig()) === "not_backed_up") {
     console.log(dim("  recovery seed not backed up — `motebit seed reveal` (once, on paper)"));
     console.log();
+  }
+
+  // Update nudge — the seed nudge's register applied to staleness: a global
+  // npm install never self-updates, and the 1.11.1→1.11.2 gap was invisible
+  // until the founder asked. Cached check, background refresh for the NEXT
+  // launch, silent offline; MOTEBIT_NO_UPDATE_CHECK=1 opts out.
+  if (process.env["MOTEBIT_NO_UPDATE_CHECK"] !== "1") {
+    const updateNudge = renderUpdateNudge({ currentVersion: VERSION, state: readUpdateState() });
+    if (updateNudge != null) {
+      console.log(dim(`  ${updateNudge}`));
+      console.log();
+    }
+    refreshUpdateCheckInBackground();
   }
 
   // First-session activation: creature speaks first after identity birth.

--- a/apps/cli/src/update-nudge.ts
+++ b/apps/cli/src/update-nudge.ts
@@ -1,0 +1,118 @@
+/**
+ * Update nudge — one dim line at REPL start when a newer motebit is on npm.
+ *
+ * Register: the seed-backup nudge's shape — calm, a single actionable
+ * line, never a nag. Mechanics keep startup honest:
+ *   - the registry check is CACHED (`update-check.json` in the config
+ *     dir) and refreshed in the BACKGROUND for the NEXT launch — startup
+ *     never blocks on the network and a session is never interrupted by
+ *     a late response;
+ *   - offline / registry errors are silent (no write, retry next launch);
+ *   - the nudge renders from whatever the cache knows: a stale cache can
+ *     only ever name a version that exists, and once the user updates,
+ *     the newer-than compare goes quiet on its own.
+ * Opt out with MOTEBIT_NO_UPDATE_CHECK=1 (CI, scripts, air-gapped).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { CONFIG_DIR } from "./config.js";
+
+export interface UpdateCheckState {
+  last_checked_at: number;
+  latest?: string;
+}
+
+const UPDATE_CHECK_TTL_MS = 24 * 60 * 60 * 1000; // one check a day is plenty
+const FETCH_TIMEOUT_MS = 3000;
+
+function updateCheckPath(): string {
+  return path.join(CONFIG_DIR, "update-check.json");
+}
+
+/**
+ * Strict numeric triple compare; anything malformed (prerelease tags,
+ * missing parts, non-numbers) compares false — the nudge fails to
+ * silence, never to noise.
+ */
+export function isNewerVersion(latest: string, current: string): boolean {
+  const parse = (v: string): number[] | null => {
+    const parts = v.trim().split(".");
+    if (parts.length !== 3) return null;
+    const nums = parts.map((p) => (/^\d+$/.test(p) ? Number(p) : NaN));
+    return nums.some((n) => Number.isNaN(n)) ? null : nums;
+  };
+  const l = parse(latest);
+  const c = parse(current);
+  if (l == null || c == null) return false;
+  for (let i = 0; i < 3; i++) {
+    if (l[i]! > c[i]!) return true;
+    if (l[i]! < c[i]!) return false;
+  }
+  return false;
+}
+
+export function readUpdateState(statePath = updateCheckPath()): UpdateCheckState | null {
+  try {
+    const raw = JSON.parse(fs.readFileSync(statePath, "utf-8")) as Record<string, unknown>;
+    if (typeof raw.last_checked_at !== "number") return null;
+    return {
+      last_checked_at: raw.last_checked_at,
+      ...(typeof raw.latest === "string" ? { latest: raw.latest } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** The dim line to render, or null for silence. Pure. */
+export function renderUpdateNudge(params: {
+  currentVersion: string;
+  state: UpdateCheckState | null;
+}): string | null {
+  const latest = params.state?.latest;
+  if (latest == null || !isNewerVersion(latest, params.currentVersion)) return null;
+  return `motebit ${latest} available — npm i -g motebit`;
+}
+
+/**
+ * Fire-and-forget cache refresh for the NEXT launch. Skips when the
+ * cache is fresh; any failure (offline, timeout, bad body) writes
+ * nothing and retries silently on a later launch.
+ */
+export function refreshUpdateCheckInBackground(params?: {
+  statePath?: string;
+  nowMs?: number;
+  ttlMs?: number;
+  fetchFn?: typeof fetch;
+}): void {
+  const statePath = params?.statePath ?? updateCheckPath();
+  const now = params?.nowMs ?? Date.now();
+  const ttl = params?.ttlMs ?? UPDATE_CHECK_TTL_MS;
+  const fetchFn = params?.fetchFn ?? fetch;
+
+  const state = readUpdateState(statePath);
+  if (state != null && now - state.last_checked_at < ttl) return;
+
+  void (async () => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+      const resp = await fetchFn("https://registry.npmjs.org/motebit/latest", {
+        signal: controller.signal,
+      });
+      if (!resp.ok) return;
+      const body = (await resp.json()) as { version?: unknown };
+      if (typeof body.version !== "string") return;
+      fs.mkdirSync(path.dirname(statePath), { recursive: true });
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({ last_checked_at: now, latest: body.version } satisfies UpdateCheckState),
+      );
+    } catch {
+      // Offline / timeout / parse failure: stay silent, retry next launch.
+    } finally {
+      clearTimeout(timer);
+    }
+  })();
+}


### PR DESCRIPTION
A global npm install never self-updates, and the founder found v1.11.1 in his terminal only after 1.11.2 shipped — the gap was invisible by design. The seed nudge's register applied to staleness:

```
  motebit 1.11.2 available — npm i -g motebit
```

- **Never blocks startup**: the registry check is cached (`~/.motebit/update-check.json`, 24h TTL — a deliberate additive entry in the cli-surface baseline) and refreshed fire-and-forget for the NEXT launch; a session is never interrupted by a late response.
- **Fails to silence, never to noise**: offline / timeout / bad body write nothing and retry on a later launch; malformed or prerelease versions compare false; once the user updates, the newer-than compare goes quiet on its own.
- **Opt-out**: `MOTEBIT_NO_UPDATE_CHECK=1` (CI, scripts, air-gapped).
- REPL-only (daemon/serve stay headless-silent).

8 tests: the compare table, render gating, TTL skip, stale-refresh, all three error paths, corrupt-cache recovery. CLI suite 398 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)