### PR TITLE
fix(cli): an implicit model follows the provider flip — the fallback can never mint an illegal pairing

### DIFF
--- a/.changeset/provider-flip-model-default.md
+++ b/.changeset/provider-flip-model-default.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+An implicit model now follows a persisted `default_provider` flip (found live on the founder's first 1.11.2 launch): the parse-time model default was derived from the parse-time provider, so a config-persisted provider switch left the old provider's default behind — bare `motebit` rendered `local-server · claude-sonnet-4-6`, the exact illegal pairing the admission gate exists to prevent, minted by the fallback path itself. The yield target is now derived through `defaultModelForProvider`, never trusted from residue; an explicit `--model` remains the user's word. Locked by an invariant test: every provider's own default is admissible on that provider.

--- a/apps/cli/src/__tests__/index.test.ts
+++ b/apps/cli/src/__tests__/index.test.ts
@@ -44,6 +44,15 @@ describe("parseCliArgs", () => {
     expect(config.model).toBe("mistral");
   });
 
+  it("modelExplicit marks the user's word apart from a derived default", () => {
+    // The 2026-07-31 live find: a persisted default_provider flip must drag
+    // an IMPLICIT model to the new provider's default, but never touch an
+    // explicit --model. The flag is how config resolution tells them apart.
+    expect(parseCliArgs(["--provider", "local-server"]).modelExplicit).toBe(false);
+    expect(parseCliArgs(["--model", "mistral"]).modelExplicit).toBe(true);
+    expect(parseCliArgs([]).modelExplicit).toBe(false);
+  });
+
   it("parses openai provider", () => {
     const config = parseCliArgs(["--provider", "openai"]);
     expect(config.provider).toBe("openai");

--- a/apps/cli/src/__tests__/model-admission.test.ts
+++ b/apps/cli/src/__tests__/model-admission.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { admitModelForProvider } from "../model-admission.js";
+import { defaultModelForProvider } from "../args.js";
 
 describe("admitModelForProvider — the provider+model pair gate (#471)", () => {
   it("refuses a hosted Claude id on local-server (witnessed direction 2)", () => {
@@ -35,5 +36,26 @@ describe("admitModelForProvider — the provider+model pair gate (#471)", () => 
 
   it("the ollama legacy alias gets the same strictness as local-server", () => {
     expect(admitModelForProvider("ollama", "claude-opus-5").admissible).toBe(false);
+  });
+
+  it("every provider's own default is admissible on that provider — the fallback can never mint an illegal pairing", () => {
+    // 2026-07-31 live find: after a persisted default_provider flip, the
+    // admission yield fell back to config.model, which still carried the
+    // PARSE-time provider's default — `local-server · claude-sonnet-4-6`
+    // on the founder's first 1.11.2 launch. The fix derives the fallback
+    // through defaultModelForProvider; this locks the derived pair as
+    // admissible by construction for every provider.
+    const providers = [
+      "anthropic",
+      "openai",
+      "google",
+      "groq",
+      "deepseek",
+      "local-server",
+      "proxy",
+    ] as const;
+    for (const p of providers) {
+      expect(admitModelForProvider(p, defaultModelForProvider(p)).admissible).toBe(true);
+    }
   });
 });

--- a/apps/cli/src/__tests__/repl-goals.test.ts
+++ b/apps/cli/src/__tests__/repl-goals.test.ts
@@ -32,6 +32,7 @@ const stubRuntime = null as unknown as MotebitRuntime;
 const stubConfig = {
   provider: "anthropic" as const,
   model: "test",
+  modelExplicit: false,
   dbPath: undefined,
   noStream: false,
   syncUrl: undefined,

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -19,6 +19,10 @@ export type CliProvider =
 export interface CliConfig {
   provider: CliProvider;
   model: string;
+  /** True when the model came from an explicit `--model` flag. An implicit
+   * model must FOLLOW any later provider change (`defaultModelForProvider`)
+   * — an explicit one is the user's word and never silently swapped. */
+  modelExplicit: boolean;
   dbPath: string | undefined;
   noStream: boolean;
   syncUrl: string | undefined;
@@ -221,18 +225,7 @@ export function parseCliArgs(args: string[] = process.argv.slice(2)): CliConfig 
   }
   const cliProvider = rawProvider as CliProvider;
 
-  const defaultModel =
-    cliProvider === "local-server"
-      ? "llama3.2"
-      : cliProvider === "openai"
-        ? "gpt-5.4-mini"
-        : cliProvider === "google"
-          ? "gemini-2.5-flash"
-          : cliProvider === "groq"
-            ? "llama-3.3-70b-versatile"
-            : cliProvider === "deepseek"
-              ? "deepseek-chat"
-              : "claude-sonnet-4-6";
+  const defaultModel = defaultModelForProvider(cliProvider);
   const allowedPaths =
     values["allowed-paths"] != null && values["allowed-paths"] !== ""
       ? values["allowed-paths"].split(",").map((p) => p.trim())
@@ -241,6 +234,7 @@ export function parseCliArgs(args: string[] = process.argv.slice(2)): CliConfig 
   return {
     provider: cliProvider,
     model: values.model ?? defaultModel,
+    modelExplicit: values.model != null,
     dbPath: values["db-path"],
     noStream: values["no-stream"],
     syncUrl: values["sync-url"],
@@ -567,6 +561,31 @@ Slash commands (in REPL):`,
 
 export function printVersion(): void {
   console.log(VERSION);
+}
+
+/**
+ * The per-provider model default — the ONLY legitimate fallback when no
+ * explicit model survives config resolution. Extracted from the parse path
+ * (2026-07-31 live find): a persisted `default_provider` used to flip the
+ * provider AFTER parse-time defaulting, leaving the OLD provider's default
+ * on `config.model` — bare `motebit` rendered `local-server ·
+ * claude-sonnet-4-6`, the exact illegal pairing the #471 admission exists
+ * to prevent, minted by the fallback path itself. Any code that changes
+ * the provider after parse must re-derive the model through this function
+ * whenever the model wasn't explicit.
+ */
+export function defaultModelForProvider(provider: CliProvider): string {
+  return provider === "local-server"
+    ? "llama3.2"
+    : provider === "openai"
+      ? "gpt-5.4-mini"
+      : provider === "google"
+        ? "gemini-2.5-flash"
+        : provider === "groq"
+          ? "llama-3.3-70b-versatile"
+          : provider === "deepseek"
+            ? "deepseek-chat"
+            : "claude-sonnet-4-6";
 }
 
 export function printBanner(opts: {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -5,7 +5,14 @@ import { connectMcpServers } from "@motebit/mcp-client";
 import { admitModelForProvider } from "./model-admission.js";
 import { createSolanaWalletRail } from "@motebit/wallet-solana";
 import { preflightGrant, renderPreflight } from "./grant-preflight.js";
-import { parseCliArgs, printHelp, printVersion, printBanner, trimHistory } from "./args.js";
+import {
+  parseCliArgs,
+  printHelp,
+  printVersion,
+  printBanner,
+  trimHistory,
+  defaultModelForProvider,
+} from "./args.js";
 import type { CliConfig } from "./args.js";
 import { loadFullConfig, extractPersonality, persistMotebitPublicKeys } from "./config.js";
 import {
@@ -466,6 +473,15 @@ async function main(): Promise<void> {
     const validProviders = ["anthropic", "openai", "google", "local-server", "proxy"] as const;
     if (validProviders.includes(personalityConfig.default_provider)) {
       config.provider = personalityConfig.default_provider;
+      // An implicit model FOLLOWS the provider (2026-07-31 live find): the
+      // parse-time default was derived from the parse-time provider, so a
+      // persisted default_provider flip left the OLD provider's default on
+      // config.model — bare `motebit` rendered `local-server ·
+      // claude-sonnet-4-6`, the illegal pairing minted by the fallback
+      // path itself. An explicit --model is the user's word and stays.
+      if (!config.modelExplicit) {
+        config.model = defaultModelForProvider(config.provider);
+      }
     }
   }
   if (
@@ -480,10 +496,13 @@ async function main(): Promise<void> {
     // check also refuses a hosted-vendor id on local-server (#471: a bare
     // launch with a persisted claude-* default 404'd against ollama — the
     // sdk primitive is deliberately permissive there, the affordance isn't).
-    // The per-provider parse-time default already sits on config.model.
     if (admitModelForProvider(config.provider, personalityConfig.default_model).admissible) {
       config.model = personalityConfig.default_model;
     } else {
+      // The yield target is DERIVED, never trusted: config.model can carry
+      // another provider's default across a provider flip (the live find
+      // above) — re-derive so the fallback is admissible by construction.
+      config.model = defaultModelForProvider(config.provider);
       console.log(
         dim(
           `  [config default_model "${personalityConfig.default_model}" belongs to another provider; using ${config.model} for ${config.provider}]`,


### PR DESCRIPTION
Found live on the founder's **first 1.11.2 launch** (minute one of the live pass): bare `motebit` rendered `local-server · claude-sonnet-4-6` — the exact illegal pairing the #471 admission exists to prevent, minted by the heal's own fallback path.

**Root cause** — config-resolution ordering: `config.json` persists `default_provider: local-server`, but the parse-time model default derives from the *parse-time* provider (`anthropic` → `claude-sonnet-4-6`). The persisted provider flips after parsing; the model doesn't follow; the #488 admission yield then trusts `config.model` residue as its fallback and prints it as truth.

**Fix**:
- `CliConfig.modelExplicit` — distinguishes the user's word (`--model`) from a derived default. Explicit is never silently swapped; implicit always follows.
- The `default_provider` override re-derives an implicit model via `defaultModelForProvider` (the per-provider chain, extracted from the parse path and exported).
- The admission yield derives its fallback the same way — never reads residue.

**Invariant test**: `admitModelForProvider(p, defaultModelForProvider(p)).admissible` for every provider — the derived pair is legal by construction, so this whole class (fallback minting a foreign pairing) is closed, not just this instance. Plus `modelExplicit` parse coverage. CLI suite 392 green.

With #495 (update nudge), this is the natural off-cycle 1.11.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)