### PR TITLE
feat(sdk,cli,gates): 2026 local-model defaults + review-by dates — defaults as perishable inventory

### DIFF
--- a/.changeset/model-defaults-2026-cli.md
+++ b/.changeset/model-defaults-2026-cli.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+The CLI's model defaults now consume the sdk registry as single source (`defaultModelForProvider` restated literals; a refresh in one place drifted the other), so the local-server first-run default becomes `qwen3` — a 2026 tool-capable model instead of a 2024 3B one. `/model` gains `qwen3` and `gpt-oss` aliases; refusal teach lines name the current default.

--- a/.changeset/model-defaults-2026.md
+++ b/.changeset/model-defaults-2026.md
@@ -1,0 +1,5 @@
+---
+"@motebit/sdk": minor
+---
+
+The local model registry catches up to 2026: `LOCAL_SERVER_SUGGESTED_MODELS` refreshes from its all-2024 table (`llama3.2`, `gemma2`, `phi3`, `qwen2`…) to the current families (`qwen3`, `gpt-oss`, `gemma3`, `llama4`, `phi4-mini`, `deepseek-r1`, `mistral-small3.2`), and `DEFAULT_LOCAL_SERVER_MODEL` moves `llama3.2` → `qwen3`. Two vendor-hint misroutes fixed (both open-weights families the prefix heuristics sent to hosted-API refusals: `gpt-oss` → openai, `deepseek-r1` → deepseek), locked by a new admissibility invariant over the whole suggested table. New export `MODEL_DEFAULT_REVIEW_BY`: every `DEFAULT_*_MODEL` carries a review-by date — defaults as perishable inventory; the scheduled drift gate goes red past a lapsed date, and the fix is a deliberate human review, never an auto-bump.

--- a/apps/cli/src/__tests__/index.test.ts
+++ b/apps/cli/src/__tests__/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { DEFAULT_LOCAL_SERVER_MODEL } from "@motebit/sdk";
 import {
   parseCliArgs,
   printHelp,
@@ -28,14 +29,14 @@ describe("parseCliArgs", () => {
   it("parses --provider local-server with default model", () => {
     const config = parseCliArgs(["--provider", "local-server"]);
     expect(config.provider).toBe("local-server");
-    expect(config.model).toBe("llama3.2");
+    expect(config.model).toBe(DEFAULT_LOCAL_SERVER_MODEL);
   });
 
   it("accepts --provider ollama as an ergonomic alias for local-server", () => {
     const config = parseCliArgs(["--provider", "ollama"]);
     // Internal representation is always the vendor-agnostic name.
     expect(config.provider).toBe("local-server");
-    expect(config.model).toBe("llama3.2");
+    expect(config.model).toBe(DEFAULT_LOCAL_SERVER_MODEL);
   });
 
   it("--model overrides provider default", () => {

--- a/apps/cli/src/__tests__/model-admission.test.ts
+++ b/apps/cli/src/__tests__/model-admission.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { admitModelForProvider } from "../model-admission.js";
 import { defaultModelForProvider } from "../args.js";
+import { LOCAL_SERVER_SUGGESTED_MODELS } from "@motebit/sdk";
 
 describe("admitModelForProvider — the provider+model pair gate (#471)", () => {
   it("refuses a hosted Claude id on local-server (witnessed direction 2)", () => {
@@ -27,6 +28,15 @@ describe("admitModelForProvider — the provider+model pair gate (#471)", () => 
     expect(admitModelForProvider("openai", "gpt-5.4").admissible).toBe(true);
     expect(admitModelForProvider("local-server", "llama3.2").admissible).toBe(true);
     expect(admitModelForProvider("local-server", "qwen2.5:7b").admissible).toBe(true);
+    // gpt-oss is OpenAI's OPEN-WEIGHTS local family — the `gpt-` prefix must
+    // not misroute it to the hosted-API refusal (2026-07-31 defaults refresh).
+    expect(admitModelForProvider("local-server", "gpt-oss:20b").admissible).toBe(true);
+  });
+
+  it("every suggested local model is admissible on local-server — the dropdown can never offer a refusal", () => {
+    for (const m of LOCAL_SERVER_SUGGESTED_MODELS) {
+      expect(admitModelForProvider("local-server", m).admissible, m).toBe(true);
+    }
   });
 
   it("stays permissive on unknown ids — registry lag must not brick a switch", () => {

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -1,6 +1,14 @@
 // --- CLI argument parsing, help, version, banner ---
 
 import { parseArgs } from "node:util";
+import {
+  DEFAULT_ANTHROPIC_MODEL,
+  DEFAULT_DEEPSEEK_MODEL,
+  DEFAULT_GOOGLE_MODEL,
+  DEFAULT_GROQ_MODEL,
+  DEFAULT_LOCAL_SERVER_MODEL,
+  DEFAULT_OPENAI_MODEL,
+} from "@motebit/sdk";
 import { VERSION } from "./config.js";
 import { bold, dim, cyan, green, command } from "./colors.js";
 
@@ -576,16 +584,16 @@ export function printVersion(): void {
  */
 export function defaultModelForProvider(provider: CliProvider): string {
   return provider === "local-server"
-    ? "llama3.2"
+    ? DEFAULT_LOCAL_SERVER_MODEL
     : provider === "openai"
-      ? "gpt-5.4-mini"
+      ? DEFAULT_OPENAI_MODEL
       : provider === "google"
-        ? "gemini-2.5-flash"
+        ? DEFAULT_GOOGLE_MODEL
         : provider === "groq"
-          ? "llama-3.3-70b-versatile"
+          ? DEFAULT_GROQ_MODEL
           : provider === "deepseek"
-            ? "deepseek-chat"
-            : "claude-sonnet-4-6";
+            ? DEFAULT_DEEPSEEK_MODEL
+            : DEFAULT_ANTHROPIC_MODEL;
 }
 
 export function printBanner(opts: {

--- a/apps/cli/src/model-admission.ts
+++ b/apps/cli/src/model-admission.ts
@@ -11,7 +11,7 @@
  * admissible — registry lag must never brick a switch.
  */
 
-import { modelVendorHint, providerAcceptsModel } from "@motebit/sdk";
+import { DEFAULT_LOCAL_SERVER_MODEL, modelVendorHint, providerAcceptsModel } from "@motebit/sdk";
 
 /** Vendors whose models are served by a hosted API, never a local server. */
 const HOSTED_VENDORS = new Set(["anthropic", "openai", "google", "deepseek"]);
@@ -39,8 +39,8 @@ export function admitModelForProvider(provider: string, model: string): ModelAdm
       teach:
         `${model} is a hosted ${hint} model — a local server can't serve it. ` +
         (flag != null
-          ? `Restart with --provider ${flag}, or pick a local model (e.g. /model llama3.2).`
-          : `Pick a local model instead (e.g. /model llama3.2).`),
+          ? `Restart with --provider ${flag}, or pick a local model (e.g. /model ${DEFAULT_LOCAL_SERVER_MODEL}).`
+          : `Pick a local model instead (e.g. /model ${DEFAULT_LOCAL_SERVER_MODEL}).`),
     };
   }
 

--- a/apps/cli/src/slash-commands.ts
+++ b/apps/cli/src/slash-commands.ts
@@ -571,7 +571,9 @@ export async function handleSlashCommand(
         "gpt-5.4-mini": "gpt-5.4-mini",
         "gpt-5.4-nano": "gpt-5.4-nano",
         o3: "o3",
-        "llama3.2": "llama3.2",
+        qwen3: "qwen3",
+        "gpt-oss": "gpt-oss",
+        "llama3.2": "llama3.2", // legacy alias — still resolvable, no longer suggested
         mistral: "mistral",
       };
 

--- a/apps/desktop/src/__tests__/index.test.ts
+++ b/apps/desktop/src/__tests__/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { DEFAULT_LOCAL_SERVER_MODEL } from "@motebit/sdk";
 import {
   DesktopApp,
   createTauriStorage,
@@ -460,7 +461,7 @@ describe("DesktopApp.currentModel", () => {
   it("returns the model after ollama initAI", async () => {
     app = new DesktopApp();
     await app.initAI({ provider: "local-server", isTauri: false });
-    expect(app.currentModel).toBe("llama3.2");
+    expect(app.currentModel).toBe(DEFAULT_LOCAL_SERVER_MODEL);
   });
 
   it("returns custom model when specified", async () => {
@@ -513,7 +514,7 @@ describe("DesktopApp.setModel", () => {
   it("switches model in-place for ollama", async () => {
     app = new DesktopApp();
     await app.initAI({ provider: "local-server", isTauri: false });
-    expect(app.currentModel).toBe("llama3.2");
+    expect(app.currentModel).toBe(DEFAULT_LOCAL_SERVER_MODEL);
     app.setModel("mistral");
     expect(app.currentModel).toBe("mistral");
   });

--- a/apps/docs/content/docs/apps/configuration.mdx
+++ b/apps/docs/content/docs/apps/configuration.mdx
@@ -82,7 +82,7 @@ ollama pull mistral
 ollama pull codellama
 ```
 
-Set `default_provider: "ollama"` and `default_model: "llama3.2"` in config, or use the CLI flag `--provider ollama --model llama3.2`.
+Set `default_provider: "ollama"` and `default_model: "qwen3"` in config, or use the CLI flag `--provider ollama --model qwen3`.
 
 Ollama runs on `http://localhost:11434` by default.
 

--- a/apps/docs/content/docs/apps/desktop.mdx
+++ b/apps/docs/content/docs/apps/desktop.mdx
@@ -36,7 +36,7 @@ Open settings (gear icon, top right) to configure your LLM provider:
 
 | Provider | Setup |
 |---|---|
-| **Ollama** (default) | Install [Ollama](https://ollama.ai), pull a model (`ollama pull llama3.2`), and select "Ollama" in settings |
+| **Ollama** (default) | Install [Ollama](https://ollama.ai), pull a model (`ollama pull qwen3`), and select "Ollama" in settings |
 | **Anthropic** | Enter your API key in settings. Key is stored in the OS keyring, never on disk. |
 
 Set the model name in the **Model** field. Examples: `llama3.2`, `claude-sonnet-4-6`.

--- a/apps/docs/content/docs/apps/mobile.mdx
+++ b/apps/docs/content/docs/apps/mobile.mdx
@@ -27,7 +27,7 @@ Open settings (gear icon, top right) to configure your LLM:
 | **Anthropic** | Enter your API key. Stored in the device keychain, never on disk. |
 | **Hybrid** | Uses Anthropic as primary, falls back to Ollama on failure. Requires both an API key and an Ollama endpoint. |
 
-Set the model name in the **Model** field. Default: `llama3.2`.
+Set the model name in the **Model** field. Default: `qwen3`.
 
 ## Voice input
 

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -5673,7 +5673,7 @@ Open settings (gear icon, top right) to configure your LLM provider:
 
 | Provider | Setup |
 |---|---|
-| **Ollama** (default) | Install [Ollama](https://ollama.ai), pull a model (`ollama pull llama3.2`), and select "Ollama" in settings |
+| **Ollama** (default) | Install [Ollama](https://ollama.ai), pull a model (`ollama pull qwen3`), and select "Ollama" in settings |
 | **Anthropic** | Enter your API key in settings. Key is stored in the OS keyring, never on disk. |
 
 Set the model name in the **Model** field. Examples: `llama3.2`, `claude-sonnet-4-6`.
@@ -5763,7 +5763,7 @@ Open settings (gear icon, top right) to configure your LLM:
 | **Anthropic** | Enter your API key. Stored in the device keychain, never on disk. |
 | **Hybrid** | Uses Anthropic as primary, falls back to Ollama on failure. Requires both an API key and an Ollama endpoint. |
 
-Set the model name in the **Model** field. Default: `llama3.2`.
+Set the model name in the **Model** field. Default: `qwen3`.
 
 ## Voice input
 
@@ -6266,7 +6266,7 @@ ollama pull mistral
 ollama pull codellama
 ```
 
-Set `default_provider: "ollama"` and `default_model: "llama3.2"` in config, or use the CLI flag `--provider ollama --model llama3.2`.
+Set `default_provider: "ollama"` and `default_model: "qwen3"` in config, or use the CLI flag `--provider ollama --model qwen3`.
 
 Ollama runs on `http://localhost:11434` by default.
 

--- a/apps/mobile/src/__tests__/mobile-app.test.ts
+++ b/apps/mobile/src/__tests__/mobile-app.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { DEFAULT_LOCAL_SERVER_MODEL } from "@motebit/sdk";
 
 // === Module Mocks ===
 
@@ -356,9 +357,9 @@ describe("MobileApp.initAI", () => {
     expect(app.currentModel).toBe("mistral");
   });
 
-  it("defaults to llama3.2 for local-server", async () => {
+  it("defaults to the sdk local-server default", async () => {
     await app.initAI({ provider: "local-server" });
-    expect(app.currentModel).toBe("llama3.2");
+    expect(app.currentModel).toBe(DEFAULT_LOCAL_SERVER_MODEL);
   });
 
   it("defaults to claude-sonnet for anthropic", async () => {
@@ -387,7 +388,7 @@ describe("MobileApp.settings", () => {
   it("returns defaults when no settings stored", async () => {
     const settings = await app.loadSettings();
     expect(settings.provider).toBe("local-server");
-    expect(settings.model).toBe("llama3.2");
+    expect(settings.model).toBe(DEFAULT_LOCAL_SERVER_MODEL);
     expect(settings.appearance.colorPreset).toBe("moonlight");
     expect(settings.approvalPreset).toBe("balanced");
   });

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -274,13 +274,13 @@ export const DEFAULT_GOVERNANCE_CONFIG: GovernanceConfig;
 export const DEFAULT_GROQ_MODEL = "llama-3.3-70b-versatile";
 
 // @public
-export const DEFAULT_LOCAL_SERVER_MODEL = "llama3.2";
+export const DEFAULT_LOCAL_SERVER_MODEL = "qwen3";
 
 // @public
 export const DEFAULT_MOTEBIT_CLOUD_URL = "https://api.motebit.com";
 
 // @public
-export const DEFAULT_OLLAMA_MODEL = "llama3.2";
+export const DEFAULT_OLLAMA_MODEL = "qwen3";
 
 // @public
 export const DEFAULT_OPENAI_MODEL = "gpt-5.4-mini";
@@ -462,7 +462,7 @@ export interface LightingSpec {
 }
 
 // @public
-export const LOCAL_SERVER_SUGGESTED_MODELS: readonly ["llama3.2", "llama3.1", "llama3", "mistral", "codellama", "gemma2", "phi3", "qwen2"];
+export const LOCAL_SERVER_SUGGESTED_MODELS: readonly ["qwen3", "gpt-oss", "gemma3", "llama4", "phi4-mini", "deepseek-r1", "mistral-small3.2"];
 
 // @public (undocumented)
 export type LocalServerSuggestedModel = (typeof LOCAL_SERVER_SUGGESTED_MODELS)[number];
@@ -587,6 +587,9 @@ export interface MlxProviderSpec {
 }
 
 // @public
+export const MODEL_DEFAULT_REVIEW_BY: Record<string, string>;
+
+// @public
 export function modelVendorHint(model: string): "anthropic" | "openai" | "google" | "deepseek" | "groq" | "local" | "unknown";
 
 // @public
@@ -638,7 +641,7 @@ export interface OklchColor {
 export function oklchToRgb(input: OklchColor): [number, number, number];
 
 // @public @deprecated (undocumented)
-export const OLLAMA_SUGGESTED_MODELS: readonly ["llama3.2", "llama3.1", "llama3", "mistral", "codellama", "gemma2", "phi3", "qwen2"];
+export const OLLAMA_SUGGESTED_MODELS: readonly ["qwen3", "gpt-oss", "gemma3", "llama4", "phi4-mini", "deepseek-r1", "mistral-small3.2"];
 
 // @public @deprecated (undocumented)
 export type OllamaSuggestedModel = LocalServerSuggestedModel;

--- a/packages/sdk/src/__tests__/model-coherence.test.ts
+++ b/packages/sdk/src/__tests__/model-coherence.test.ts
@@ -7,7 +7,7 @@
  * ids stay permissive so new model releases never brick startup.
  */
 import { describe, it, expect } from "vitest";
-import { modelVendorHint, providerAcceptsModel } from "../models.js";
+import { modelVendorHint, providerAcceptsModel, LOCAL_SERVER_SUGGESTED_MODELS } from "../models.js";
 
 describe("modelVendorHint", () => {
   it("attributes registry members and naming signatures", () => {
@@ -45,5 +45,22 @@ describe("providerAcceptsModel — refuses only KNOWN cross-vendor mismatches", 
   it("groq serves open-family models", () => {
     expect(providerAcceptsModel("groq", "llama-3.3-70b-versatile")).toBe(true);
     expect(providerAcceptsModel("groq", "claude-sonnet-4-6")).toBe(false);
+  });
+});
+
+describe("gpt-oss is the open-weights LOCAL family, never the hosted OpenAI API (2026-07-31)", () => {
+  it("vendor hint is local for every gpt-oss form", () => {
+    expect(modelVendorHint("gpt-oss")).toBe("local");
+    expect(modelVendorHint("gpt-oss:20b")).toBe("local");
+    expect(modelVendorHint("gpt-oss:120b")).toBe("local");
+    // The hosted family is untouched by the carve-out
+    expect(modelVendorHint("gpt-5.4")).toBe("openai");
+    expect(modelVendorHint("gpt-5.4-mini")).toBe("openai");
+  });
+
+  it("local-server serves its whole suggested table", () => {
+    for (const m of LOCAL_SERVER_SUGGESTED_MODELS) {
+      expect(providerAcceptsModel("local-server", m), m).toBe(true);
+    }
   });
 });

--- a/packages/sdk/src/models.ts
+++ b/packages/sdk/src/models.ts
@@ -85,14 +85,13 @@ export const GROQ_MODELS = ["llama-3.3-70b-versatile", "openai/gpt-oss-120b"] as
  * the safe defaults to surface first.
  */
 export const LOCAL_SERVER_SUGGESTED_MODELS = [
-  "llama3.2",
-  "llama3.1",
-  "llama3",
-  "mistral",
-  "codellama",
-  "gemma2",
-  "phi3",
-  "qwen2",
+  "qwen3", // balanced all-rounder, tool-capable — the first-run default
+  "gpt-oss", // OpenAI open-weights — best small tool-use class (~16GB)
+  "gemma3", // Google open family
+  "llama4", // Meta current family
+  "phi4-mini", // minimal-hardware tier (entry laptops, iGPU)
+  "deepseek-r1", // reasoning-class open weights
+  "mistral-small3.2", // Mistral current small
 ] as const;
 
 /**
@@ -145,8 +144,13 @@ export const DEFAULT_DEEPSEEK_MODEL = "deepseek-chat";
  */
 export const DEFAULT_GROQ_MODEL = "llama-3.3-70b-versatile";
 
-/** Default Ollama model — used as the `local-server` default too. */
-export const DEFAULT_OLLAMA_MODEL = "llama3.2";
+/** Default Ollama model — used as the `local-server` default too.
+ * 2026-07-31 refresh: `llama3.2` (Sept 2024, 3B) was the witnessed weak-model
+ * floor — safe under the governance stack but not useful (fabricated a money
+ * proposal from noise). `qwen3` is the current balanced, tool-capable local
+ * family. A default can be old; it can never be UNEXAMINED — see
+ * MODEL_DEFAULT_REVIEW_BY below. */
+export const DEFAULT_OLLAMA_MODEL = "qwen3";
 
 /**
  * Canonical default model for the on-device `local-server` backend.
@@ -160,6 +164,27 @@ export const DEFAULT_LOCAL_SERVER_MODEL = DEFAULT_OLLAMA_MODEL;
 
 /** Default proxy model (used when no model is specified). */
 export const DEFAULT_PROXY_MODEL = "claude-sonnet-4-6";
+
+/**
+ * Review-by dates for the DEFAULT_*_MODEL constants — defaults as
+ * perishable inventory with a printed expiry. Model half-life is months
+ * now; a default frozen at authoring time ships an old brain in a new
+ * body without anyone deciding that. The rule (coverage-graduation's
+ * shape applied to intelligence): a default can be old — behind-on-purpose
+ * is a product choice — but it can never be UNEXAMINED. The scheduled
+ * external gate (`check-model-catalog-drift`) goes red past a date with a
+ * repair naming this table; the fix is a DELIBERATE human review — bump
+ * the date with or without a model change. The gate never bumps a model.
+ */
+export const MODEL_DEFAULT_REVIEW_BY: Record<string, string> = {
+  anthropic: "2026-10-31",
+  openai: "2026-10-31",
+  google: "2026-10-31",
+  deepseek: "2026-10-31",
+  groq: "2026-10-31",
+  "local-server": "2026-10-31",
+  proxy: "2026-10-31",
+};
 
 // === Type Helpers ===
 
@@ -201,8 +226,16 @@ export function modelVendorHint(
   if ((DEEPSEEK_MODELS as readonly string[]).includes(m)) return "deepseek";
   if ((GROQ_MODELS as readonly string[]).includes(m)) return "groq";
   if (m.startsWith("claude")) return "anthropic";
+  // gpt-oss is OpenAI's OPEN-WEIGHTS family — local-served (ollama/LM
+  // Studio/Groq), never the hosted API. Must precede the `gpt-` branch or
+  // the local-server admission gate refuses its own suggested model.
+  if (m.startsWith("gpt-oss")) return "local";
   if (m.startsWith("gpt-") || /^o[0-9]/.test(m)) return "openai";
   if (m.startsWith("gemini")) return "google";
+  // deepseek-r1 is the OPEN-WEIGHTS reasoning family (ollama tag) — the
+  // hosted API ids are deepseek-chat / deepseek-reasoner. Caught by the
+  // suggested-table admissibility invariant on its first run (2026-07-31).
+  if (m.startsWith("deepseek-r1")) return "local";
   if (m.startsWith("deepseek")) return "deepseek";
   // Ollama-style tags and the common local families.
   if (m.includes(":") || /^(llama|mistral|qwen|phi|gemma|smollm)/.test(m)) return "local";

--- a/scripts/check-docs-default-models.ts
+++ b/scripts/check-docs-default-models.ts
@@ -16,8 +16,8 @@
  *   For every backtick-anchored model-literal that **looks like a
  *   default-context reference** in any in-scope doc, the literal must
  *   match the canonical default for that provider as derived from
- *   `apps/cli/src/args.ts` (the `defaultModel` ternary chain at the
- *   top of `parseCliArgs`).
+ *   `packages/sdk/src/models.ts` (`DEFAULT_ANTHROPIC_MODEL`, the
+ *   registry home the CLI itself consumes).
  *
  * Canonical extraction:
  *
@@ -30,9 +30,13 @@
  *     "claude-sonnet-4-6"
  *
  *   Each branch maps a provider key to its default model. The gate
- *   parses this chain (regex, anchored to the local `defaultModel`
- *   constant) so a future bump to e.g. `claude-sonnet-5-1` only
- *   requires editing args.ts; the gate auto-follows.
+ *   parses this chain (regex, anchored to
+ *   `DEFAULT_ANTHROPIC_MODEL`) so a future bump to e.g.
+ *   `claude-sonnet-5-1` only requires editing models.ts; the gate
+ *   auto-follows. (2026-07-31: extraction moved from the CLI's
+ *   `defaultModel` ternary to the sdk registry when the ternary was
+ *   refactored to consume the sdk constants — the canonical followed
+ *   the single source one level down.)
  *
  * Provider families gated:
  *
@@ -73,7 +77,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..");
 
-const ARGS_TS = path.join(REPO_ROOT, "apps/cli/src/args.ts");
+const MODELS_TS = path.join(REPO_ROOT, "packages/sdk/src/models.ts");
 const DOCS_ROOT = path.join(REPO_ROOT, "apps/docs/content");
 
 const SKIP_DIRS = new Set([
@@ -115,19 +119,20 @@ function findFiles(dir: string, predicate: (p: string) => boolean): string[] {
 }
 
 /**
- * Extract the canonical Claude default model from `apps/cli/src/args.ts`.
- * Looks for the literal default in the `defaultModel` constant — the
- * fall-through (Anthropic) branch of the per-provider ternary chain.
+ * Extract the canonical Claude default model from
+ * `packages/sdk/src/models.ts` — `DEFAULT_ANTHROPIC_MODEL`, the registry
+ * home. (2026-07-31: the CLI's `defaultModel` ternary this gate used to
+ * parse was refactored to consume the sdk constants — the canonical moved
+ * one level down to the true single source, and the gate follows.)
  *
- * If the dispatcher pattern changes (e.g., the constant is renamed or
- * moved into a registry), this regex needs to follow. The inline
- * doctrine note above tells the next maintainer.
+ * If the constant is renamed or the default leaves the sonnet family,
+ * this regex needs to follow. The inline doctrine note above tells the
+ * next maintainer.
  */
 function loadCanonicalClaudeModel(): string | null {
-  const text = fs.readFileSync(ARGS_TS, "utf8");
-  // Match the closing fall-through of the defaultModel ternary chain:
-  // `: "claude-sonnet-N-M[-DDDDDDDD]";`
-  const pattern = /defaultModel\s*=[\s\S]*?:\s*"(claude-sonnet-\d+-\d+(?:-\d+)?)"\s*;/m;
+  const text = fs.readFileSync(MODELS_TS, "utf8");
+  // `export const DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-N-M[-DDDDDDDD]";`
+  const pattern = /DEFAULT_ANTHROPIC_MODEL\s*=\s*"(claude-sonnet-\d+-\d+(?:-\d+)?)"\s*;/m;
   const m = text.match(pattern);
   return m ? m[1]! : null;
 }
@@ -182,13 +187,13 @@ function scanDoc(doc: string, canonical: string): Finding[] {
 
 function main(): void {
   console.log(
-    "▸ check-docs-default-models — drift defense against stale default-model literals in docs (e.g. `claude-sonnet-4-5-20250929` after the production default moved to `claude-sonnet-4-6`). Extracts the canonical default from `apps/cli/src/args.ts` `defaultModel` ternary and validates every default-context literal in scope matches.",
+    "▸ check-docs-default-models — drift defense against stale default-model literals in docs (e.g. `claude-sonnet-4-5-20250929` after the production default moved to `claude-sonnet-4-6`). Extracts the canonical default from `packages/sdk/src/models.ts` DEFAULT_ANTHROPIC_MODEL and validates every default-context literal in scope matches.",
   );
 
   const canonical = loadCanonicalClaudeModel();
   if (!canonical) {
     console.error(
-      "✗ check-docs-default-models: failed to extract the canonical Claude default model from apps/cli/src/args.ts — the `defaultModel` ternary pattern may have changed; update the regex in loadCanonicalClaudeModel.",
+      "✗ check-docs-default-models: failed to extract the canonical Claude default model from packages/sdk/src/models.ts — the DEFAULT_ANTHROPIC_MODEL pattern may have changed; update the regex in loadCanonicalClaudeModel.",
     );
     process.exit(1);
   }
@@ -205,7 +210,7 @@ function main(): void {
 
   if (allFindings.length === 0) {
     console.log(
-      `✓ check-docs-default-models: ${docs.length} doc(s) scanned; every default-context Claude literal matches the canonical \`${canonical}\` from apps/cli/src/args.ts.`,
+      `✓ check-docs-default-models: ${docs.length} doc(s) scanned; every default-context Claude literal matches the canonical \`${canonical}\` from packages/sdk/src/models.ts.`,
     );
     return;
   }

--- a/scripts/check-model-catalog-drift.ts
+++ b/scripts/check-model-catalog-drift.ts
@@ -33,9 +33,64 @@
  * it skips politely.
  */
 
-import { ANTHROPIC_MODELS } from "@motebit/sdk";
+import {
+  ANTHROPIC_MODELS,
+  DEFAULT_ANTHROPIC_MODEL,
+  DEFAULT_DEEPSEEK_MODEL,
+  DEFAULT_GOOGLE_MODEL,
+  DEFAULT_GROQ_MODEL,
+  DEFAULT_LOCAL_SERVER_MODEL,
+  DEFAULT_OPENAI_MODEL,
+  DEFAULT_PROXY_MODEL,
+  MODEL_DEFAULT_REVIEW_BY,
+} from "@motebit/sdk";
 import { modelRejectsSamplingParams } from "@motebit/ai-core/browser";
 import { failWithRepair } from "./lib/gate-report.js";
+
+const DEFAULTS_BY_PROVIDER: Record<string, string> = {
+  anthropic: DEFAULT_ANTHROPIC_MODEL,
+  openai: DEFAULT_OPENAI_MODEL,
+  google: DEFAULT_GOOGLE_MODEL,
+  deepseek: DEFAULT_DEEPSEEK_MODEL,
+  groq: DEFAULT_GROQ_MODEL,
+  "local-server": DEFAULT_LOCAL_SERVER_MODEL,
+  proxy: DEFAULT_PROXY_MODEL,
+};
+
+/**
+ * Defaults as perishable inventory: every DEFAULT_*_MODEL carries a
+ * review-by date (MODEL_DEFAULT_REVIEW_BY). Past the date the gate goes
+ * red — the repair is a DELIBERATE human review, never an auto-bump
+ * (behind-on-purpose is a product choice; behind-unknowingly is the
+ * defect). Runs KEYLESS — this half needs no network, so a local
+ * `pnpm check-model-catalog-drift` exercises it too.
+ */
+function checkDefaultReviewDates(): void {
+  const today = new Date().toISOString().slice(0, 10);
+  const lapsed: string[] = [];
+  for (const [provider, reviewBy] of Object.entries(MODEL_DEFAULT_REVIEW_BY)) {
+    const current = DEFAULTS_BY_PROVIDER[provider] ?? "?";
+    if (today > reviewBy) {
+      lapsed.push(`${provider} — default "${current}" unreviewed since ${reviewBy}`);
+    } else {
+      console.log(
+        `check-model-catalog-drift: default ${provider}=${current} reviewed through ${reviewBy}`,
+      );
+    }
+  }
+  if (lapsed.length > 0) {
+    failWithRepair({
+      invariant:
+        "Every DEFAULT_*_MODEL carries an unexpired review-by date — a default can be old, never UNEXAMINED (model half-life is months).",
+      sites: lapsed,
+      canonical: "packages/sdk/src/models.ts",
+      fix:
+        "Review each lapsed DEFAULT_*_MODEL against the current model landscape, then bump its MODEL_DEFAULT_REVIEW_BY date in packages/sdk/src/models.ts deliberately — with or without a model change. " +
+        "Never auto-bump the model itself; behind-on-purpose is a product choice (#475).",
+      doctrine: "docs/doctrine/intelligence-pluggability-contract.md",
+    });
+  }
+}
 
 /** Families whose request shape is the LEGACY one (sampling params
  * accepted, budget_tokens thinking). A live id matching neither this nor
@@ -52,6 +107,9 @@ async function fetchLiveIds(apiKey: string): Promise<string[]> {
 }
 
 async function main(): Promise<void> {
+  // Keyless half first: default review-by dates (fails fast when lapsed).
+  checkDefaultReviewDates();
+
   const requireKey = process.argv.includes("--require-key");
   const apiKey = process.env.ANTHROPIC_API_KEY;
 


### PR DESCRIPTION
Born from the founder's question after the llama3.2 incident: *should the system metabolize model progress itself?* The whole local table was 2024 vintage, and a stale default ships an old brain in a new body without anyone deciding that.

**Part 1 — the refresh** (research-verified against the July 2026 local landscape):
- `LOCAL_SERVER_SUGGESTED_MODELS`: all-2024 table → current families (`qwen3`, `gpt-oss`, `gemma3`, `llama4`, `phi4-mini`, `deepseek-r1`, `mistral-small3.2`).
- `DEFAULT_LOCAL_SERVER_MODEL`: `llama3.2` → `qwen3` (balanced, tool-capable — the witnessed incident was a 3B 2024 model fabricating a money proposal; safe under governance, not useful).
- CLI consumes the sdk registry as **single source** (`defaultModelForProvider` restated literals; refreshing one place drifted the other).
- **Two vendor-hint misroutes fixed**: `gpt-oss` and `deepseek-r1` are open-weights local families the prefix heuristics sent to hosted-API refusals — the second was caught by the new invariant test (*every suggested local model admissible on local-server*) on its first run.

**Part 2 — the expiry system**:
- `MODEL_DEFAULT_REVIEW_BY` (sdk): every `DEFAULT_*_MODEL` carries a review-by date (all 2026-10-31 — quarterly). Coverage-graduation's shape applied to intelligence: a default can be old, never UNEXAMINED.
- `check-model-catalog-drift` grows a **keyless half** that prints the review-through table and goes red past a lapsed date; the repair is a deliberate human review — the gate never bumps a model (behind-on-purpose stays a choice, #475).

**The sibling cascade this triggered — every one caught mechanically before push**: `check-docs-default-models` fail-loud refused to extract from the refactored ternary (its canonical now reads `DEFAULT_ANTHROPIC_MODEL` in sdk — the gate followed the source one level down); three docs pages carried `llama3.2` as the default; `llms-full.txt` regenerated; mobile + desktop tests re-pinned the old default as literals — now asserting against `DEFAULT_LOCAL_SERVER_MODEL` itself, so the next refresh touches one file and zero tests. (Web's `llama3.2` is a stored-user-choice fixture, correctly untouched.)

sdk minor + motebit patch. Suites: sdk 145, cli 401, mobile 402, desktop 509, web 572, all 137 gates. Companion issue: #501 (capability-tiered tool admission).

🤖 Generated with [Claude Code](https://claude.com/claude-code)