### PR TITLE
fix(cli): retire the owned region on exit; /receipt accepts the id the render actually shows

### DIFF
--- a/.changeset/live-pass-polish-nits.md
+++ b/.changeset/live-pass-polish-nits.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+Two rendering nits witnessed in the 1.11.3 live pass. Exit lines no longer glue onto the mode row: `destroyTerminal()` now retires the owned bottom region (flushes the partial line and any in-flight input as history, clears the status/mode rows, parks the cursor on a fresh line) before shutdown output prints. `/receipt` is now usable from its own render: the rendered receipt shows a truncated task id, so the command accepts a unique prefix (a pasted trailing "…" is stripped), lists candidates on an ambiguous prefix, and with no argument re-renders the session's latest receipt.

--- a/apps/cli/src/__tests__/invoke-command.test.ts
+++ b/apps/cli/src/__tests__/invoke-command.test.ts
@@ -201,6 +201,56 @@ describe("handleReceiptCommand", () => {
     expect(joined).toContain(receipt.task_id.slice(0, 12));
     expect(joined).toContain("verified");
   });
+
+  it("resolves a unique prefix — the render truncates ids, so the visible chars must work", async () => {
+    const { receipt } = await makeSignedReceipt({
+      task_id: "c9c302ee-8cf4-4a51-9d33-000000000001",
+    });
+    archiveReceipt(receipt);
+
+    const out: string[] = [];
+    // Exactly what the user can read off the rendered receipt (shortHash = 12 chars).
+    await handleReceiptCommand("c9c302ee-8cf", { out: (line) => out.push(line) });
+    expect(out.join("\n")).toContain("verified");
+  });
+
+  it("strips a trailing ellipsis pasted from the rendered id", async () => {
+    const { receipt } = await makeSignedReceipt({
+      task_id: "c9c302ee-8cf4-4a51-9d33-000000000001",
+    });
+    archiveReceipt(receipt);
+
+    const out: string[] = [];
+    await handleReceiptCommand("c9c302ee-8cf…", { out: (line) => out.push(line) });
+    expect(out.join("\n")).toContain("verified");
+  });
+
+  it("lists candidates on an ambiguous prefix instead of guessing", async () => {
+    const a = await makeSignedReceipt({ task_id: "aaaa-1111" });
+    const b = await makeSignedReceipt({ task_id: "aaaa-2222" });
+    archiveReceipt(a.receipt);
+    archiveReceipt(b.receipt);
+
+    const out: string[] = [];
+    await handleReceiptCommand("aaaa", { out: (line) => out.push(line) });
+    const joined = out.join("\n");
+    expect(joined).toContain("matches 2 receipts");
+    expect(joined).toContain("aaaa-1111");
+    expect(joined).toContain("aaaa-2222");
+  });
+
+  it("no-arg re-renders the latest receipt of the session", async () => {
+    const first = await makeSignedReceipt({ task_id: "task-first" });
+    const second = await makeSignedReceipt({ task_id: "task-second" });
+    archiveReceipt(first.receipt);
+    archiveReceipt(second.receipt);
+
+    const out: string[] = [];
+    await handleReceiptCommand("", { out: (line) => out.push(line) });
+    const joined = out.join("\n");
+    expect(joined).toContain("task-second");
+    expect(joined).not.toContain("task-first");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/cli/src/__tests__/terminal-render.test.ts
+++ b/apps/cli/src/__tests__/terminal-render.test.ts
@@ -330,4 +330,33 @@ describe("terminal renderer — owned bottom region", () => {
     r.handleEvent({ type: "paste", text: "XY" });
     expect(vt.screen()).toBe("you> aXYb");
   });
+
+  it("finalize clears the region so exit lines land on their own row (shutdown glue)", () => {
+    const { vt, r } = setup(60);
+    r.writeOutput("Goodbye!\n");
+    r.setModeRow("  ── llama3.2 · local-server");
+    void r.readInput("you> ");
+    r.finalize();
+    // The exit path writes directly to the terminal after finalize — the
+    // 2026-07-30 live pass witnessed it gluing onto the mode row.
+    vt.write("Synced on exit: pushed 0, pulled 0\n");
+    expect(vt.screen()).toBe("Goodbye!\nyou>\nSynced on exit: pushed 0, pulled 0");
+    expect(vt.screen()).not.toContain("local-serverSynced");
+  });
+
+  it("finalize preserves typed input as history instead of erasing it", () => {
+    const { vt, r } = setup(60);
+    void r.readInput("you> ");
+    type(r, "half-typed thought");
+    r.finalize();
+    vt.write("done\n");
+    expect(vt.screen()).toBe("you> half-typed thought\ndone");
+  });
+
+  it("finalize is idempotent and safe with nothing painted", () => {
+    const { vt, r } = setup(60);
+    r.finalize();
+    r.finalize();
+    expect(vt.screen()).toBe("");
+  });
 });

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -387,7 +387,10 @@ export const COMMANDS: CommandEntry[] = [
   { usage: "/proposal <id> [accept|reject|counter]", desc: "Respond to a proposal" },
   { usage: "/operator", desc: "Show operator mode status" },
   { usage: "/invoke <cap> <prompt>", desc: "Invoke a capability deterministically (no AI loop)" },
-  { usage: "/receipt <task-id>", desc: "Re-render an archived receipt (offline-verified)" },
+  {
+    usage: "/receipt [task-id-prefix]",
+    desc: "Re-render an archived receipt (offline-verified); no arg = latest",
+  },
   { usage: "/voice [on|off]", desc: "Toggle TTS voice output (opt-in, off by default)" },
   { usage: "/say <text>", desc: "Speak text via TTS (requires voice provider)" },
   { usage: "/skills", desc: "List installed skills with provenance badges" },

--- a/apps/cli/src/commands/invoke.ts
+++ b/apps/cli/src/commands/invoke.ts
@@ -14,7 +14,7 @@
 // immediately — closing the loop locally, no relay roundtrip needed for
 // verification.
 //
-// `/receipt <task-id>` re-renders an archived receipt. It does NOT invoke
+// `/receipt [task-id-prefix]` re-renders an archived receipt. It does NOT invoke
 // anything — it reads from the session archive, verifies the signature
 // offline, and prints. But it IS an affordance (user typed a specific
 // command), and category-error-wise it routes through the receipt subsystem,
@@ -22,7 +22,12 @@
 
 import type { MotebitRuntime, StreamChunk } from "@motebit/runtime";
 
-import { archiveReceipt, getArchivedReceipt, renderReceipt } from "../receipt.js";
+import {
+  archiveReceipt,
+  findArchivedReceipt,
+  latestArchivedReceipt,
+  renderReceipt,
+} from "../receipt.js";
 import { dim, error as errorColor, warn } from "../colors.js";
 import type { VoiceController } from "../voice.js";
 
@@ -68,7 +73,9 @@ export async function handleInvokeCommand(args: string, deps: InvokeCommandDeps)
 }
 
 /**
- * Handle `/receipt <task-id>` — re-render an archived receipt. Does not
+ * Handle `/receipt [task-id-prefix]` — re-render an archived receipt (no
+ * arg = the session's latest; a unique prefix of the rendered id works,
+ * since the render truncates). Does not
  * invoke a capability; it is a read of local state plus an offline verify.
  */
 export async function handleReceiptCommand(
@@ -77,14 +84,27 @@ export async function handleReceiptCommand(
 ): Promise<void> {
   const out = deps.out ?? ((s: string) => console.log(s));
   const taskId = args.trim();
+  let receipt;
   if (!taskId) {
-    out(errorColor("Usage: /receipt <task-id>"));
-    return;
-  }
-  const receipt = getArchivedReceipt(taskId);
-  if (!receipt) {
-    out(warn(`No archived receipt for task_id=${taskId}`));
-    return;
+    // The rendered receipt shows a truncated id, so the no-arg form is the
+    // common affordance: re-render the most recent receipt of the session.
+    receipt = latestArchivedReceipt();
+    if (!receipt) {
+      out(warn("No receipts archived this session. Usage: /receipt [task-id-prefix]"));
+      return;
+    }
+  } else {
+    const found = findArchivedReceipt(taskId);
+    if (found.kind === "ambiguous") {
+      out(warn(`Prefix "${taskId}" matches ${found.taskIds.length} receipts:`));
+      for (const id of found.taskIds) out(dim(`  ${id}`));
+      return;
+    }
+    if (found.kind === "miss") {
+      out(warn(`No archived receipt matches "${taskId}" this session.`));
+      return;
+    }
+    receipt = found.receipt;
   }
   // renderReceipt no longer emits its own blank bracket (#480) — spacing
   // belongs to the caller.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -728,13 +728,13 @@ async function main(): Promise<void> {
       runtimeRef,
     });
   } catch (err: unknown) {
+    destroyTerminal();
     console.error(
       `Runtime-host election failed: ${err instanceof Error ? err.message : String(err)}`,
     );
     console.error(
       "Another motebit process may be coordinating with an incompatible build. Stop it and retry.",
     );
-    destroyTerminal();
     process.exit(1);
   }
   if (election.role === "frontend") {
@@ -984,7 +984,10 @@ async function main(): Promise<void> {
   };
 
   process.on("SIGINT", () => {
-    console.log("\nGoodbye!");
+    // Retire the region before printing — otherwise "Goodbye!" glues onto
+    // the mode row and desyncs the clear math inside destroyTerminal.
+    destroyTerminal();
+    console.log("Goodbye!");
     void shutdown().then(() => process.exit(0));
   });
 

--- a/apps/cli/src/receipt.ts
+++ b/apps/cli/src/receipt.ts
@@ -48,6 +48,35 @@ export function getArchivedReceipt(taskId: string): ExecutionReceipt | undefined
   return ARCHIVE.get(taskId);
 }
 
+/**
+ * Resolve a full task_id OR a unique prefix to an archived receipt. The
+ * rendered receipt only ever shows a truncated id (`shortHash`, 12 chars +
+ * "…"), so `/receipt` must accept what the user can actually see and type.
+ * A trailing "…" from copy-pasting the rendered id is stripped.
+ */
+export function findArchivedReceipt(
+  idOrPrefix: string,
+):
+  | { kind: "hit"; receipt: ExecutionReceipt }
+  | { kind: "ambiguous"; taskIds: string[] }
+  | { kind: "miss" } {
+  const prefix = idOrPrefix.replace(/…$/, "");
+  if (prefix === "") return { kind: "miss" };
+  const exact = ARCHIVE.get(prefix);
+  if (exact) return { kind: "hit", receipt: exact };
+  const matches = [...ARCHIVE.keys()].filter((id) => id.startsWith(prefix));
+  if (matches.length === 1) return { kind: "hit", receipt: ARCHIVE.get(matches[0]!)! };
+  if (matches.length > 1) return { kind: "ambiguous", taskIds: matches };
+  return { kind: "miss" };
+}
+
+/** The most recently archived receipt this session, if any. */
+export function latestArchivedReceipt(): ExecutionReceipt | undefined {
+  let last: ExecutionReceipt | undefined;
+  for (const r of ARCHIVE.values()) last = r;
+  return last;
+}
+
 /** Clear the session archive. Used by tests. */
 export function clearReceiptArchive(): void {
   ARCHIVE.clear();

--- a/apps/cli/src/terminal.ts
+++ b/apps/cli/src/terminal.ts
@@ -125,6 +125,12 @@ export interface TerminalRenderer {
   repaint(): void;
   /** Abandon any active input (stdin closed / shutdown). */
   detach(): void;
+  /** Retire the owned region: flush any partial line and the in-flight
+   * input row into scrollback, clear the status/mode rows, park the cursor
+   * at a fresh line start. After this, plain console writes (exit-path
+   * lines like "Synced on exit") land on their own line instead of gluing
+   * onto the last region row. Idempotent. */
+  finalize(): void;
 }
 
 export function createTerminalRenderer(io: TerminalIO): TerminalRenderer {
@@ -324,7 +330,8 @@ export function createTerminalRenderer(io: TerminalIO): TerminalRenderer {
     if (result === "submit") {
       submit();
     } else if (result === "exit") {
-      io.write("\n");
+      // No direct io.write here — it would desync the painted-region
+      // tracking before finalize's clear math runs inside destroyTerminal.
       destroyTerminal();
       process.exit(0);
     } else {
@@ -364,6 +371,25 @@ export function createTerminalRenderer(io: TerminalIO): TerminalRenderer {
     }
   }
 
+  function finalize(): void {
+    let scrollback = "";
+    if (tail !== "") {
+      scrollback += tail + "\n";
+      tail = "";
+    }
+    if (inputActive) {
+      // Preserve whatever the user had typed as history instead of
+      // erasing it with the region.
+      scrollback += buildInputRow().row + "\n";
+      inputResolver = null;
+      inputRejecter = null;
+      inputActive = false;
+    }
+    statusRow = null;
+    modeRow = null;
+    commit(scrollback);
+  }
+
   return {
     writeOutput,
     writeLine,
@@ -374,6 +400,7 @@ export function createTerminalRenderer(io: TerminalIO): TerminalRenderer {
     handleEvent,
     repaint: () => commit(""),
     detach,
+    finalize,
   };
 }
 
@@ -665,6 +692,12 @@ export function initTerminal(): void {
 export function destroyTerminal(): void {
   if (!initialized) return;
   initialized = false;
+
+  // Retire the owned region first (clears the mode/status rows and parks
+  // the cursor on a fresh line) so exit-path console writes don't glue
+  // onto the last region row (witnessed 2026-07-30: mode row + "Synced on
+  // exit:" concatenated on one line).
+  renderer.finalize();
 
   process.stdin.removeListener("data", onStdinData);
   process.stdout.removeListener("resize", onResize);


### PR DESCRIPTION
Two rendering nits witnessed in the founder's 1.11.3 live pass (#480 close-out).

## Exit-line glue (witnessed: `── llama3.2 · local-serverSynced on exit: pushed 0, pulled 0`)

`destroyTerminal()` unhooked listeners but never retired the owned bottom region, leaving the cursor parked at the end of the mode row — every direct `console.log` on the exit path glued onto it. New `renderer.finalize()`: flushes the partial line and any in-flight input row into scrollback (typed text preserved as history, not erased), clears the status/mode rows, parks the cursor on a fresh line. `destroyTerminal()` calls it first; the two call sites that printed *before* destroying (SIGINT "Goodbye!", election-failure error) are reordered, and the renderer's own exit path drops a stray `io.write("\n")` that would have desynced the clear math.

## `/receipt` unusable from its own render

The receipt block only ever shows `shortHash()` truncated ids (`c9c302ee-8cf…`) while the archive lookup was exact `Map.get` — the full id is displayed nowhere, so the command could never be driven from what the user sees. `/receipt` now resolves a unique task-id prefix (a pasted trailing "…" is stripped), lists candidates on an ambiguous prefix, and with no argument re-renders the session's latest receipt. Usage strings updated to `/receipt [task-id-prefix]`.

## Tests

- Golden VT: literal replay of the shutdown glue (finalize → direct write lands on its own row), typed-input-preserved-as-history, idempotent/no-op finalize.
- `/receipt`: prefix hit with exactly the 12 visible chars, ellipsis strip, ambiguous listing, no-arg = latest.

Changeset: `motebit` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)