### PR TITLE
fix(policy,web): injection tag pattern requires a closing tag; web renders the designed sentence, not the regex

### DIFF
--- a/apps/web/src/ui/chat.ts
+++ b/apps/web/src/ui/chat.ts
@@ -935,9 +935,15 @@ export function initChat(ctx: WebContext, callbacks: ChatCallbacks): ChatAPI {
           }
 
           case "injection_warning": {
+            // Designed sentence (#499, sibling of the CLI's calm render):
+            // the raw detector patterns are gate-internals — they belong in
+            // the console for operators, never on the chat surface.
+            console.warn(
+              `[injection] tool "${chunk.tool_name}" matched: ${chunk.patterns.join(", ")}`,
+            );
             addMessage(
               "system",
-              `Injection warning from tool "${chunk.tool_name}": ${chunk.patterns.join(", ")}`,
+              `Content from "${chunk.tool_name}" contained text shaped like a prompt-injection attempt — treated as untrusted data, not instructions.`,
             );
             break;
           }

--- a/packages/policy/src/__tests__/sanitizer.test.ts
+++ b/packages/policy/src/__tests__/sanitizer.test.ts
@@ -25,6 +25,32 @@ describe("ContentSanitizer", () => {
       expect(result.directiveDensity).toBeDefined();
       expect(result.directiveDensity!).toBeLessThan(DIRECTIVE_DENSITY_THRESHOLD);
     });
+
+    // #499 — the tag pattern fires on tag SHAPES, not on prefixes.
+    // Witnessed live 2026-07-31: the open-prefix form flagged motebit's
+    // own CLI docs (and would flag any page about LLMs). These are the
+    // legitimate shapes that must pass.
+    it("does not flag TypeScript generics, JSX, or docs prose about prompts (#499)", () => {
+      const s = sanitizer();
+      const legit = [
+        "const templates: Array<PromptTemplate> = loadTemplates();",
+        "renders the <PromptInput> component with autosave",
+        "when load < system capacity, the queue drains normally",
+        "configure the model, then edit the file as documented",
+      ];
+      for (const text of legit) {
+        const result = s.sanitize(text, "docs");
+        expect(result.injectionDetected, text).toBe(false);
+      }
+    });
+
+    it("still flags the exact tag shapes, spaced and self-closing", () => {
+      const s = sanitizer();
+      for (const attack of ["<system>", "< system >", "<instructions/>", "<prompt >"]) {
+        const result = s.sanitize(`data ${attack} data`, "test");
+        expect(result.injectionDetected, attack).toBe(true);
+      }
+    });
   });
 
   describe("jailbreak pattern detection", () => {

--- a/packages/policy/src/sanitizer.ts
+++ b/packages/policy/src/sanitizer.ts
@@ -21,7 +21,15 @@ const INJECTION_PATTERNS: RegExp[] = [
   /\b(?:pretend|act\s+as\s+if|roleplay)\b/i,
   /\bdo\s+not\s+(?:follow|obey|listen)\b/i,
   /\b(?:override|bypass|ignore)\s+(?:safety|policy|rules|constraints)\b/i,
-  /<\s*(?:system|prompt|instruction)/i,
+  // Exact tag shape only (`<system>`, `< prompt >`, `<instructions/>`).
+  // The old open-prefix form (`<\s*(?:system|prompt|instruction)`) fired on
+  // TypeScript generics (`Array<PromptTemplate>`), JSX components, and any
+  // docs page whose prose puts these words after a `<` — witnessed live
+  // 2026-07-31 flagging motebit's own CLI docs (#499). An attack needs the
+  // tag to CLOSE to read as chat-template framing; attribute-carrying
+  // variants fall through to the directive-density and boundary layers
+  // (the [EXTERNAL_DATA] wrap is the defense — detection is signal).
+  /<\s*(?:system|prompt|instruction)s?\s*\/?>/i,
 
   // --- Chat template injection ---
   /<\|im_start\|>\s*system/i,


### PR DESCRIPTION
Closes #499. Witnessed live 2026-07-31: `read_url` on motebit's own CLI docs tripped the open-prefix pattern `<\s*(?:system|prompt|instruction)` — which also fires on TypeScript generics (`Array<PromptTemplate>`), JSX components, and any legitimate page about LLMs — and the web chat surface rendered the raw regex to the user.

## Two fixes, one canonical rule each

**Sanitizer (packages/policy)** — the tag pattern now requires the tag to CLOSE: `<system>`, `< prompt >`, `<instructions/>` still flag; prose, generics, and comparison operators don't. Attribute-carrying variants fall through to the directive-density and structural layers — the `[EXTERNAL_DATA]` wrap is the defense; detection is signal (the sanitizer flags, it never blocks — block-vs-flag was already right). Negative fixtures lock the witnessed legitimate shapes; positive fixtures lock the spaced and self-closing attack shapes.

**Web chat surface** — `injection_warning` renders one calm sentence ("contained text shaped like a prompt-injection attempt — treated as untrusted data, not instructions"); the matched patterns go to `console.warn` for operators. Sibling parity per the #485 designed-sentences rule: CLI, desktop, and mobile were already calm — web was the drifted sibling.

Policy 484 + web 572 tests green; no changesets (both packages private).

🤖 Generated with [Claude Code](https://claude.com/claude-code)