### PR TITLE
feat(sdk,runtime,cli): capability-tiered tool admission — minimal models are never offered money tools

### DIFF
--- a/.changeset/capability-tiered-tool-admission.md
+++ b/.changeset/capability-tiered-tool-admission.md
@@ -1,0 +1,5 @@
+---
+"motebit": minor
+---
+
+Capability-tiered tool admission (#501): a minimal-tier model (e.g. a 3B local model) is no longer offered money-moving tools by default — the runtime omits `R4_MONEY`-classified tools from the model-visible list and fail-closes execution, so the witnessed incident class (a weak model fabricating a real-money hire proposal from noise) becomes unrepresentable instead of merely caught by the approval gate. A rail-less `delegate_to_agent` (no wallet bound) stays available — the tool crosses the withholding line exactly when it can move money. Mid-session `/model` switches adjust exposure live. Sovereignty preserved: set `offer_money_tools_to_minimal_models: true` in `~/.motebit/config.json` to restore full exposure; the CLI says what's withheld in one dim line at launch and on `/model` switch, never mid-conversation. User-tap `/invoke` is unaffected (a tap is its own authorizer).

--- a/.changeset/model-capability-tier.md
+++ b/.changeset/model-capability-tier.md
@@ -1,0 +1,5 @@
+---
+"@motebit/sdk": minor
+---
+
+New capability-tier axis on the model registry: `modelCapabilityTier(model)` returns `"frontier" | "capable" | "minimal"` from family knowledge plus embedded parameter sizes (ollama `:NNb` tags and dash-form ids like `Llama-3.2-3B-Instruct…`), with `unknown → "capable"` so registry lag never lobotomizes a new model. The runtime keys money-tool exposure on it (#501); nothing here gates admission — a minimal model remains a legitimate sovereign choice.

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -96,6 +96,15 @@ export interface FullConfig {
    * (#428). Also set by `motebit restore` (holding the seed IS the backup).
    */
   seed_backed_up_at?: number;
+  /**
+   * Capability-tiered tool admission override (#501). Default (absent):
+   * a minimal-tier model (e.g. a 3B local model) is never OFFERED
+   * money-moving tools — the runtime omits them from the model-visible
+   * list. Set `true` to restore full exposure: sovereignty preserved,
+   * only the footgun default removed. A deliberate config field, not a
+   * flag — a per-launch flag invites cargo-culting into scripts.
+   */
+  offer_money_tools_to_minimal_models?: boolean;
   cli_encrypted_key?: {
     ciphertext: string; // hex
     nonce: string; // hex

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -2,7 +2,7 @@ import { DEFAULT_CONFIG } from "@motebit/ai-core";
 import type { MotebitPersonalityConfig } from "@motebit/ai-core";
 import { deriveSyncEncryptionKey, mintAudienceToken } from "@motebit/encryption";
 import { connectMcpServers } from "@motebit/mcp-client";
-import { admitModelForProvider } from "./model-admission.js";
+import { admitModelForProvider, MONEY_TOOLS_WITHHELD_NOTICE } from "./model-admission.js";
 import { createSolanaWalletRail } from "@motebit/wallet-solana";
 import { preflightGrant, renderPreflight } from "./grant-preflight.js";
 import {
@@ -1025,6 +1025,14 @@ async function main(): Promise<void> {
       console.log();
     }
     refreshUpdateCheckInBackground();
+  }
+
+  // Capability-tier honesty (#501): when the selected model's tier is
+  // withholding money tools, say so ONCE at launch in the nudge register —
+  // the owner must never discover the difference mid-conversation.
+  if (runtime.moneyToolsWithheld) {
+    console.log(dim(`  ${MONEY_TOOLS_WITHHELD_NOTICE}`));
+    console.log();
   }
 
   // First-session activation: creature speaks first after identity birth.

--- a/apps/cli/src/model-admission.ts
+++ b/apps/cli/src/model-admission.ts
@@ -58,3 +58,11 @@ export function admitModelForProvider(provider: string, model: string): ModelAdm
 
   return { admissible: true };
 }
+
+/**
+ * The one calm line rendered when capability tiering withholds money
+ * tools from the selected model (#501). Shared by launch (index.ts) and
+ * the /model switch so the wording can never drift between the two.
+ */
+export const MONEY_TOOLS_WITHHELD_NOTICE =
+  "money tools withheld from this model (minimal tier) — set offer_money_tools_to_minimal_models in ~/.motebit/config.json if you mean it";

--- a/apps/cli/src/runtime-factory.ts
+++ b/apps/cli/src/runtime-factory.ts
@@ -790,6 +790,12 @@ export async function createRuntime(
       // (enableInteractiveDelegation). Absent ⇒ delegation degrades to
       // relay-mode honestly.
       ...(solanaWallet ? { solanaWallet } : {}),
+      // #501 — sovereign override for capability-tiered tool admission.
+      // Default (absent/false): a minimal-tier model is never offered
+      // R4_MONEY tools; the owner can restore full exposure in config.
+      ...(loadFullConfig().offer_money_tools_to_minimal_models === true
+        ? { offerMoneyToolsToMinimalModels: true }
+        : {}),
       policy: {
         operatorMode: config.operator,
         pathAllowList: config.allowedPaths,

--- a/apps/cli/src/slash-commands.ts
+++ b/apps/cli/src/slash-commands.ts
@@ -4,7 +4,7 @@ import type { MotebitRuntime, ReflectionResult, RelayConfig } from "@motebit/run
 import type { TokenAudience } from "@motebit/sdk";
 import { isTokenAudience, fromMicro, modelVendorHint } from "@motebit/sdk";
 import { discoverModels } from "@motebit/ai-core";
-import { admitModelForProvider } from "./model-admission.js";
+import { admitModelForProvider, MONEY_TOOLS_WITHHELD_NOTICE } from "./model-admission.js";
 import { createSolanaWalletRail } from "@motebit/wallet-solana";
 import { renderIdentityCard } from "./subcommands/id.js";
 import { DEFAULT_SOLANA_RPC_URL, WALLET_GUIDANCE_LINES } from "./subcommands/wallet.js";
@@ -670,6 +670,12 @@ export async function handleSlashCommand(
         break;
       }
       runtime.setModel(modelId);
+      // Capability-tier honesty (#501): a switch that crosses the tier
+      // line must say so at the moment it happens — the model-visible
+      // toolset just changed.
+      if (runtime.moneyToolsWithheld) {
+        console.log(`\n  ${dim(MONEY_TOOLS_WITHHELD_NOTICE)}`);
+      }
       if (fullConfig) {
         fullConfig.default_model = modelId;
         // Persist the PAIR: a model default with no memory of its provider is

--- a/packages/runtime/src/__tests__/capability-tier-admission.test.ts
+++ b/packages/runtime/src/__tests__/capability-tier-admission.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Capability-tiered tool admission (#501): a minimal-tier model is never
+ * OFFERED an R4_MONEY tool — omitted from the model-visible list,
+ * fail-closed on execute — unless the sovereign override is set. Born
+ * live 2026-07-31: llama3.2 (3B) fabricated a real-money hire proposal
+ * from noise; governance caught it, this makes the class unrepresentable
+ * (runtime-invariants-over-prompt-rules; intelligence-pluggability
+ * commitment #3).
+ */
+import { describe, it, expect, vi } from "vitest";
+import { RiskLevel, SideEffect } from "@motebit/sdk";
+import type { AIResponse, ContextPack, ToolDefinition } from "@motebit/sdk";
+import type { StreamingProvider } from "@motebit/ai-core";
+
+vi.mock("@motebit/memory-graph", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@motebit/memory-graph")>();
+  return {
+    ...actual,
+    embedText: vi.fn().mockResolvedValue(new Array(384).fill(0.1)),
+  };
+});
+
+import { MotebitRuntime, NullRenderer, createInMemoryStorage } from "../index";
+import type { ScopedToolRegistry } from "../scoped-tool-registry";
+
+function createMockProvider(initialModel: string): StreamingProvider {
+  const response: AIResponse = {
+    text: "ok",
+    confidence: 0.8,
+    memory_candidates: [],
+    state_updates: {},
+  };
+  // Mirrors real providers: setModel mutates the live `model` field the
+  // tier predicate reads by reference. `model` is readonly on the
+  // interface, so the mutable truth lives beside it.
+  let currentModel = initialModel;
+  const provider: StreamingProvider = {
+    get model() {
+      return currentModel;
+    },
+    setModel: (m: string) => {
+      currentModel = m;
+    },
+    generate: vi.fn<(ctx: ContextPack) => Promise<AIResponse>>().mockResolvedValue(response),
+    estimateConfidence: vi.fn<() => Promise<number>>().mockResolvedValue(0.8),
+    extractMemoryCandidates: vi.fn<(r: AIResponse) => Promise<never[]>>().mockResolvedValue([]),
+    async *generateStream(_ctx: ContextPack) {
+      yield { type: "text" as const, text: "ok" };
+      yield { type: "done" as const, response };
+    },
+  };
+  return provider;
+}
+
+const MONEY_TOOL: ToolDefinition = {
+  name: "pay_worker",
+  description: "Delegate a paid task to a worker agent",
+  inputSchema: { type: "object", properties: {} },
+  riskHint: { risk: RiskLevel.R4_MONEY, sideEffect: SideEffect.IRREVERSIBLE },
+};
+
+const READ_TOOL: ToolDefinition = {
+  name: "read_notes",
+  description: "Read local notes",
+  inputSchema: { type: "object", properties: {} },
+  riskHint: { risk: RiskLevel.R0_READ, sideEffect: SideEffect.NONE },
+};
+
+/** The R2 shape delegate_to_agent takes when NO payment rail is bound. */
+const RAILLESS_DELEGATE: ToolDefinition = {
+  name: "delegate_to_agent",
+  description: "Delegate a task to a remote agent",
+  inputSchema: { type: "object", properties: {} },
+  riskHint: { risk: RiskLevel.R2_WRITE, sideEffect: SideEffect.REVERSIBLE },
+};
+
+function build(model: string, offerOverride?: boolean) {
+  const runtime = new MotebitRuntime(
+    {
+      motebitId: "tier-test",
+      tickRateHz: 0,
+      ...(offerOverride != null ? { offerMoneyToolsToMinimalModels: offerOverride } : {}),
+    },
+    {
+      storage: createInMemoryStorage(),
+      renderer: new NullRenderer(),
+      ai: createMockProvider(model),
+    },
+  );
+  runtime.getToolRegistry().register(MONEY_TOOL, async () => ({ ok: true }));
+  runtime.getToolRegistry().register(READ_TOOL, async () => ({ ok: true }));
+  const scoped = (runtime as unknown as { scopedToolRegistry: ScopedToolRegistry })
+    .scopedToolRegistry;
+  return { runtime, scoped };
+}
+
+describe("capability-tiered tool admission (#501)", () => {
+  it("a minimal-tier model never SEES the money tool; execute fail-closes", async () => {
+    const { runtime, scoped } = build("llama3.2");
+    const visible = scoped.list().map((t) => t.name);
+    expect(visible).toContain("read_notes");
+    expect(visible).not.toContain("pay_worker");
+
+    const result = await scoped.execute("pay_worker", {});
+    expect(result.ok).toBe(false);
+
+    expect(runtime.moneyToolsWithheld).toBe(true);
+  });
+
+  it("a capable/frontier model gets full exposure", () => {
+    const { runtime, scoped } = build("claude-sonnet-4-6");
+    expect(scoped.list().map((t) => t.name)).toContain("pay_worker");
+    expect(runtime.moneyToolsWithheld).toBe(false);
+  });
+
+  it("a mid-session model switch adjusts exposure with no re-wire (predicate reads by reference)", () => {
+    const { runtime, scoped } = build("claude-sonnet-4-6");
+    expect(scoped.list().map((t) => t.name)).toContain("pay_worker");
+
+    runtime.setModel("llama3.2");
+    expect(scoped.list().map((t) => t.name)).not.toContain("pay_worker");
+    expect(runtime.moneyToolsWithheld).toBe(true);
+
+    runtime.setModel("qwen3");
+    expect(scoped.list().map((t) => t.name)).toContain("pay_worker");
+    expect(runtime.moneyToolsWithheld).toBe(false);
+  });
+
+  it("the sovereign override restores full exposure to a minimal model", () => {
+    const { runtime, scoped } = build("llama3.2", true);
+    expect(scoped.list().map((t) => t.name)).toContain("pay_worker");
+    expect(runtime.moneyToolsWithheld).toBe(false);
+  });
+
+  it("a rail-less delegate tool (R2) stays offered to a minimal model — the tool crosses the line only when it can move money", () => {
+    const { scoped, runtime } = build("llama3.2");
+    runtime.getToolRegistry().register(RAILLESS_DELEGATE, async () => ({ ok: true }));
+    expect(scoped.list().map((t) => t.name)).toContain("delegate_to_agent");
+  });
+
+  it("non-money tools are untouched on every tier", () => {
+    for (const model of ["llama3.2", "qwen3", "claude-opus-5"]) {
+      const { scoped } = build(model);
+      expect(scoped.list().map((t) => t.name)).toContain("read_notes");
+    }
+  });
+});

--- a/packages/runtime/src/motebit-runtime.ts
+++ b/packages/runtime/src/motebit-runtime.ts
@@ -46,6 +46,7 @@ import {
   rankSensitivity,
   CONTEXT_SAFE_SENSITIVITY,
   RiskLevel,
+  modelCapabilityTier,
 } from "@motebit/sdk";
 import type { SensitivityCleared } from "@motebit/sdk";
 import type {
@@ -547,6 +548,8 @@ export class MotebitRuntime {
   /** Allowed proactive capability names. Empty by default — fail-closed
    *  sovereign default. User opts in explicitly via runtime config. */
   private _proactiveCapabilities: ReadonlySet<string>;
+  /** #501 — config override: offer R4_MONEY tools to minimal-tier models. */
+  private _offerMoneyToolsToMinimalModels: boolean;
   /** Auto-anchor policy; null when disabled. Stored by reference so the
    *  submitter can be rotated by the surface without re-constructing the
    *  runtime. */
@@ -790,8 +793,16 @@ export class MotebitRuntime {
     // Memory-mutation tools only — no surface side effects during tending.
     this._proactiveCapabilities = new Set(config.proactiveCapabilities ?? []);
     this._proactiveAnchor = config.proactiveAnchor ?? null;
+    this._offerMoneyToolsToMinimalModels = config.offerMoneyToolsToMinimalModels ?? false;
     this.scopedToolRegistry = new ScopedToolRegistry(this.toolRegistry, {
       allows: (toolName) => {
+        // Capability tier (#501): a minimal-tier model is never OFFERED an
+        // R4_MONEY tool — omitted from list(), fail-closed on execute().
+        // Composes by AND with the presence scope below; reads the CURRENT
+        // model by reference, so a mid-session /model switch adjusts
+        // exposure with no re-wire. invokeCapability (user-tap) does not
+        // route through this registry — a tap is its own authorizer.
+        if (!this.tierAllowsTool(toolName)) return false;
         const presence = this.presence.get();
         if (presence.mode === "responsive" || presence.mode === "idle") return true;
         // tending: only the user-allowed proactive tools, intersected with
@@ -1375,6 +1386,36 @@ export class MotebitRuntime {
 
   get currentModel(): string | null {
     return this.provider?.model ?? null;
+  }
+
+  /**
+   * Capability-tiered tool admission (#501): may the CURRENT model be
+   * offered `toolName`? True unless the model is `minimal`-tier AND the
+   * tool classifies at `R4_MONEY` AND the config override is off. Keys on
+   * the SAME `classifyTool` vocabulary the approval gate uses, so any
+   * future money tool inherits the policy at birth — and a rail-less
+   * `delegate_to_agent` (R2 without a payment builder) stays offered:
+   * the tool crosses the withholding line exactly when it can move money.
+   */
+  private tierAllowsTool(toolName: string): boolean {
+    if (this._offerMoneyToolsToMinimalModels) return true;
+    const model = this.provider?.model ?? null;
+    if (model == null || modelCapabilityTier(model) !== "minimal") return true;
+    const def = this.toolRegistry.list().find((t) => t.name === toolName);
+    if (def == null) return true;
+    return classifyTool(def).risk < RiskLevel.R4_MONEY;
+  }
+
+  /**
+   * Surface-honesty readout (#501): true when the current model's tier is
+   * withholding at least one registered money tool. Surfaces render ONE
+   * calm line from this (launch / model switch) — never a toast.
+   */
+  get moneyToolsWithheld(): boolean {
+    if (this._offerMoneyToolsToMinimalModels) return false;
+    const model = this.provider?.model ?? null;
+    if (model == null || modelCapabilityTier(model) !== "minimal") return false;
+    return this.toolRegistry.list().some((t) => classifyTool(t).risk >= RiskLevel.R4_MONEY);
   }
 
   setModel(model: string): void {

--- a/packages/runtime/src/runtime-config.ts
+++ b/packages/runtime/src/runtime-config.ts
@@ -255,6 +255,20 @@ export interface RuntimeConfig {
    */
   proactiveCapabilities?: string[];
   /**
+   * Capability-tiered tool admission override (#501). By default a
+   * `minimal`-tier model (per `modelCapabilityTier` in `@motebit/sdk`)
+   * is never OFFERED tools classified at `R4_MONEY` — the tool is
+   * omitted from the model-visible list and execute() fail-closes.
+   * Witnessed 2026-07-31: a 3B model fabricated a real-money hire
+   * proposal from noise; governance caught it, this makes the class
+   * unrepresentable (runtime-invariants-over-prompt-rules).
+   *
+   * Set `true` to restore full exposure — sovereignty preserved, only
+   * the footgun default removed. Never affects `invokeCapability`
+   * (a user tap is its own authorizer) or non-money tools.
+   */
+  offerMoneyToolsToMinimalModels?: boolean;
+  /**
    * Auto-anchor policy for consolidation receipts. When configured, the
    * runtime invokes `anchorPendingConsolidationReceipts` after signing a
    * receipt if either trigger fires:

--- a/packages/sdk/etc/sdk.api.md
+++ b/packages/sdk/etc/sdk.api.md
@@ -590,6 +590,12 @@ export interface MlxProviderSpec {
 export const MODEL_DEFAULT_REVIEW_BY: Record<string, string>;
 
 // @public
+export type ModelCapabilityTier = "frontier" | "capable" | "minimal";
+
+// @public
+export function modelCapabilityTier(model: string): ModelCapabilityTier;
+
+// @public
 export function modelVendorHint(model: string): "anthropic" | "openai" | "google" | "deepseek" | "groq" | "local" | "unknown";
 
 // @public

--- a/packages/sdk/src/__tests__/model-coherence.test.ts
+++ b/packages/sdk/src/__tests__/model-coherence.test.ts
@@ -7,7 +7,12 @@
  * ids stay permissive so new model releases never brick startup.
  */
 import { describe, it, expect } from "vitest";
-import { modelVendorHint, providerAcceptsModel, LOCAL_SERVER_SUGGESTED_MODELS } from "../models.js";
+import {
+  modelVendorHint,
+  modelCapabilityTier,
+  providerAcceptsModel,
+  LOCAL_SERVER_SUGGESTED_MODELS,
+} from "../models.js";
 
 describe("modelVendorHint", () => {
   it("attributes registry members and naming signatures", () => {
@@ -62,5 +67,54 @@ describe("gpt-oss is the open-weights LOCAL family, never the hosted OpenAI API 
     for (const m of LOCAL_SERVER_SUGGESTED_MODELS) {
       expect(providerAcceptsModel("local-server", m), m).toBe(true);
     }
+  });
+});
+
+describe("modelCapabilityTier — the capability floor (#501)", () => {
+  it("the witnessed incident model is minimal", () => {
+    expect(modelCapabilityTier("llama3.2")).toBe("minimal");
+    expect(modelCapabilityTier("llama3.2:latest")).toBe("minimal");
+    expect(modelCapabilityTier("llama3.2:1b")).toBe("minimal");
+  });
+
+  it("embedded parameter sizes are the honest signal — ollama tags and dash-form ids", () => {
+    expect(modelCapabilityTier("qwen3:0.6b")).toBe("minimal");
+    expect(modelCapabilityTier("gemma3:4b")).toBe("minimal");
+    expect(modelCapabilityTier("qwen3:8b")).toBe("capable");
+    expect(modelCapabilityTier("llama3.1:70b")).toBe("capable"); // a size never claims frontier
+    // WebLLM / HuggingFace dash-form ids (the web surface's on-device models)
+    expect(modelCapabilityTier("Llama-3.2-3B-Instruct-q4f32_1-MLC")).toBe("minimal");
+    expect(modelCapabilityTier("llama-3.3-70b-versatile")).toBe("capable");
+    expect(modelCapabilityTier("openai/gpt-oss-120b")).toBe("capable");
+  });
+
+  it("known-small families are minimal, including the suggested-table entry", () => {
+    expect(modelCapabilityTier("phi4-mini")).toBe("minimal");
+    expect(modelCapabilityTier("gpt-5.4-nano")).toBe("minimal");
+    expect(modelCapabilityTier("smollm2")).toBe("minimal");
+  });
+
+  it("frontier classes, with small flagship variants demoted", () => {
+    expect(modelCapabilityTier("claude-opus-5")).toBe("frontier");
+    expect(modelCapabilityTier("claude-fable-5")).toBe("frontier");
+    expect(modelCapabilityTier("claude-sonnet-4-6")).toBe("frontier");
+    expect(modelCapabilityTier("gpt-5.4")).toBe("frontier");
+    expect(modelCapabilityTier("gemini-2.5-pro")).toBe("frontier");
+    expect(modelCapabilityTier("gpt-5.4-mini")).toBe("capable");
+    expect(modelCapabilityTier("gemini-2.5-flash")).toBe("capable");
+    expect(modelCapabilityTier("claude-haiku-4-5-20251001")).toBe("capable");
+  });
+
+  it("unknown ids are capable — registry lag must not lobotomize a new model", () => {
+    expect(modelCapabilityTier("totally-new-thing")).toBe("capable");
+    expect(modelCapabilityTier("")).toBe("capable");
+  });
+
+  it("the local suggested table is never accidentally all-minimal", () => {
+    // phi4-mini is DELIBERATELY the minimal-hardware entry; the rest of
+    // the table must stay instrument-capable or the local default
+    // experience silently loses money tools.
+    const tiers = LOCAL_SERVER_SUGGESTED_MODELS.map((m) => modelCapabilityTier(m));
+    expect(tiers.filter((t) => t === "minimal")).toHaveLength(1);
   });
 });

--- a/packages/sdk/src/models.ts
+++ b/packages/sdk/src/models.ts
@@ -258,3 +258,89 @@ export function providerAcceptsModel(provider: string, model: string): boolean {
   if (provider === "groq") return hint === "groq" || hint === "local"; // groq serves open models
   return hint === provider;
 }
+
+// === Capability tiers ===
+//
+// Born live, 2026-07-31 (#501): `llama3.2` (3B, 2024) was offered
+// `delegate_to_agent` — a real-money tool — and fabricated a hire proposal
+// from noise. The governance stack held (approval gate, money band, denial
+// brake; $0 moved), which proved the SAFETY floor. The tier axis is the
+// CAPABILITY floor: intelligence-pluggability commitment #3 — tools adapt
+// to the selected model — needs a registry answer to "what class of model
+// is this?". The runtime keys money-tool exposure on it; nothing here
+// gates admission (a minimal model is a legitimate sovereign choice).
+
+/** Capability class of a model id. `unknown → "capable"` — permissive,
+ *  like admission: registry lag must never lobotomize a good new model. */
+export type ModelCapabilityTier = "frontier" | "capable" | "minimal";
+
+/** Model families known to be small (≤~4B): useful for chat, memory, and
+ *  local tools; not reliable instrument-holders. Matched on the id's base
+ *  name (before any `:tag`). */
+const MINIMAL_FAMILIES = [
+  "llama3.2", // 1B/3B family — the witnessed weak-model floor
+  "phi4-mini",
+  "phi-3",
+  "phi3",
+  "smollm",
+  "tinyllama",
+  "gpt-5.4-nano",
+] as const;
+
+/** Frontier prefixes — the strongest hosted classes. Haiku is deliberately
+ *  absent (capable); so are minis/flashes. */
+const FRONTIER_PREFIXES = [
+  "claude-fable",
+  "claude-mythos",
+  "claude-opus",
+  "claude-sonnet",
+  "gpt-5.4", // bare flagship; -mini/-nano handled before this check
+  "gemini-2.5-pro",
+] as const;
+
+/**
+ * Best-effort capability tier for a model id.
+ *
+ * Resolution order:
+ *   1. Ollama-style size tag (`model:NNb`) — the honest parameter signal
+ *      for local pulls: under 7B → `minimal`, otherwise `capable` (a size
+ *      tag never claims frontier).
+ *   2. Known-small families → `minimal`.
+ *   3. Frontier prefixes (with mini/nano demoted first) → `frontier`.
+ *   4. Everything else — including unknown ids — → `capable`.
+ *
+ * Like the defaults table, this is perishable knowledge: it rides the
+ * same review discipline (`MODEL_DEFAULT_REVIEW_BY`) rather than
+ * pretending to be timeless.
+ */
+export function modelCapabilityTier(model: string): ModelCapabilityTier {
+  const m = model.trim().toLowerCase();
+  if (m === "") return "capable";
+
+  // 1. Embedded parameter size — ollama tags (`qwen3:0.6b`, `gemma3:4b`)
+  // and dash-form ids (`Llama-3.2-3B-Instruct…`, `gpt-oss-120b`,
+  // `llama-3.3-70b-versatile`). The honest signal wherever it appears.
+  const sizeTag = /[:\-_](\d+(?:\.\d+)?)b(?:[-_.:]|$)/.exec(m);
+  if (sizeTag != null) {
+    return parseFloat(sizeTag[1]!) < 7 ? "minimal" : "capable";
+  }
+
+  const base = m.split(":")[0]!;
+
+  // 2. Known-small families — prefix match so version suffixes stay in
+  // the family (`smollm2`, `phi3.5`).
+  if (MINIMAL_FAMILIES.some((f) => base.startsWith(f))) {
+    return "minimal";
+  }
+
+  // 3. Frontier — demote the small variants of flagship names first.
+  if (base.endsWith("-mini") || base.endsWith("-nano") || base.includes("flash")) {
+    return "capable";
+  }
+  if (FRONTIER_PREFIXES.some((p) => base.startsWith(p))) {
+    return "frontier";
+  }
+
+  // 4. Permissive default.
+  return "capable";
+}


### PR DESCRIPTION
Closes #501, per the design pass posted on the issue. Born from the 2026-07-31 live incident: `llama3.2` (3B) was offered `delegate_to_agent` and fabricated a real-money hire proposal from noise. Governance held (band, honest pricing, denial brake, $0 moved) — that proved the SAFETY floor. This is the CAPABILITY floor: intelligence-pluggability commitment #3 enforced at the runtime, not claimed in prose.

## sdk — the tier axis

`modelCapabilityTier(model) → "frontier" | "capable" | "minimal"` in models.ts (same home as `modelVendorHint`): family knowledge where we have it, embedded parameter sizes as the honest signal — **both** ollama `:NNb` tags and dash-form ids (`Llama-3.2-3B-Instruct-q4f32_1-MLC`), so the web surface's on-device WebLLM models tier correctly with zero web-side code. `unknown → capable`: registry lag must never lobotomize a good new model. api-surface baseline updated (+`ModelCapabilityTier`, `modelCapabilityTier`); sdk minor.

## runtime — the policy, at the existing seam

A second predicate AND-composed into the `ScopedToolRegistry` the AI loop already reads: minimal tier ⇒ tools classified `≥ R4_MONEY` are omitted from `list()` (the model never sees them) and fail-closed on `execute()`. Three properties worth calling out:

- **Keys on `classifyTool`, the same closed vocabulary the approval gate uses** — no hand-list; any future money tool inherits the policy at birth. And because `delegate_to_agent` declares R4 *only when a payment rail is bound* (R2 otherwise), a wallet-less motebit's weak model keeps full delegation — the tool crosses the withholding line exactly when it can move money. A test locks this.
- **Predicate reads the live provider model by reference** — a mid-session `/model` switch adjusts exposure with no re-wire (tested live-switch both directions).
- **`invokeCapability` (user-tap) is untouched** — it has its own manager and never routes through the scoped registry; a tap is its own authorizer (surface-determinism).

`moneyToolsWithheld` getter is the surface-honesty readout; `offerMoneyToolsToMinimalModels` config override (default false) preserves sovereignty — only the footgun default is removed.

## cli — one calm line

`offer_money_tools_to_minimal_models` in `~/.motebit/config.json`; a single dim notice at launch and on `/model` switch when withholding is active (shared constant so the wording can't drift between the two sites). Never mid-conversation, never a toast.

## Tests

sdk 15 (incident model, size tags + dash forms, frontier/demotions, unknown-permissive, suggested-table invariant) · runtime 6 (never-sees + fail-closed execute, full exposure on capable, live switch, override, rail-less delegate stays, non-money untouched). Changesets: sdk minor, motebit minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)