### PR TITLE
fix(cli): /model live-catalog membership normalizes ollama :latest tags

### DIFF
--- a/.changeset/model-live-catalog-tag-normalization.md
+++ b/.changeset/model-live-catalog-tag-normalization.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+`/model` accepts what the local server actually serves: ollama's live catalog returns tagged ids (`llama3.2:latest`) while users — and motebit's own defaults — use bare family names, so `/model qwen3` and `/model llama3.2` were refused as "not served" on a machine that served both (witnessed on the 1.12.0 live pass). Live-catalog membership now normalizes the `:latest` form, and the active-model marker in the `/model` list matches across the same normalization.

--- a/apps/cli/src/__tests__/model-admission.test.ts
+++ b/apps/cli/src/__tests__/model-admission.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { admitModelForProvider } from "../model-admission.js";
+import { admitModelForProvider, liveCatalogServes } from "../model-admission.js";
 import { defaultModelForProvider } from "../args.js";
 import { LOCAL_SERVER_SUGGESTED_MODELS } from "@motebit/sdk";
 
@@ -67,5 +67,25 @@ describe("admitModelForProvider — the provider+model pair gate (#471)", () => 
     for (const p of providers) {
       expect(admitModelForProvider(p, defaultModelForProvider(p)).admissible).toBe(true);
     }
+  });
+});
+
+describe("liveCatalogServes — ollama tag normalization (2026-08-01 live-pass find)", () => {
+  const live = new Set(["qwen3:latest", "llama3.2:latest", "qwen3:8b", "claude-opus-5"]);
+
+  it("bare family names resolve to their :latest form — the witnessed refusals", () => {
+    expect(liveCatalogServes(live, "llama3.2")).toBe(true);
+    expect(liveCatalogServes(live, "qwen3")).toBe(true); // the shipped default itself
+  });
+
+  it("verbatim ids still pass, tagged or not", () => {
+    expect(liveCatalogServes(live, "qwen3:8b")).toBe(true);
+    expect(liveCatalogServes(live, "llama3.2:latest")).toBe(true);
+    expect(liveCatalogServes(live, "claude-opus-5")).toBe(true);
+  });
+
+  it("a model the server does not hold is still refused", () => {
+    expect(liveCatalogServes(live, "gemma3")).toBe(false);
+    expect(liveCatalogServes(live, "qwen3:0.6b")).toBe(false);
   });
 });

--- a/apps/cli/src/model-admission.ts
+++ b/apps/cli/src/model-admission.ts
@@ -66,3 +66,16 @@ export function admitModelForProvider(provider: string, model: string): ModelAdm
  */
 export const MONEY_TOOLS_WITHHELD_NOTICE =
   "money tools withheld from this model (minimal tier) — set offer_money_tools_to_minimal_models in ~/.motebit/config.json if you mean it";
+
+/**
+ * Live-catalog membership with ollama tag normalization (#513-class,
+ * witnessed 2026-08-01 on the 1.12.0 live pass): ollama's /api/tags
+ * returns TAGGED ids (`llama3.2:latest`) but resolves bare family names
+ * to `:latest` server-side — so `/model llama3.2` (and even the shipped
+ * default `qwen3`) was refused as "not served" while the server happily
+ * served it. Membership must accept exactly what the server accepts:
+ * the id verbatim, or its `:latest` form.
+ */
+export function liveCatalogServes(liveIds: ReadonlySet<string>, modelId: string): boolean {
+  return liveIds.has(modelId) || liveIds.has(`${modelId}:latest`);
+}

--- a/apps/cli/src/slash-commands.ts
+++ b/apps/cli/src/slash-commands.ts
@@ -4,7 +4,11 @@ import type { MotebitRuntime, ReflectionResult, RelayConfig } from "@motebit/run
 import type { TokenAudience } from "@motebit/sdk";
 import { isTokenAudience, fromMicro, modelVendorHint } from "@motebit/sdk";
 import { discoverModels } from "@motebit/ai-core";
-import { admitModelForProvider, MONEY_TOOLS_WITHHELD_NOTICE } from "./model-admission.js";
+import {
+  admitModelForProvider,
+  liveCatalogServes,
+  MONEY_TOOLS_WITHHELD_NOTICE,
+} from "./model-admission.js";
 import { createSolanaWalletRail } from "@motebit/wallet-solana";
 import { renderIdentityCard } from "./subcommands/id.js";
 import { DEFAULT_SOLANA_RPC_URL, WALLET_GUIDANCE_LINES } from "./subcommands/wallet.js";
@@ -642,7 +646,9 @@ export async function handleSlashCommand(
         if (catalog.source === "live") {
           const col = Math.max(...catalog.models.map((m) => m.id.length)) + 2;
           for (const m of catalog.models) {
-            const active = m.id === current;
+            // Tag-normalized: the runtime may hold `qwen3` while ollama
+            // lists `qwen3:latest` — same model, the ● must show.
+            const active = m.id === current || m.id === `${current}:latest`;
             const marker = active ? green(" ●") : "  ";
             const gap = " ".repeat(Math.max(1, col - m.id.length));
             console.log(`${marker} ${cyan(m.id)}${gap}${dim(m.displayName ?? "")}`);
@@ -683,7 +689,9 @@ export async function handleSlashCommand(
       const input = args.toLowerCase();
       const resolved = MODEL_ALIASES[input];
       // A live catalog admits full ids the alias table never knew about.
-      const isFullId = Object.values(MODEL_ALIASES).includes(args) || (liveIds?.has(args) ?? false);
+      const isFullId =
+        Object.values(MODEL_ALIASES).includes(args) ||
+        (liveIds != null && liveCatalogServes(liveIds, args));
       if (!resolved && !isFullId) {
         console.log(`\nUnknown model: ${cyan(args)}\n`);
         showModelList(runtime.currentModel ?? "");
@@ -693,8 +701,9 @@ export async function handleSlashCommand(
       const modelId = resolved ?? args;
       // Live-membership admission first (#475): the provider just told us
       // what it serves — an id outside that list cannot work, whatever the
-      // offline heuristic thinks.
-      if (liveIds != null && !liveIds.has(modelId)) {
+      // offline heuristic thinks. Tag-normalized (ollama serves bare
+      // family names as `:latest`).
+      if (liveIds != null && !liveCatalogServes(liveIds, modelId)) {
         console.log(
           `\n  ${warn(`${modelId} is not served by ${config.provider} right now — /model lists what is`)}\n`,
         );


### PR DESCRIPTION
Witnessed 2026-08-01 on the 1.12.0 live pass: `/model llama3.2` — and `/model qwen3`, the shipped default itself — refused as "not served by local-server right now" on a machine whose ollama served both.

Cause: `discoverModels` returns ollama's TAGGED ids (`llama3.2:latest`) while users (and motebit's own defaults) use bare family names, which ollama resolves to `:latest` server-side. The live-membership check compared verbatim, so the live catalog — added to make `/model` honest — refused models the server accepts.

Fix: `liveCatalogServes(liveIds, modelId)` in model-admission.ts accepts the id verbatim or its `:latest` form; used at both membership sites (full-id recognition + admission refusal) and the active-● marker in the live `/model` list (the runtime may hold `qwen3` while the catalog lists `qwen3:latest` — same model, the marker must show).

Deliberately narrow: only the `:latest` convention is normalized — `/model qwen3:0.6b` on a server holding only `qwen3:8b` still refuses, as it should.

Tests: 3 new cases in model-admission.test.ts (the two witnessed refusals incl. the shipped default, verbatim tagged/untagged ids, still-refused absent models). Full CLI suite 420 green. Changeset: `motebit` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)