### PR TITLE
fix(cli): teach lines route through the renderer — no mode-row glue mid-session

### DIFF
--- a/.changeset/repl-teach-lines-renderer.md
+++ b/.changeset/repl-teach-lines-renderer.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+The shell-command teach line and the `→ /slash` routing arrow now fold in above the owned bottom region instead of gluing onto the mode row (witnessed live 2026-08-01: `── llama3.2 · local-serverthat's a shell command…`) — REPL-loop output routes through the renderer, never a raw console write while the region is painted.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -35,7 +35,14 @@ import {
   openMotebitDatabase,
 } from "./runtime-factory.js";
 import { consumeStream } from "./stream.js";
-import { readInput, writeOutput, setModeRow, initTerminal, destroyTerminal } from "./terminal.js";
+import {
+  readInput,
+  writeOutput,
+  writeLine,
+  setModeRow,
+  initTerminal,
+  destroyTerminal,
+} from "./terminal.js";
 import { renderModeRow } from "./mode-render.js";
 import { electCliRuntimeHost } from "./runtime-host.js";
 import { runAttachedRepl } from "./attached-repl.js";
@@ -1127,7 +1134,12 @@ async function main(): Promise<void> {
     // question or a sentence.
     const bareSlash = resolveBareCommand(trimmed);
     const effective = bareSlash ?? trimmed;
-    if (bareSlash != null) console.log(dim(`  → ${bareSlash}`));
+    // Renderer-routed, never console.log: while the owned region is
+    // painted, a direct console write starts at the parked cursor and
+    // glues onto the mode row (witnessed live 2026-08-01 — the #500
+    // teach line rendered as `── llama3.2 · local-serverthat's a shell
+    // command…`). writeLine folds in above the region.
+    if (bareSlash != null) writeLine(dim(`  → ${bareSlash}`));
 
     // A full CLI invocation typed at the chat prompt (#500) teaches instead
     // of reaching the model — a weak model once fabricated a money intent
@@ -1136,8 +1148,8 @@ async function main(): Promise<void> {
     if (bareSlash == null) {
       const shellTeach = detectShellInvocation(trimmed);
       if (shellTeach != null) {
-        console.log(dim(shellTeach));
-        console.log();
+        writeLine(dim(shellTeach));
+        writeLine("");
         prompt();
         return;
       }


### PR DESCRIPTION
Witnessed live 2026-08-01 on the founder's 1.12.0 real-identity pass: the #500 shell teach line rendered glued onto the mode row (`── llama3.2:latest · local-server  that's a shell command…`). The PTY harness structurally couldn't see this — flattened captures hide cursor position; a human screen caught it in one paste.

Cause: `console.log` while the owned bottom region is painted starts writing at the parked cursor — the #505 exit-glue class appearing mid-session. The shell-detector teach line and the `→ /slash` bare-command arrow now route through `writeLine` (the renderer's fold-in-above-the-region primitive).

Sibling note, deliberately deferred: slash-command handlers mask the same class with their leading-`\n` convention (which is why the `/model` withheld notice rendered clean). A systematic sweep of slash output through the renderer is a bigger change than these two witnessed sites — left for a dedicated pass.

Changeset: `motebit` patch. CLI suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)