### PR TITLE
fix(cli): live /model list teaches the cross-provider path

### DIFF
--- a/.changeset/model-list-other-providers.md
+++ b/.changeset/model-list-other-providers.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+The live `/model` catalog now teaches the cross-provider path the offline list always had: a dim footer names each other provider with its restart command and default model (`--provider anthropic (claude-sonnet-4-6) · …`). The live list shows only what the active provider serves — correct, but from inside it the other providers were invisible with no path named.

--- a/apps/cli/src/slash-commands.ts
+++ b/apps/cli/src/slash-commands.ts
@@ -30,7 +30,7 @@ import { computeReputationScore } from "@motebit/policy";
 import { mintAudienceToken, verifyExecutionReceipt, hexToBytes } from "@motebit/encryption";
 import { McpServerAdapter, wireServerDeps } from "@motebit/mcp-server";
 import type { McpServerConfig as McpServerAdapterConfig } from "@motebit/mcp-server";
-import { type CliConfig, COMMANDS } from "./args.js";
+import { type CliConfig, COMMANDS, defaultModelForProvider } from "./args.js";
 import type { FullConfig } from "./config.js";
 import { CONFIG_DIR, saveFullConfig } from "./config.js";
 import { join } from "node:path";
@@ -654,6 +654,21 @@ export async function handleSlashCommand(
             console.log(`${marker} ${cyan(m.id)}${gap}${dim(m.displayName ?? "")}`);
           }
           console.log(dim(`\n  live from ${config.provider}`));
+          // The live catalog lists only the ACTIVE provider's models — the
+          // offline fallback list teaches the cross-provider path, and the
+          // live branch must too (witnessed 2026-08-01: "where are the
+          // others?"). Switching providers is a restart, so name the exact
+          // command per provider with its default model.
+          const others = (["anthropic", "openai", "google", "local-server"] as const).filter(
+            (p) => p !== config.provider,
+          );
+          console.log(
+            dim(
+              `  other providers (restart to switch): ${others
+                .map((p) => `--provider ${p} (${defaultModelForProvider(p)})`)
+                .join(" · ")}`,
+            ),
+          );
           return;
         }
         const col = Math.max(...Object.keys(MODEL_ALIASES).map((k) => k.length)) + 2;


### PR DESCRIPTION
Witnessed 2026-08-01 (founder: "the options are only local server models? what about the others?"): the live catalog honestly lists only the ACTIVE provider's models — correct, since `/model` switches within a provider — but unlike the offline fallback list (which dims other-provider rows with the `--provider` repair), it named no path to the rest. From inside the live list, the other providers were invisible.

One dim footer under the live list: `other providers (restart to switch): --provider anthropic (claude-sonnet-4-6) · --provider openai (gpt-5.4-mini) · --provider google (gemini-2.5-flash)` — each other provider with its restart command and default model, sourced from `defaultModelForProvider` (never a hand-list). groq/deepseek deliberately absent: they're not in the persisted-provider union.

Changeset: `motebit` patch. CLI suite 420 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)