### PR TITLE
feat(ai-core): tier-adapted voice block — below-frontier models inhabit, not describe

### DIFF
--- a/.changeset/tier-adapted-voice.md
+++ b/.changeset/tier-adapted-voice.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+Below-frontier models now get an imperative first-person voice block in the prompt's dynamic suffix (#519): "You ARE this motebit… your self-knowledge is your own body and history, not a document to summarize," with a wrong/right example. Witnessed on qwen3: asked about itself, it delivered a third-person book report of its own anatomy — strong models inhabit the identity, weaker ones need the register spelled out. Follows mid-session `/model` switches; the cached static prefix stays byte-identical across models.

--- a/packages/ai-core/src/__tests__/prompt.test.ts
+++ b/packages/ai-core/src/__tests__/prompt.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { buildSystemPrompt, derivePersonalityNote, formatBodyAwareness } from "../prompt";
+import {
+  buildSystemPrompt,
+  buildSystemPromptCacheable,
+  derivePersonalityNote,
+  formatBodyAwareness,
+  TIER_ADAPTED_VOICE,
+} from "../prompt";
 import { TrustMode, BatteryMode, SensitivityLevel } from "@motebit/sdk";
 import type { ContextPack, MotebitState, BehaviorCues } from "@motebit/sdk";
 
@@ -160,6 +166,39 @@ describe("formatBodyAwareness", () => {
 // ---------------------------------------------------------------------------
 // buildSystemPrompt
 // ---------------------------------------------------------------------------
+
+describe("tier-adapted voice block (#519)", () => {
+  it("below-frontier models get the imperative first-person register — incl. the witnessed capable-tier case", () => {
+    for (const model of ["llama3.2:latest", "qwen3:latest", "gpt-5.4-mini"]) {
+      const prompt = buildSystemPrompt(makeContextPack(), undefined, { model });
+      expect(prompt, model).toContain(TIER_ADAPTED_VOICE);
+    }
+  });
+
+  it("frontier models get no voice block — the identity prose suffices", () => {
+    for (const model of ["claude-opus-5", "claude-fable-5", "gpt-5.4", "gemini-2.5-pro"]) {
+      const prompt = buildSystemPrompt(makeContextPack(), undefined, { model });
+      expect(prompt, model).not.toContain("[Voice]");
+    }
+  });
+
+  it("no model passed — no block (fail-open to the strong-model prompt)", () => {
+    expect(buildSystemPrompt(makeContextPack())).not.toContain("[Voice]");
+  });
+
+  it("rides the DYNAMIC block, never the cached static prefix", () => {
+    const blocks = buildSystemPromptCacheable(makeContextPack(), undefined, {
+      model: "llama3.2",
+    });
+    expect(blocks[0]!.text).not.toContain("[Voice]");
+    expect(blocks[1]!.text).toContain(TIER_ADAPTED_VOICE);
+    // Static prefix is byte-identical to the strong-model assembly — cache-safe.
+    const strong = buildSystemPromptCacheable(makeContextPack(), undefined, {
+      model: "claude-opus-5",
+    });
+    expect(blocks[0]!.text).toBe(strong[0]!.text);
+  });
+});
 
 describe("buildSystemPrompt", () => {
   it("includes all core sections", () => {

--- a/packages/ai-core/src/core.ts
+++ b/packages/ai-core/src/core.ts
@@ -1471,7 +1471,12 @@ export class AnthropicProvider implements StreamingProvider {
   private buildSystemBlocks(
     contextPack: ContextPack,
   ): Array<{ type: "text"; text: string; cache_control?: { type: "ephemeral" } }> {
-    return buildPromptCacheable(contextPack, this.config.personalityConfig);
+    // Live model per call (#519): a /model switch mid-session must move the
+    // tier-adapted voice block with it. Only the dynamic suffix varies — the
+    // cached static prefix stays byte-identical across models.
+    return buildPromptCacheable(contextPack, this.config.personalityConfig, {
+      model: this.model,
+    });
   }
 
   /**

--- a/packages/ai-core/src/openai-provider.ts
+++ b/packages/ai-core/src/openai-provider.ts
@@ -470,7 +470,11 @@ export class OpenAIProvider implements IntelligenceProvider {
   private buildMessages(contextPack: ContextPack): OpenAIMessage[] {
     // Split the system prompt into its static prefix (cacheable, fixed) and the
     // per-turn dynamic suffix — the same two blocks the Anthropic path caches.
-    const blocks = buildSystemPromptCacheable(contextPack, this.config.personalityConfig);
+    // Live model per call (#519): the tier-adapted voice block follows a
+    // mid-session model switch; the cached static block stays byte-identical.
+    const blocks = buildSystemPromptCacheable(contextPack, this.config.personalityConfig, {
+      model: this.model,
+    });
     const staticDoctrine = blocks[0]?.text ?? "";
     const dynamicContext = blocks[1]?.text; // undefined when there's no suffix
 

--- a/packages/ai-core/src/prompt.ts
+++ b/packages/ai-core/src/prompt.ts
@@ -1,5 +1,5 @@
 import type { ContextPack, MotebitState, BehaviorCues } from "@motebit/sdk";
-import { BatteryMode } from "@motebit/sdk";
+import { BatteryMode, modelCapabilityTier } from "@motebit/sdk";
 import type { MotebitPersonalityConfig } from "./config.js";
 import { DEFAULT_CONFIG } from "./config.js";
 import { packContext } from "./core.js";
@@ -450,11 +450,30 @@ If asked what you can do, answer honestly about both what is active now and what
  * Use this when sending requests through a proxy that supports structured system blocks.
  * For surfaces that need a plain string, use `buildSystemPrompt()` instead.
  */
+/**
+ * Tier-adapted voice block (#519, intelligence-pluggability commitment #2):
+ * a below-frontier model inhabits the identity only when TOLD to,
+ * imperatively — witnessed live 2026-08-01: asked "tell me about
+ * yourself", qwen3 (capable tier, 8B) called recall_self correctly and
+ * then delivered a third-person book report of its own anatomy. Frontier
+ * models need none of this (the identity prose suffices); everything
+ * below gets the register spelled out with a wrong/right example — the
+ * witness was CAPABLE tier, so the scope is non-frontier, not just
+ * minimal. Appended to the DYNAMIC suffix, never the static prefix — the
+ * model can change mid-session and the tier must follow (also keeps the
+ * cached prefix byte-identical across models).
+ */
+export const TIER_ADAPTED_VOICE = `[Voice]
+You ARE this motebit. Speak as yourself, in the first person, always.
+Your self-knowledge (recall_self results, [SELF_DESCRIPTION]) is your own body and history, not a document to summarize. Wrong: "The response provides an explanation of Motebit's philosophy." Right: "My identity is a keypair I generated; my memory accumulates."
+Answer plainly and briefly. No headings or structured summaries unless asked.`;
+
 export function buildSystemPromptCacheable(
   contextPack: ContextPack,
   config?: MotebitPersonalityConfig,
+  opts?: { model?: string },
 ): Array<{ type: "text"; text: string; cache_control?: { type: "ephemeral" } }> {
-  const dynamicText = buildDynamicSuffix(contextPack, config);
+  const dynamicText = buildDynamicSuffix(contextPack, config, opts);
   const blocks: Array<{ type: "text"; text: string; cache_control?: { type: "ephemeral" } }> = [
     { type: "text", text: STATIC_PREFIX, cache_control: { type: "ephemeral" } },
   ];
@@ -464,7 +483,11 @@ export function buildSystemPromptCacheable(
   return blocks;
 }
 
-function buildDynamicSuffix(contextPack: ContextPack, config?: MotebitPersonalityConfig): string {
+function buildDynamicSuffix(
+  contextPack: ContextPack,
+  config?: MotebitPersonalityConfig,
+  opts?: { model?: string },
+): string {
   const resolved = { ...DEFAULT_CONFIG, ...config };
   const sections: string[] = [];
 
@@ -586,6 +609,13 @@ function buildDynamicSuffix(contextPack: ContextPack, config?: MotebitPersonalit
     "If the user shared something new and lasting about themselves, tag it with <memory> before your response.",
   );
 
+  // Tier-adapted voice (#519): imperative register for below-frontier
+  // models, late in the suffix so it lands close to the response. Absent
+  // for frontier models and when the caller passed no model.
+  if (opts?.model != null && modelCapabilityTier(opts.model) !== "frontier") {
+    sections.push(TIER_ADAPTED_VOICE);
+  }
+
   // Activation — system-triggered generation, appended last so it's the immediate directive
   if (contextPack.activationPrompt) {
     sections.push(`[Activation] ${contextPack.activationPrompt}`);
@@ -597,7 +627,8 @@ function buildDynamicSuffix(contextPack: ContextPack, config?: MotebitPersonalit
 export function buildSystemPrompt(
   contextPack: ContextPack,
   config?: MotebitPersonalityConfig,
+  opts?: { model?: string },
 ): string {
-  const dynamic = buildDynamicSuffix(contextPack, config);
+  const dynamic = buildDynamicSuffix(contextPack, config, opts);
   return dynamic ? `${STATIC_PREFIX}\n\n${dynamic}` : STATIC_PREFIX;
 }


### PR DESCRIPTION
Closes #519. Witnessed live 2026-08-01: qwen3 (capable tier) asked "tell me about yourself" called `recall_self` correctly, then delivered a third-person book report of its own anatomy. Frontier models inhabit the identity from the existing prose; everything below needs the register spelled out imperatively.

**Scope correction from the issue**: the witness was CAPABLE tier, so the block applies to `modelCapabilityTier(model) !== "frontier"` — not just minimal (a minimal-only block would have missed its own motivating case).

`TIER_ADAPTED_VOICE` (four imperative prose lines with a wrong/right example lifted from the transcript) rides the DYNAMIC suffix via new `opts.model` on `buildSystemPrompt(Cacheable)`; both providers pass their live model per call, so `/model` switches move the block and the cached static prefix stays byte-identical across models (test-locked — prompt-cache economics untouched). Prose lines, not bullets: `check-prompt-density` baseline unchanged (68); `check-prompt-budget` 33,227 of 45,000.

Tests: 4 new (below-frontier gets it incl. the witnessed qwen3 case, frontier doesn't, no-model fail-open, dynamic-block placement + static byte-identity). ai-core 576 green. Changeset: `motebit` patch (the shipped CLI behavior changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)