### PR TITLE
fix(ai-core,runtime): the closing floor can no longer deny its own actions

### DIFF
--- a/.changeset/fallback-honesty-money-moments.md
+++ b/.changeset/fallback-honesty-money-moments.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+The turn-closing fallback can no longer deny actions it took (#521). Witnessed on the first local-brain paid hire: a silent model made the runtime say "I didn't take any action there" three times — while its own hire sat pending approval, after the approved $0.25 hire completed, and after the human's refusal. The approval path now threads what it did into the continuation loop, and the floor gained honest variants: pending → "that needs your approval — the request is right above"; refused → "you declined `X` — nothing ran"; completed → "`X` completed — the result is above." Floor invariant: no-action is only claimable when no call was emitted.

--- a/packages/ai-core/src/__tests__/loop.test.ts
+++ b/packages/ai-core/src/__tests__/loop.test.ts
@@ -2050,12 +2050,66 @@ describe("synthesizeClosingFallback — runtime guarantee of visible closing tex
       { toolCallsSucceeded: 1, toolCallsFailed: 0, lastToolName: "" },
       { toolCallsSucceeded: 0, toolCallsFailed: 1, lastToolName: "" },
       { toolCallsSucceeded: 100, toolCallsFailed: 100, lastToolName: "x" },
+      { toolCallsSucceeded: 0, toolCallsFailed: 0, lastToolName: "", toolCallsAwaitingApproval: 1 },
+      { toolCallsSucceeded: 0, toolCallsFailed: 0, lastToolName: "x", toolCallsRefusedByHuman: 1 },
     ];
     for (const c of cases) {
       const out = synthesizeClosingFallback(c);
       expect(out.length).toBeGreaterThan(0);
       expect(out.trim()).not.toBe("");
     }
+  });
+
+  // ── #521 — the money-moment lies, witnessed live 2026-08-01: the floor
+  // said "I didn't take any action" three times in one flow (pending
+  // approval, completed $0.25 hire, human refusal) because the approval
+  // path's actions weren't threaded. Floor invariant: never claim
+  // no-action when a call was emitted this turn.
+  it("awaiting approval: points at the band, never denies the proposal exists", () => {
+    const out = synthesizeClosingFallback({
+      toolCallsSucceeded: 0,
+      toolCallsFailed: 0,
+      lastToolName: "delegate_to_agent",
+      toolCallsAwaitingApproval: 1,
+    });
+    expect(out).toMatch(/approval/i);
+    expect(out).not.toMatch(/didn't take any action/i);
+  });
+
+  it("human refusal: a decision, not an absence — names the tool, never 'no action'", () => {
+    const out = synthesizeClosingFallback({
+      toolCallsSucceeded: 0,
+      toolCallsFailed: 0,
+      lastToolName: "delegate_to_agent",
+      toolCallsRefusedByHuman: 1,
+    });
+    expect(out).toContain("delegate_to_agent");
+    expect(out).toMatch(/declined/i);
+    expect(out).not.toMatch(/didn't take any action/i);
+  });
+
+  it("completed pre-continuation execution (seeded success): acknowledges, points at the result", () => {
+    // resumeAfterApproval seeds the continuation loop; the call site
+    // composes succeeded+1 with the executed tool's name.
+    const out = synthesizeClosingFallback({
+      toolCallsSucceeded: 1,
+      toolCallsFailed: 0,
+      lastToolName: "delegate_to_agent",
+    });
+    expect(out).toContain("delegate_to_agent");
+    expect(out).toMatch(/completed|done/i);
+    expect(out).not.toMatch(/didn't take any action/i);
+  });
+
+  it("success outranks refusal/awaiting — a completed action is the headline", () => {
+    const out = synthesizeClosingFallback({
+      toolCallsSucceeded: 1,
+      toolCallsFailed: 0,
+      lastToolName: "web_search",
+      toolCallsAwaitingApproval: 1,
+      toolCallsRefusedByHuman: 1,
+    });
+    expect(out).toMatch(/completed|done/i);
   });
 });
 

--- a/packages/ai-core/src/loop.ts
+++ b/packages/ai-core/src/loop.ts
@@ -55,22 +55,45 @@ const MAX_TOOL_ITERATIONS = 10;
  *     more to say"); the floor just acknowledges and yields the turn
  *     back to the user.
  *
- *   - **Zero actions** (`toolCallsSucceeded === 0 && toolCallsFailed === 0`):
- *     the model emitted no tool calls and no text. Most likely a
- *     model-state weirdness; the floor confesses and invites
- *     redirection.
+ *   - **Awaiting approval** (`toolCallsAwaitingApproval > 0`, nothing
+ *     executed): the turn suspended on the human's decision — the band
+ *     IS the message; the floor points at it instead of denying the
+ *     proposal exists.
+ *
+ *   - **Refused by human** (`toolCallsRefusedByHuman > 0`, nothing
+ *     executed): the human said no. A decision, not an absence of
+ *     action — say so and yield.
+ *
+ *   - **Zero actions** (every counter zero): the model emitted no tool
+ *     calls and no text. Most likely a model-state weirdness; the floor
+ *     confesses and invites redirection.
+ *
+ * #521 floor invariant: NEVER claim "I didn't take any action" when any
+ * tool call was emitted this turn — pending, executed, refused, or
+ * seeded from a pre-continuation execution (the approval path runs the
+ * tool in the streaming layer, then starts a FRESH loop; witnessed live
+ * 2026-08-01: the fallback denied a completed $0.25 hire three times in
+ * one flow because these counters weren't threaded).
  *
  * Doctrine: motebit-computer.md §"Typed truth on results" applied to
- * the turn-completion contract. The runtime promises the user a
- * response per message; this is the mechanical floor that enforces
- * the promise even when model behavior drifts.
+ * the turn-completion contract; composition-preserves-enforcement (the
+ * honesty logic and the money path live in different packages — the
+ * counters are the wire that keeps them composed). The runtime promises
+ * the user a response per message; this is the mechanical floor that
+ * enforces the promise even when model behavior drifts.
  */
 export function synthesizeClosingFallback(args: {
   readonly toolCallsSucceeded: number;
   readonly toolCallsFailed: number;
   readonly lastToolName: string;
+  /** Calls suspended on a human approval this turn (band on screen). */
+  readonly toolCallsAwaitingApproval?: number;
+  /** Calls the human explicitly refused this turn (decision, not failure). */
+  readonly toolCallsRefusedByHuman?: number;
 }): string {
   const { toolCallsSucceeded, toolCallsFailed, lastToolName } = args;
+  const awaiting = args.toolCallsAwaitingApproval ?? 0;
+  const refused = args.toolCallsRefusedByHuman ?? 0;
   if (toolCallsFailed > 0 && toolCallsSucceeded === 0) {
     return lastToolName
       ? `I tried but \`${lastToolName}\` didn't go through — what would you like me to try next?`
@@ -82,7 +105,17 @@ export function synthesizeClosingFallback(args: {
       : `I got partway through (${toolCallsSucceeded}/${toolCallsSucceeded + toolCallsFailed} succeeded) but hit an issue. What should I do next?`;
   }
   if (toolCallsSucceeded > 0) {
-    return "Done. Let me know what's next.";
+    return lastToolName
+      ? `\`${lastToolName}\` completed — the result is above. Let me know what's next.`
+      : "Done. Let me know what's next.";
+  }
+  if (refused > 0) {
+    return lastToolName
+      ? `You declined \`${lastToolName}\` — nothing ran. What would you like instead?`
+      : "You declined that — nothing ran. What would you like instead?";
+  }
+  if (awaiting > 0) {
+    return "That needs your approval — the request is right above.";
   }
   return "I didn't take any action there — what would you like me to do?";
 }
@@ -578,6 +611,22 @@ export interface TurnOptions {
   verifiedGrant?: NonNullable<TurnContext["verifiedGrant"]>;
   /** First conversation ever — no prior history exists. */
   firstConversation?: boolean;
+  /**
+   * #521 — continuation seeding. The approval path executes (or the human
+   * refuses) the gated tool in the STREAMING layer, then starts a fresh
+   * loop for the continuation turn — so this loop's own counters never
+   * saw the action. Witnessed live 2026-08-01: the closing fallback
+   * denied a completed $0.25 hire ("I didn't take any action") because
+   * nothing threaded the pre-continuation execution through. Set by
+   * `resumeAfterApproval`; consumed by the empty-text safety-net gate and
+   * `synthesizeClosingFallback` — raw counters stay pure for metrics.
+   */
+  priorTurnActions?: {
+    /** Tool executed (approved) in the streaming layer before this continuation. */
+    completedToolName?: string;
+    /** Tool the human refused before this continuation. */
+    humanRefusedToolName?: string;
+  };
   /** System-triggered generation — goes into system prompt, not user message. */
   activationPrompt?: string;
   /**
@@ -1017,6 +1066,14 @@ export async function* runTurnStreaming(
   // docs/doctrine/delegation.md + agent-task-handler.ts.
   let toolCallsDenied = 0;
   let toolCallsFailed = 0;
+  // #521 — approval pauses this turn (band on screen when the loop exits).
+  let toolCallsAwaitingApproval = 0;
+  // #521 — continuation seeding (see TurnOptions.priorTurnActions): the
+  // approval path's pre-continuation execution/refusal, threaded so the
+  // closing floor can't deny it. Raw counters stay pure for TurnResult
+  // metrics; only the safety-net gate and the fallback read these.
+  const priorCompletedTool = options?.priorTurnActions?.completedToolName ?? null;
+  const priorRefusedTool = options?.priorTurnActions?.humanRefusedToolName ?? null;
   // Typed-truth log for the dishonest-closing intercept. Captures
   // structured tool result data PRE-sanitization so the typed-truth
   // fields (navigation_triggered, recovery_hint, bot_detection_detected)
@@ -1218,6 +1275,7 @@ export async function* runTurnStreaming(
 
         if (decision.requiresApproval) {
           toolCallsBlocked++;
+          toolCallsAwaitingApproval++;
           const profile = deps.policyGate.classify(toolDef);
           yield {
             type: "approval_request",
@@ -1485,6 +1543,7 @@ export async function* runTurnStreaming(
       // Fallback: no policy gate — use legacy requiresApproval check
       if (toolDef?.requiresApproval === true) {
         toolCallsBlocked++;
+        toolCallsAwaitingApproval++;
         yield {
           type: "approval_request",
           tool_call_id: toolCall.id,
@@ -1653,7 +1712,7 @@ export async function* runTurnStreaming(
   // that got stripped, the user sees nothing. Re-prompt once without tools to
   // force visible text. This typically happens when the model reflects on its
   // own internals after a recall_memories call.
-  if (finalText.trim() === "" && toolCallsSucceeded > 0) {
+  if (finalText.trim() === "" && (toolCallsSucceeded > 0 || priorCompletedTool != null)) {
     conversationHistory.push({
       role: "assistant",
       content: finalResponse.text || "",
@@ -1721,9 +1780,11 @@ export async function* runTurnStreaming(
   // turn-completion contract.
   if (finalText.trim() === "") {
     finalText = synthesizeClosingFallback({
-      toolCallsSucceeded,
+      toolCallsSucceeded: toolCallsSucceeded + (priorCompletedTool != null ? 1 : 0),
       toolCallsFailed,
-      lastToolName,
+      lastToolName: lastToolName || priorCompletedTool || priorRefusedTool || "",
+      toolCallsAwaitingApproval,
+      toolCallsRefusedByHuman: priorRefusedTool != null ? 1 : 0,
     });
     yield { type: "text", text: finalText };
     // Reflect the synthesized text on finalResponse so downstream

--- a/packages/runtime/src/__tests__/streaming.test.ts
+++ b/packages/runtime/src/__tests__/streaming.test.ts
@@ -1430,6 +1430,50 @@ describe("resumeAfterApproval", () => {
     expect(runtime.hasPendingApproval).toBe(false);
     expect(runtime.pendingApprovalInfo).toBeNull();
   });
+
+  // #521 — the continuation loop starts fresh, so what THIS layer just did
+  // (executed on approval / recorded the refusal) must be threaded, or the
+  // loop's closing floor denies a completed money action (witnessed live
+  // 2026-08-01: "I didn't take any action" after a $0.25 hire).
+  it("approved resume threads priorTurnActions.completedToolName into the continuation", async () => {
+    mockRunTurnStreaming.mockReturnValueOnce(
+      yieldChunks(
+        { type: "approval_request", tool_call_id: "tc-p1", name: "delegate_to_agent", args: {} },
+        { type: "result", result: makeTurnResult() },
+      ),
+    );
+    await collectChunks(runtime.sendMessageStreaming("hire someone"));
+    mockRunTurnStreaming.mockReturnValueOnce(
+      yieldChunks({ type: "result", result: makeTurnResult("ok") }),
+    );
+    await collectChunks(runtime.resumeAfterApproval(true));
+
+    const continuationOpts = mockRunTurnStreaming.mock.calls.at(-1)![2] as {
+      priorTurnActions?: { completedToolName?: string; humanRefusedToolName?: string };
+    };
+    expect(continuationOpts.priorTurnActions).toEqual({ completedToolName: "delegate_to_agent" });
+  });
+
+  it("denied resume threads priorTurnActions.humanRefusedToolName into the continuation", async () => {
+    mockRunTurnStreaming.mockReturnValueOnce(
+      yieldChunks(
+        { type: "approval_request", tool_call_id: "tc-p2", name: "delegate_to_agent", args: {} },
+        { type: "result", result: makeTurnResult() },
+      ),
+    );
+    await collectChunks(runtime.sendMessageStreaming("hire someone"));
+    mockRunTurnStreaming.mockReturnValueOnce(
+      yieldChunks({ type: "result", result: makeTurnResult("ok") }),
+    );
+    await collectChunks(runtime.resumeAfterApproval(false));
+
+    const continuationOpts = mockRunTurnStreaming.mock.calls.at(-1)![2] as {
+      priorTurnActions?: { completedToolName?: string; humanRefusedToolName?: string };
+    };
+    expect(continuationOpts.priorTurnActions).toEqual({
+      humanRefusedToolName: "delegate_to_agent",
+    });
+  });
 });
 
 // === External tool registration ===

--- a/packages/runtime/src/streaming.ts
+++ b/packages/runtime/src/streaming.ts
@@ -887,11 +887,18 @@ export class StreamingManager {
         );
       }
 
-      // Run continuation turn with updated history
+      // Run continuation turn with updated history. `priorTurnActions`
+      // threads what THIS layer just did (executed on approval / recorded
+      // the human's refusal) into the fresh loop, so its closing floor
+      // can never deny the action (#521 — witnessed live 2026-08-01:
+      // "I didn't take any action" after a completed $0.25 hire).
       const stream = runTurnStreaming(loopDeps, pending.userMessage, {
         conversationHistory: this.deps.getLiveHistory(),
         previousCues: this.deps.getLatestCues(),
         runId: pending.runId,
+        priorTurnActions: approved
+          ? { completedToolName: pending.toolName }
+          : { humanRefusedToolName: pending.toolName },
       });
       yield* this.processStream(stream, pending.userMessage, pending.runId);
     } finally {


### PR DESCRIPTION
Closes #521. Witnessed live 2026-08-01 on the first local-brain paid hire: a silent model made `synthesizeClosingFallback` say "I didn't take any action there" three times in one flow — while its own `delegate_to_agent` call sat PENDING approval, after the approved $0.25 hire COMPLETED, and after the human's REFUSAL.

Root cause: the fallback's honesty logic branches on counters the approval path never threads — the gated tool executes in the streaming layer, then a FRESH continuation loop starts at zero. Composition-preserves-enforcement, textbook: the honesty logic and the money path live in different packages, and composition severed them.

## Fix

- **loop.ts**: the floor gains honest variants — awaiting approval → "that needs your approval — the request is right above"; refused → "you declined `X` — nothing ran"; completed → "`X` completed — the result is above." Floor invariant: **no-action is only claimable when no call was emitted** (pending, executed, refused, and seeded all count). New `toolCallsAwaitingApproval` counter at both approval yield sites.
- **`TurnOptions.priorTurnActions`** seeds the continuation loop with what the streaming layer just did. Raw counters stay pure for `TurnResult` metrics — only the safety-net gate and the fallback read the seed (deliberate: the continuation's reported metrics don't claim an execution that happened pre-continuation).
- **streaming.ts**: `resumeAfterApproval` threads `{completedToolName | humanRefusedToolName}` into the continuation.

## Tests

Each witnessed firing is a fixture: pending-approval, human-refusal, seeded-completed, plus priority ordering (a completed action is the headline) and the extended never-empty sweep. Runtime side: both resume directions assert the threaded option. ai-core 69 loop tests + runtime 132 streaming tests green.

Changeset: `motebit` patch (shipped CLI behavior — the money-moment sentences change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)