### PR TITLE
feat(runtime,cli): purchased results stay reachable; the band names same-turn spend

### DIFF
--- a/.changeset/purchased-result-visibility.md
+++ b/.changeset/purchased-result-visibility.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+A purchased result can no longer vanish when the model fails to relay it (#522). The inline receipt block now ends with a dim pointer (`· full result: /receipt <id>`), and `/receipt` renders the artifact itself — unwrapping JSON envelopes to the report the buyer paid for. And when a paid delegation has already settled this exchange, any subsequent approval band says so ("a paid hire already completed this turn — this proposes another spend"), stamped by the runtime's own count, never model-authored. Both halves witnessed on the first local-brain hire: a $0.25 report reached the human only as a receipt, followed by a redundant re-spend proposal with nothing on the band naming the money that had already moved.

--- a/apps/cli/src/__tests__/approval-render.test.ts
+++ b/apps/cli/src/__tests__/approval-render.test.ts
@@ -109,6 +109,40 @@ describe("renderApprovalRequest", () => {
     expect(out).toContain("1/3 approvals collected");
   });
 
+  // #522 — witnessed 2026-08-01: a re-spend proposal rendered with nothing
+  // saying money had already moved this exchange.
+  it("names same-turn settled spend when the runtime stamped it", () => {
+    const out = plain(
+      renderApprovalRequest({
+        name: "delegate_to_agent",
+        args: { prompt: "x" },
+        riskLevel: 4,
+        priorSettledThisTurn: 1,
+      }),
+    );
+    expect(out).toContain("already completed this turn");
+    expect(out).toContain("another spend");
+  });
+
+  it("pluralizes multiple settled spends", () => {
+    const out = plain(
+      renderApprovalRequest({
+        name: "delegate_to_agent",
+        args: { prompt: "x" },
+        riskLevel: 4,
+        priorSettledThisTurn: 2,
+      }),
+    );
+    expect(out).toContain("2 paid hires already completed");
+  });
+
+  it("no stamp — no history line", () => {
+    const out = plain(
+      renderApprovalRequest({ name: "delegate_to_agent", args: { prompt: "x" }, riskLevel: 4 }),
+    );
+    expect(out).not.toContain("already completed this turn");
+  });
+
   it("clips a long prompt without letting it wrap the decision off-screen", () => {
     const out = plain(
       renderApprovalRequest({

--- a/apps/cli/src/__tests__/receipt.test.ts
+++ b/apps/cli/src/__tests__/receipt.test.ts
@@ -13,7 +13,7 @@ vi.mock("@motebit/encryption", () => ({
   verifyReceiptChain: (...args: unknown[]) => verifyReceiptChainMock(...args),
 }));
 
-const { renderReceipt } = await import("../receipt.js");
+const { renderReceipt, receiptResultBody } = await import("../receipt.js");
 
 function makeReceipt(overrides: Partial<ExecutionReceipt> = {}): ExecutionReceipt {
   return {
@@ -69,5 +69,33 @@ describe("renderReceipt — identity binding status", () => {
   it("unverified → 'verification failed'", async () => {
     const out = await capture({ verified: false, error: "bad signature", delegations: [] });
     expect(out).toContain("verification failed");
+  });
+});
+
+// === #522 — the purchased artifact must be reachable from the receipt ===
+
+describe("receiptResultBody / includeResult (#522)", () => {
+  it("unwraps a JSON envelope to the report the buyer paid for", () => {
+    const receipt = {
+      task_id: "t-1",
+      result: JSON.stringify({ report: "The findings.\nLine two.", citations: [] }),
+    } as unknown as import("@motebit/sdk").ExecutionReceipt;
+    expect(receiptResultBody(receipt)).toBe("The findings.\nLine two.");
+  });
+
+  it("falls back to the raw string when the result is not an envelope", () => {
+    const receipt = {
+      task_id: "t-2",
+      result: "plain text result",
+    } as unknown as import("@motebit/sdk").ExecutionReceipt;
+    expect(receiptResultBody(receipt)).toBe("plain text result");
+  });
+
+  it("null when there is nothing displayable", () => {
+    const receipt = {
+      task_id: "t-3",
+      result: "",
+    } as unknown as import("@motebit/sdk").ExecutionReceipt;
+    expect(receiptResultBody(receipt)).toBeNull();
   });
 });

--- a/apps/cli/src/approval-render.ts
+++ b/apps/cli/src/approval-render.ts
@@ -37,6 +37,13 @@ export interface ApprovalRequestView {
   quorum?: { required: number; approvers: string[]; collected: string[] };
   /** Hard ceiling from `--budget`, in USD, when the session set one. */
   budgetUsd?: number;
+  /**
+   * #522 — paid delegations that already SETTLED this exchange (stamped by
+   * the runtime, never model-authored). When present, the band names the
+   * fact: the human deciding on a re-spend must see that money already
+   * moved, in the same frame as the Allow?.
+   */
+  priorSettledThisTurn?: number;
 }
 
 /** Truncate for display without lying about it. */
@@ -88,6 +95,19 @@ export function renderApprovalRequest(req: ApprovalRequestView): string[] {
     // The stakes lead. A money act must never be visually indistinguishable
     // from a read — this is the line the founder's $0.26 slipped past.
     lines.push(`  ${warn(bold("⚠ MONEY · IRREVERSIBLE"))}`);
+  }
+
+  // Same-turn spend history (#522): witnessed 2026-08-01 — a model that
+  // failed to digest a delivered result proposed the same hire again, and
+  // nothing on the band said money had already moved this exchange.
+  if (req.priorSettledThisTurn != null && req.priorSettledThisTurn > 0) {
+    lines.push(
+      `  ${warn(
+        req.priorSettledThisTurn === 1
+          ? "A paid hire already completed this turn (receipt above) — this proposes another spend."
+          : `${req.priorSettledThisTurn} paid hires already completed this turn — this proposes another spend.`,
+      )}`,
+    );
   }
 
   for (const [i, line] of describeAction(req.name, req.args).entries()) {

--- a/apps/cli/src/attached-repl.ts
+++ b/apps/cli/src/attached-repl.ts
@@ -35,6 +35,7 @@ interface WireChunk {
   code?: string;
   tool_name?: string;
   risk_level?: number;
+  prior_settled_this_turn?: number;
   receipt?: { task_id?: string; status?: string };
 }
 
@@ -42,6 +43,7 @@ interface PendingApproval {
   name: string;
   args: Record<string, unknown>;
   riskLevel?: number;
+  priorSettledThisTurn?: number;
 }
 
 async function renderStream(
@@ -99,6 +101,9 @@ async function renderStream(
             name: chunk.name ?? "tool",
             args: chunk.args ?? {},
             ...(chunk.risk_level != null ? { riskLevel: chunk.risk_level } : {}),
+            ...(chunk.prior_settled_this_turn != null
+              ? { priorSettledThisTurn: chunk.prior_settled_this_turn }
+              : {}),
           };
           break;
         case "delegation_start":
@@ -179,6 +184,9 @@ async function renderTurn(
       name: pendingApproval.name,
       args: pendingApproval.args,
       ...(pendingApproval.riskLevel != null ? { riskLevel: pendingApproval.riskLevel } : {}),
+      ...(pendingApproval.priorSettledThisTurn != null
+        ? { priorSettledThisTurn: pendingApproval.priorSettledThisTurn }
+        : {}),
     })) {
       writeLine(line);
     }

--- a/apps/cli/src/commands/invoke.ts
+++ b/apps/cli/src/commands/invoke.ts
@@ -107,9 +107,10 @@ export async function handleReceiptCommand(
     receipt = found.receipt;
   }
   // renderReceipt no longer emits its own blank bracket (#480) — spacing
-  // belongs to the caller.
+  // belongs to the caller. includeResult: /receipt IS the recovery
+  // affordance for a purchased artifact the model failed to relay (#522).
   out("");
-  await renderReceipt(receipt, out);
+  await renderReceipt(receipt, out, undefined, { includeResult: true });
   out("");
 }
 

--- a/apps/cli/src/receipt.ts
+++ b/apps/cli/src/receipt.ts
@@ -184,10 +184,42 @@ function renderReceiptLine(receipt: ExecutionReceipt, depth: number, last: boole
  * Returns the verified flag so callers can compose their own messaging, but
  * does its own output — rendering and verification are paired by design.
  */
+/**
+ * Extract the human-readable artifact from a receipt's `result` field
+ * (#522). Wire results are often JSON envelopes (the Researcher ships
+ * `{report, citations, …}`); the buyer wants the report, not the
+ * envelope. Falls back to the raw string. Null when there is nothing
+ * displayable.
+ */
+export function receiptResultBody(receipt: ExecutionReceipt): string | null {
+  const raw = receipt.result;
+  if (raw == null || (typeof raw === "string" && raw.trim() === "")) return null;
+  const text = typeof raw === "string" ? raw : JSON.stringify(raw);
+  try {
+    const parsed = JSON.parse(text) as Record<string, unknown>;
+    if (parsed != null && typeof parsed === "object" && typeof parsed.report === "string") {
+      return parsed.report;
+    }
+  } catch {
+    // not JSON — the raw string IS the artifact
+  }
+  return text;
+}
+
 export async function renderReceipt(
   receipt: ExecutionReceipt,
   out: (line: string) => void = (s) => console.log(s),
   trustedAnchor?: Map<string, Uint8Array>,
+  opts?: {
+    /**
+     * #522 — render the purchased artifact itself (the receipt's `result`
+     * body). Off on the inline post-delegation render (the model usually
+     * relays it; duplicating would double a long report), on for the
+     * explicit `/receipt` affordance — the recovery path when the model
+     * eats the result.
+     */
+    includeResult?: boolean;
+  },
 ): Promise<{ verified: boolean; error?: string }> {
   // Vertical rhythm is the CALLER's: the stream consumer brackets with
   // writeGap(), the /receipt command with its own spacing (#480). Emitting
@@ -196,6 +228,15 @@ export async function renderReceipt(
   const header = `${dim("─ receipt ")}${dim("·")} ${cyan(shortHash(receipt.task_id))}`;
   out(header);
   for (const line of lines) out(line);
+
+  if (opts?.includeResult === true) {
+    const body = receiptResultBody(receipt);
+    if (body != null) {
+      out("");
+      out(dim("─ result"));
+      for (const bodyLine of body.split("\n")) out(bodyLine);
+    }
+  }
 
   // Offline verify — the "oh" beat that makes the receipt evidence, not a
   // claim. Zero relay contact. Verify against the caller's trusted anchor; with

--- a/apps/cli/src/stream.ts
+++ b/apps/cli/src/stream.ts
@@ -28,6 +28,7 @@ export async function consumeStream(
     args: Record<string, unknown>;
     quorum?: { required: number; approvers: string[]; collected: string[] };
     risk_level?: number;
+    prior_settled_this_turn?: number;
   } | null = null;
   let status: StatusHandle | null = null;
   // Model-latency cover (#480): the row that answers "is anything happening?"
@@ -114,6 +115,8 @@ export async function consumeStream(
             // Carried so the prompt can name the stakes. Previously dropped —
             // which is why a money act rendered identically to a read (#432).
             risk_level: chunk.risk_level,
+            // #522 — runtime-stamped same-turn spend history for the band.
+            prior_settled_this_turn: chunk.prior_settled_this_turn,
           };
           break;
 
@@ -148,6 +151,17 @@ export async function consumeStream(
             archiveReceipt(chunk.full_receipt);
             writeGap();
             await renderReceipt(chunk.full_receipt, (line) => writeOutput(line + "\n"));
+            // #522 — the purchased artifact must stay reachable even when
+            // the model eats it (witnessed 2026-08-01: a \$0.25 report
+            // reached the human only as this receipt). One dim pointer at
+            // the recovery affordance; /receipt renders the result body.
+            if (chunk.full_receipt.result != null && chunk.full_receipt.result !== "") {
+              writeLine(
+                meta(
+                  `  · full result: /receipt ${String(chunk.full_receipt.task_id).slice(0, 12)}`,
+                ),
+              );
+            }
             writeGap();
             if (chunk.full_receipt.status === "completed" && chunk.full_receipt.result) {
               lastCompletedReceiptResult = chunk.full_receipt.result;
@@ -228,6 +242,9 @@ export async function consumeStream(
       ...(pendingApproval.risk_level != null ? { riskLevel: pendingApproval.risk_level } : {}),
       ...(pendingApproval.quorum ? { quorum: pendingApproval.quorum } : {}),
       ...(opts?.budgetUsd != null ? { budgetUsd: opts.budgetUsd } : {}),
+      ...(pendingApproval.prior_settled_this_turn != null
+        ? { priorSettledThisTurn: pendingApproval.prior_settled_this_turn }
+        : {}),
     })) {
       writeLine(line);
     }

--- a/packages/runtime/src/__tests__/streaming.test.ts
+++ b/packages/runtime/src/__tests__/streaming.test.ts
@@ -3532,3 +3532,119 @@ describe("delegate_to_agent receipt beat (#493)", () => {
     expect(beat.full_receipt?.task_id).toBe("task-approved");
   });
 });
+
+// === #522: same-turn spend history stamped onto the approval band ===
+//
+// Witnessed 2026-08-01: a model that failed to digest a delivered result
+// proposed the same hire again, and nothing on the band said money had
+// already moved this exchange. The manager counts its own
+// delegation_complete emissions and stamps the count onto any subsequent
+// approval_request — produced, never model-authored.
+
+describe("approval band spend-history stamp (#522)", () => {
+  let runtime: MotebitRuntime;
+
+  function stashOf(rt: MotebitRuntime): { pushReceipt(r: unknown): void } {
+    return (rt as unknown as { interactiveDelegation: { pushReceipt(r: unknown): void } })
+      .interactiveDelegation;
+  }
+
+  function delegationReceipt(taskId: string): Record<string, unknown> {
+    return {
+      task_id: taskId,
+      motebit_id: "worker-1",
+      status: "completed",
+      tools_used: ["research"],
+      result: "the purchased report",
+      signature: "sig-" + taskId,
+      public_key: "aa".repeat(32),
+      prompt_hash: "",
+      result_hash: "",
+      submitted_at: Date.now(),
+      completed_at: Date.now(),
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runtime = new MotebitRuntime(
+      { motebitId: "spend-stamp-test", tickRateHz: 0 },
+      createAdapters(createMockProvider()),
+    );
+  });
+
+  it("an approval_request AFTER a settled delegation carries prior_settled_this_turn", async () => {
+    mockRunTurnStreaming.mockReturnValueOnce(
+      (async function* () {
+        yield {
+          type: "tool_status" as const,
+          name: "delegate_to_agent",
+          status: "calling" as const,
+        };
+        stashOf(runtime).pushReceipt(delegationReceipt("task-settle-1"));
+        yield {
+          type: "tool_status" as const,
+          name: "delegate_to_agent",
+          status: "done" as const,
+          result: "done",
+        };
+        // The witnessed re-proposal: a second hire in the same stream.
+        yield {
+          type: "approval_request" as const,
+          tool_call_id: "tc-respend",
+          name: "delegate_to_agent",
+          args: { prompt: "again" },
+          risk_level: 4,
+        };
+        yield { type: "result" as const, result: makeTurnResult() };
+      })(),
+    );
+
+    const chunks = await collectChunks(runtime.sendMessageStreaming("hire a researcher"));
+    const band = chunks.find((c) => c.type === "approval_request") as
+      { prior_settled_this_turn?: number } | undefined;
+    expect(band).toBeDefined();
+    expect(band!.prior_settled_this_turn).toBe(1);
+  });
+
+  it("a fresh user exchange resets the count — the band stays clean", async () => {
+    // First exchange settles a delegation.
+    mockRunTurnStreaming.mockReturnValueOnce(
+      (async function* () {
+        yield {
+          type: "tool_status" as const,
+          name: "delegate_to_agent",
+          status: "calling" as const,
+        };
+        stashOf(runtime).pushReceipt(delegationReceipt("task-settle-2"));
+        yield {
+          type: "tool_status" as const,
+          name: "delegate_to_agent",
+          status: "done" as const,
+          result: "done",
+        };
+        yield { type: "result" as const, result: makeTurnResult() };
+      })(),
+    );
+    await collectChunks(runtime.sendMessageStreaming("hire someone"));
+
+    // Next user message: new exchange, new proposal — no stale history.
+    mockRunTurnStreaming.mockReturnValueOnce(
+      (async function* () {
+        yield {
+          type: "approval_request" as const,
+          tool_call_id: "tc-fresh",
+          name: "delegate_to_agent",
+          args: { prompt: "new thing" },
+          risk_level: 4,
+        };
+        yield { type: "result" as const, result: makeTurnResult() };
+      })(),
+    );
+    const chunks = await collectChunks(runtime.sendMessageStreaming("do something new"));
+    const band = chunks.find((c) => c.type === "approval_request") as
+      { prior_settled_this_turn?: number } | undefined;
+    expect(band).toBeDefined();
+    expect(band!.prior_settled_this_turn).toBeUndefined();
+  });
+});

--- a/packages/runtime/src/runtime-config.ts
+++ b/packages/runtime/src/runtime-config.ts
@@ -402,6 +402,17 @@ export type StreamChunk =
       args: Record<string, unknown>;
       risk_level?: number;
       quorum?: { required: number; approvers: string[]; collected: string[] };
+      /**
+       * #522 — count of paid delegations that already SETTLED in this
+       * exchange, stamped by the streaming manager (produced, never
+       * model-authored) when > 0. Surface honesty for the band: the human
+       * deciding on a re-spend sees "a hire already completed this turn"
+       * in the same frame as the Allow?. Witnessed 2026-08-01: a model
+       * that failed to digest a delivered result immediately proposed the
+       * same hire again, and nothing on the band said money had already
+       * moved.
+       */
+      prior_settled_this_turn?: number;
     }
   | { type: "injection_warning"; tool_name: string; patterns: string[] }
   | { type: "approval_expired"; tool_name: string }

--- a/packages/runtime/src/streaming.ts
+++ b/packages/runtime/src/streaming.ts
@@ -300,6 +300,14 @@ export class StreamingManager {
    * mis-classify.
    */
   private readonly deniedToolsThisExchange = new Set<string>();
+  /**
+   * #522 — paid delegations that SETTLED in this exchange (a
+   * `delegation_complete` carrying a receipt passed through). Reset with
+   * the denial brake at each genuine user turn; stamped onto any
+   * subsequent `approval_request` so the band can say "a hire already
+   * completed this turn" at the decision moment.
+   */
+  private settledDelegationsThisExchange = 0;
   private approvalExpiredCallback: (() => void) | null = null;
   /** Fired when a NEW turn voids a pending approval (#462) — the owning surface renders the void. */
   private approvalVoidedCallback: ((toolName: string) => void) | null = null;
@@ -386,6 +394,7 @@ export class StreamingManager {
    */
   beginExchange(): void {
     this.deniedToolsThisExchange.clear();
+    this.settledDelegationsThisExchange = 0;
   }
 
   /** Shared stream processing — extracts state tags, handles tool/approval/injection chunks. */
@@ -557,6 +566,7 @@ export class StreamingManager {
               }
             }
             this.deps.setDelegating(false);
+            this.settledDelegationsThisExchange++;
             yield {
               type: "delegation_complete",
               server: motebitServer,
@@ -580,6 +590,7 @@ export class StreamingManager {
             delegateStashMark = null;
             const stashed = this.deps.delegationReceiptStash?.peekSince(mark) ?? [];
             for (const receipt of stashed) {
+              this.settledDelegationsThisExchange++;
               yield {
                 type: "delegation_complete",
                 server: "relay",
@@ -694,6 +705,17 @@ export class StreamingManager {
 
         this.startApprovalTimeout();
         this.deps.pushStateUpdate({ processing: 0.5 });
+
+        // #522 — stamp settled-spend history onto the band's chunk
+        // (produced by this layer's own count, never model-authored). The
+        // human deciding on a re-spend sees that money already moved this
+        // exchange, in the same frame as the Allow?. Witnessed 2026-08-01:
+        // a model that failed to digest a delivered result proposed the
+        // same hire again with nothing on the band saying so.
+        if (this.settledDelegationsThisExchange > 0) {
+          (chunk as { prior_settled_this_turn?: number }).prior_settled_this_turn =
+            this.settledDelegationsThisExchange;
+        }
       }
 
       // Injection warning — processing dips, personality shifts deferred
@@ -816,6 +838,9 @@ export class StreamingManager {
         if (approvedStashMark != null) {
           const stashed = this.deps.delegationReceiptStash?.peekSince(approvedStashMark) ?? [];
           for (const receipt of stashed) {
+            // #522 — the post-approval hire is the exact settled spend the
+            // witnessed re-proposal followed; count it.
+            this.settledDelegationsThisExchange++;
             yield {
               type: "delegation_complete" as const,
               server: "relay",


### PR DESCRIPTION
Closes #522. Witnessed 2026-08-01 on the first local-brain paid hire: the researcher's report went into the model as tool output and vanished — the $0.25 artifact reached the human ONLY as a receipt — and the model then proposed the same hire again with nothing on the band saying money had already moved. Both halves are runtime-produced honesty; neither depends on model quality.

## Same-turn spend history on the band

The streaming manager counts its own `delegation_complete` emissions per exchange — all three emission sites (MCP path, #493 stash path, post-approval resume), reset with the denial brake at each genuine user turn — and stamps `prior_settled_this_turn` onto any subsequent `approval_request`. Produced by the layer's own ledger, never model-authored. The CLI band renders it right under the money warning: **"A paid hire already completed this turn (receipt above) — this proposes another spend."** Attached REPL sibling wired.

## The purchased artifact stays reachable

- `receiptResultBody()` unwraps JSON envelopes (`{report, …}`) to the artifact the buyer paid for; falls back to the raw string.
- `/receipt` renders the result body — the recovery affordance for a report the model ate (verified missing before: `renderReceipt` never printed `result`).
- The inline receipt block ends with a dim pointer: `· full result: /receipt <task-id-prefix>` — always true, one line, calm register (the founder's stranded report becomes one command away).
- Deliberately NOT rendered inline in full: when the model relays properly, duplicating a long report would double it.

## Tests

Runtime: stamp-after-settle + fresh-exchange-reset (2, reusing the #493 harness). CLI: band line singular/plural/absent (3), `receiptResultBody` envelope/raw/empty (3). Full CLI suite 426 green; runtime streaming suite green.

Changeset: `motebit` patch. The `[Now]` proprioceptive act-state endgame stays tracked on the issue for the next sensorium increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)