### PR TITLE
fix(runtime-host,cli): the election root follows the config root

### DIFF
--- a/.changeset/socket-root-follows-config-dir.md
+++ b/.changeset/socket-root-follows-config-dir.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+The runtime-host election root now follows the config root (#512): with `MOTEBIT_CONFIG_DIR` set, the coordinator socket and lockfile live inside it instead of always at `~/.motebit/` — a sandboxed or scaffolded instance is a different sovereign and elects its own coordinator, never silently attaching its chat turns to the user's live runtime under the user's identity. The normal case is byte-identical. Unix socket paths past the OS `sun_path` limit (~104 chars) now fail loud at construction naming the repair (a shorter config dir), and the election-failure message distinguishes bind problems (path/permissions/stale socket) from attach problems (incompatible coordinator) instead of blaming the wrong one.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -737,12 +737,21 @@ async function main(): Promise<void> {
     });
   } catch (err: unknown) {
     destroyTerminal();
-    console.error(
-      `Runtime-host election failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    console.error(
-      "Another motebit process may be coordinating with an incompatible build. Stop it and retry.",
-    );
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`Runtime-host election failed: ${msg}`);
+    // #512 — bind failures and attach failures have different causes and
+    // different repairs; the old one-size advice ("incompatible build")
+    // sent the 2026-07-31 socket-path bug hunting in the wrong direction.
+    if (/bind failed|socket path|sun_path|ENOENT|EACCES/i.test(msg)) {
+      console.error(
+        "The socket could not be created — check the config directory exists and the path is short enough " +
+          "(unix sockets cap at ~104 chars), and remove a stale runtime.sock if one is left over.",
+      );
+    } else {
+      console.error(
+        "Another motebit process may be coordinating with an incompatible build. Stop it and retry.",
+      );
+    }
     process.exit(1);
   }
   if (election.role === "frontend") {

--- a/apps/cli/src/runtime-host.ts
+++ b/apps/cli/src/runtime-host.ts
@@ -17,8 +17,9 @@ import {
   type RuntimeHostPaths,
   type RuntimeHostServer,
 } from "@motebit/runtime-host";
-import { defaultRuntimeHostPaths, nodePlatform } from "@motebit/runtime-host/node";
+import { runtimeHostPathsForDir, nodePlatform } from "@motebit/runtime-host/node";
 import { computerDefinition } from "@motebit/tools/web-safe";
+import { CONFIG_DIR } from "./config.js";
 import type { FullConfig } from "./config.js";
 import { fromHex, loadActiveSigningKey } from "./identity.js";
 
@@ -61,7 +62,13 @@ export { pickSafeChatOptions as pickChatOptions, pickSafeInvokeOptions as pickIn
  * is our own; anything else refuses fail-closed.
  */
 export async function electCliRuntimeHost(deps: CliElectionDeps): Promise<ElectionOutcome> {
-  const paths = deps.paths ?? defaultRuntimeHostPaths();
+  // #512 — the election root FOLLOWS the config root. A sandboxed
+  // MOTEBIT_CONFIG_DIR is a different sovereign; deriving the socket from
+  // homedir() attached it to the user's live coordinator (identity
+  // category error, witnessed 2026-07-31). CONFIG_DIR already resolves
+  // the override or defaults to ~/.motebit, so the normal case is
+  // byte-identical to before (desktop shares the same root).
+  const paths = deps.paths ?? runtimeHostPathsForDir(CONFIG_DIR);
   const deviceId = deps.fullConfig.device_id;
   const devicePublicKey = deps.fullConfig.device_public_key;
 

--- a/packages/runtime-host/src/__tests__/paths.test.ts
+++ b/packages/runtime-host/src/__tests__/paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { defaultRuntimeHostPaths } from "../paths.js";
+import { defaultRuntimeHostPaths, runtimeHostPathsForDir } from "../paths.js";
 
 describe("defaultRuntimeHostPaths", () => {
   it("resolves the unix socket + lockfile under ~/.motebit", () => {
@@ -24,5 +24,39 @@ describe("defaultRuntimeHostPaths", () => {
     const b = defaultRuntimeHostPaths("C:\\Users\\dave", "win32");
     expect(a.socketPath).not.toBe(b.socketPath);
     expect(defaultRuntimeHostPaths("C:\\Users\\carol", "win32").socketPath).toBe(a.socketPath);
+  });
+});
+
+// #512 — the election root follows the config root. A sandboxed
+// MOTEBIT_CONFIG_DIR is a different sovereign; sharing homedir()'s socket
+// attached it to the user's live coordinator (witnessed 2026-07-31).
+describe("runtimeHostPathsForDir", () => {
+  it("puts socket + lockfile inside the given config root", () => {
+    const paths = runtimeHostPathsForDir("/tmp/agent-a/.motebit", "linux");
+    expect(paths.socketPath).toBe("/tmp/agent-a/.motebit/runtime.sock");
+    expect(paths.lockfilePath).toBe("/tmp/agent-a/.motebit/runtime.lock");
+  });
+
+  it("two config roots elect independently — different sockets", () => {
+    const a = runtimeHostPathsForDir("/tmp/agent-a/.motebit", "linux");
+    const b = runtimeHostPathsForDir("/tmp/agent-b/.motebit", "linux");
+    expect(a.socketPath).not.toBe(b.socketPath);
+  });
+
+  it("defaultRuntimeHostPaths is the same derivation rooted at ~/.motebit", () => {
+    expect(defaultRuntimeHostPaths("/home/alice", "linux")).toEqual(
+      runtimeHostPathsForDir("/home/alice/.motebit", "linux"),
+    );
+  });
+
+  it("fails LOUD past the unix sun_path limit, naming the repair", () => {
+    const deep = "/tmp/" + "x".repeat(120) + "/.motebit";
+    expect(() => runtimeHostPathsForDir(deep, "darwin")).toThrow(/shorter|limit|104/i);
+  });
+
+  it("windows named pipes have no length constraint — deep dirs hash fine", () => {
+    const deep = "C:\\Users\\" + "x".repeat(200) + "\\.motebit";
+    const paths = runtimeHostPathsForDir(deep, "win32");
+    expect(paths.socketPath).toMatch(/^\\\\\.\\pipe\\motebit-runtime-[0-9a-f]{16}$/);
   });
 });

--- a/packages/runtime-host/src/node.ts
+++ b/packages/runtime-host/src/node.ts
@@ -1,4 +1,4 @@
 // Node host entry — the only module in this package permitted to pull
 // node:net / node:fs / node:os into a consumer's bundle.
 export { nodePlatform } from "./node-platform.js";
-export { defaultRuntimeHostPaths } from "./paths.js";
+export { defaultRuntimeHostPaths, runtimeHostPathsForDir } from "./paths.js";

--- a/packages/runtime-host/src/paths.ts
+++ b/packages/runtime-host/src/paths.ts
@@ -18,14 +18,33 @@ import { join } from "node:path";
 import type { RuntimeHostPaths } from "./paths-shared.js";
 
 /**
- * Resolve the canonical endpoint for a home directory. Both arguments
- * are injectable for tests; production callers pass nothing.
+ * Practical `sun_path` ceiling for unix domain sockets. macOS caps at 104
+ * bytes, Linux at 108; binding beyond it truncates or fails with errors
+ * that blame the wrong thing (witnessed 2026-07-31, #512: a deep
+ * `MOTEBIT_CONFIG_DIR` produced a truncated bind followed by a chmod
+ * ENOENT that surfaced as "incompatible build"). Fail LOUD at path
+ * construction instead.
  */
-export function defaultRuntimeHostPaths(
-  home: string = homedir(),
+const MAX_UNIX_SOCKET_PATH = 100;
+
+/**
+ * Resolve the runtime-host endpoint for an explicit config-root directory
+ * (#512). The config root and the election root are ONE concept: a
+ * process whose identity/config lives in `<dir>` must elect on
+ * `<dir>/runtime.sock` — deriving the socket from `homedir()` while the
+ * config dir was overridden attached a DIFFERENT sovereign's sandbox to
+ * the user's live coordinator (an identity category error, not a
+ * convenience bug). Callers with a `MOTEBIT_CONFIG_DIR`-style override
+ * pass it here; `defaultRuntimeHostPaths` delegates with the default
+ * root.
+ *
+ * Throws on unix socket paths beyond the OS `sun_path` limit — the
+ * repair is a shorter config dir, and the error says so.
+ */
+export function runtimeHostPathsForDir(
+  dir: string,
   platform: NodeJS.Platform = process.platform,
 ): RuntimeHostPaths {
-  const dir = join(home, ".motebit");
   if (platform === "win32") {
     const tag = createHash("sha256").update(dir).digest("hex").slice(0, 16);
     return {
@@ -33,8 +52,27 @@ export function defaultRuntimeHostPaths(
       lockfilePath: join(dir, "runtime.lock"),
     };
   }
+  const socketPath = join(dir, "runtime.sock");
+  if (socketPath.length > MAX_UNIX_SOCKET_PATH) {
+    throw new Error(
+      `runtime-host socket path is ${socketPath.length} chars — over the OS unix-socket limit (~104). ` +
+        `The config directory is too deep for a socket: use a shorter MOTEBIT_CONFIG_DIR (e.g. under /tmp). ` +
+        `Path: ${socketPath}`,
+    );
+  }
   return {
-    socketPath: join(dir, "runtime.sock"),
+    socketPath,
     lockfilePath: join(dir, "runtime.lock"),
   };
+}
+
+/**
+ * Resolve the canonical endpoint for a home directory. Both arguments
+ * are injectable for tests; production callers pass nothing.
+ */
+export function defaultRuntimeHostPaths(
+  home: string = homedir(),
+  platform: NodeJS.Platform = process.platform,
+): RuntimeHostPaths {
+  return runtimeHostPathsForDir(join(home, ".motebit"), platform);
 }


### PR DESCRIPTION
Closes #512. A sandboxed `MOTEBIT_CONFIG_DIR` is a DIFFERENT sovereign — deriving `runtime.sock` from `homedir()` unconditionally attached its chat turns to the user's live coordinator under the user's identity (a category error per surface-authority doctrine: frontends attach to a coordinator that shares their identity, and a config-dir sandbox doesn't). Witnessed 2026-07-31 building the qwen3 PTY harness, which had to override `HOME` to escape it.

## Fix

- **runtime-host**: `runtimeHostPathsForDir(dir)` — the config root and the election root are ONE concept; `defaultRuntimeHostPaths` delegates with `~/.motebit`, so the normal case (CLI and desktop sharing the home root) is byte-identical to before. Unix socket paths past the `sun_path` limit (~104 chars) throw at construction with the repair named — the witnessed failure mode was a truncated bind followed by chmod ENOENT surfaced as "incompatible build".
- **cli**: `electCliRuntimeHost` derives paths from `CONFIG_DIR` (which already resolves the `MOTEBIT_CONFIG_DIR` override or defaults to `~/.motebit`). The election-failure message splits bind-shaped causes (path/permissions/stale socket, with the sun_path hint) from attach-shaped ones (incompatible coordinator).

## Tests

runtime-host paths: config-root derivation, independent sandbox elections, default≡delegation equivalence, loud sun_path failure, Windows named-pipe indifference to depth. Full runtime-host suite 122 green; CLI suite 420 green.

Changeset: `motebit` patch (runtime-host is private; the shipped behavior change is the CLI's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)