### PR TITLE
perf(research): prompt caching in the worker loop; cost meter on the hire path

### DIFF
--- a/services/research/src/__tests__/research.test.ts
+++ b/services/research/src/__tests__/research.test.ts
@@ -29,7 +29,7 @@ vi.mock("@motebit/mcp-client", () => ({
 
 import { querySelfKnowledge } from "@motebit/self-knowledge";
 import type { AdapterFactory, AtomAdapter, ResearchConfig, SignedReceipt } from "../research.js";
-import { research } from "../research.js";
+import { research, withPrefixCacheBreakpoint } from "../research.js";
 
 /**
  * In-memory AtomAdapter — the injectable test seam. Mirrors
@@ -785,8 +785,11 @@ describe("research — cryptographic citation chain (via mcp-client)", () => {
 
     expect(result.search_count).toBe(2);
     expect(result.report).toContain("Forced synthesis");
-    const finalCall = mockCreate.mock.calls[2]![0] as { system: string };
-    expect(finalCall.system).toContain("tool budget exhausted");
+    // System is now a cached block array; the budget note rides as an
+    // uncached second block so the cached prefix stays byte-identical.
+    const finalCall = mockCreate.mock.calls[2]![0] as { system: Array<{ text: string }> };
+    const systemText = finalCall.system.map((b) => b.text).join("\n");
+    expect(systemText).toContain("tool budget exhausted");
   });
 
   it("declares the three-tier tool set (interior + web search + web fetch) to Claude", async () => {
@@ -795,17 +798,21 @@ describe("research — cryptographic citation chain (via mcp-client)", () => {
       ...baseConfig,
       adapterFactory: () => new StubAtomAdapter([]),
     });
-    const call = mockCreate.mock.calls[0]![0] as { tools: Array<{ name: string }>; system: string };
+    const call = mockCreate.mock.calls[0]![0] as {
+      tools: Array<{ name: string }>;
+      system: Array<{ text: string }>;
+    };
     expect(call.tools.map((t) => t.name).sort()).toEqual([
       "motebit_read_url",
       "motebit_recall_self",
       "motebit_web_search",
     ]);
     // Interior-first guidance must be visible in the system prompt.
-    expect(call.system).toContain("motebit_recall_self");
-    expect(call.system).toContain("motebit_web_search");
-    expect(call.system).toContain("motebit_read_url");
-    expect(call.system).toContain("FIRST");
+    const systemText = call.system.map((b) => b.text).join("\n");
+    expect(systemText).toContain("motebit_recall_self");
+    expect(systemText).toContain("motebit_web_search");
+    expect(systemText).toContain("motebit_read_url");
+    expect(systemText).toContain("FIRST");
   });
 
   // ── Interior tier (Ring 1: recall_self) ──
@@ -1536,5 +1543,101 @@ describe("research — report shape guard (#504)", () => {
 
     const result = await run(adapters);
     expect(result.report).toBe(NOTES);
+  });
+});
+
+// === Prompt caching + cache-aware cost (2026-08-01, the reprice lever) ===
+
+describe("research — prompt caching", () => {
+  beforeEach(() => mockCreate.mockReset());
+
+  const stubFactory = () =>
+    makeFactory(
+      new Map([
+        ["web-search", new StubAtomAdapter([])],
+        ["read-url", new StubAtomAdapter([])],
+      ]),
+    );
+
+  it("every loop request carries cached system, cached tools, and a prefix breakpoint", async () => {
+    mockCreate.mockResolvedValueOnce({ content: [{ type: "text", text: "Direct answer." }] });
+    await research("q", { ...baseConfig, adapterFactory: stubFactory() });
+
+    const req = mockCreate.mock.calls[0]![0] as {
+      system: Array<{ text: string; cache_control?: { type: string } }>;
+      tools: Array<{ cache_control?: { type: string } }>;
+      messages: Array<{ content: unknown }>;
+    };
+    expect(req.system[0]!.cache_control).toEqual({ type: "ephemeral" });
+    expect(req.tools.at(-1)!.cache_control).toEqual({ type: "ephemeral" });
+    // The user question (a string message) was converted to a marked block.
+    const lastMsg = req.messages.at(-1)! as {
+      content: Array<{ type: string; cache_control?: { type: string } }>;
+    };
+    expect(lastMsg.content.at(-1)!.cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  it("the canonical messages array stays clean — breakpoints never accumulate", async () => {
+    const receipt = makeReceipt({
+      task_id: "cache-1",
+      motebit_id: "web-search-agent",
+      result: "[]",
+      signature: "sig-c1",
+    });
+    const ws = new StubAtomAdapter([receipt]);
+    const ru = new StubAtomAdapter([]);
+    mockCreate
+      .mockResolvedValueOnce({
+        content: [
+          { type: "tool_use", id: "tu-1", name: "motebit_web_search", input: { query: "q" } },
+        ],
+      })
+      .mockResolvedValueOnce({ content: [{ type: "text", text: "Synthesized." }] });
+
+    await research("q", {
+      ...baseConfig,
+      adapterFactory: makeFactory(
+        new Map([
+          ["web-search", ws],
+          ["read-url", ru],
+        ]),
+      ),
+    });
+
+    const secondReq = mockCreate.mock.calls[1]![0] as {
+      messages: Array<{ content: unknown }>;
+    };
+    // Exactly ONE message-level breakpoint per request (the moving one on
+    // the last message) — earlier messages carry none.
+    let marked = 0;
+    for (const m of secondReq.messages) {
+      if (Array.isArray(m.content)) {
+        for (const b of m.content as Array<{ cache_control?: unknown }>) {
+          if (b.cache_control != null) marked++;
+        }
+      }
+    }
+    expect(marked).toBe(1);
+  });
+
+  it("cost estimate prices cache writes at 1.25x and reads at 0.1x input", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: "Direct answer." }],
+      usage: {
+        input_tokens: 1000,
+        output_tokens: 1000,
+        cache_creation_input_tokens: 10000,
+        cache_read_input_tokens: 100000,
+      },
+    });
+    const result = await research("q", { ...baseConfig, adapterFactory: stubFactory() });
+    // 1000*3 + 1000*15 + 10000*3.75 + 100000*0.3  = 3000+15000+37500+30000 = 85_500 / 1e6
+    expect(result.cost_estimate_usd).toBeCloseTo(0.0855, 6);
+  });
+
+  it("withPrefixCacheBreakpoint edge shapes: empty list and empty block array pass through", () => {
+    expect(withPrefixCacheBreakpoint([])).toEqual([]);
+    const empty = [{ role: "user" as const, content: [] }];
+    expect(withPrefixCacheBreakpoint(empty)).toEqual(empty);
   });
 });

--- a/services/research/src/index.ts
+++ b/services/research/src/index.ts
@@ -214,8 +214,10 @@ async function main(): Promise<void> {
               "empty report body — refusing to sign a completed receipt over an empty artifact",
             );
           }
+          // The reprice tuning signal (2026-08-01): cost was logged only on
+          // the unused tool-registry path — the HIRE path priced blind.
           log(
-            `research complete: ${r.report.length} chars, ${r.recall_self_count} interior, ${r.search_count} searches, ${r.fetch_count} fetches, ${r.citations.length} citations`,
+            `research complete: ${r.report.length} chars, ${r.recall_self_count} interior, ${r.search_count} searches, ${r.fetch_count} fetches, ${r.citations.length} citations, report_cost_estimate_usd=${r.cost_estimate_usd.toFixed(4)}`,
           );
           delegationReceipts = r.delegation_receipts as unknown as Record<string, unknown>[];
           // The wire payload now carries the citation list. Interior

--- a/services/research/src/research.ts
+++ b/services/research/src/research.ts
@@ -303,6 +303,47 @@ const TOOLS: Anthropic.Tool[] = [
   },
 ];
 
+/**
+ * Prompt caching (2026-08-01, the reprice lever): the loop re-sends the
+ * ENTIRE growing history — including every fetched page — on every
+ * iteration, and it ran uncached, which is where the 26–42¢/report
+ * worst case came from. The static prefix (system + tools) and the
+ * conversation prefix are cache-marked; iterations land seconds apart,
+ * far inside the 5-minute TTL, so iterations 2..N read the prefix at
+ * 0.1× input price. The moving breakpoint is applied per REQUEST to a
+ * shallow copy — the canonical `messages` array stays clean, so markers
+ * never accumulate past the API's 4-breakpoint limit.
+ */
+const CACHED_SYSTEM: Anthropic.TextBlockParam[] = [
+  { type: "text", text: SYSTEM_PROMPT, cache_control: { type: "ephemeral" } },
+];
+
+const CACHED_TOOLS: Anthropic.Tool[] = TOOLS.map((t, i) =>
+  i === TOOLS.length - 1 ? { ...t, cache_control: { type: "ephemeral" as const } } : t,
+);
+
+/** Request-time shallow copy with a cache breakpoint on the final content
+ * block of the final message — caches the whole conversation prefix. */
+export function withPrefixCacheBreakpoint(
+  messages: Anthropic.MessageParam[],
+): Anthropic.MessageParam[] {
+  const last = messages[messages.length - 1];
+  if (last == null) return messages;
+  const mark = { cache_control: { type: "ephemeral" as const } };
+  if (typeof last.content === "string") {
+    return [
+      ...messages.slice(0, -1),
+      { ...last, content: [{ type: "text", text: last.content, ...mark }] },
+    ] as Anthropic.MessageParam[];
+  }
+  if (Array.isArray(last.content) && last.content.length > 0) {
+    const blocks = [...last.content];
+    blocks[blocks.length - 1] = { ...blocks[blocks.length - 1], ...mark } as never;
+    return [...messages.slice(0, -1), { ...last, content: blocks }] as Anthropic.MessageParam[];
+  }
+  return messages;
+}
+
 // === Optional relay budget binding ===
 
 /**
@@ -479,10 +520,28 @@ export async function research(question: string, config: ResearchConfig): Promis
     let recallSelfCount = 0;
     // claude-sonnet-4-6 list pricing per million tokens; estimate only —
     // logged per report so the operator can tune MOTEBIT_UNIT_COST.
+    // Cache tiers: writes bill 1.25x input, reads 0.1x — the loop's
+    // repeated prefix makes reads dominate from iteration 2 on.
     const USD_PER_M_INPUT = 3;
     const USD_PER_M_OUTPUT = 15;
+    const USD_PER_M_CACHE_WRITE = 3.75;
+    const USD_PER_M_CACHE_READ = 0.3;
     let inputTokens = 0;
     let outputTokens = 0;
+    let cacheWriteTokens = 0;
+    let cacheReadTokens = 0;
+    const addUsage = (u: Anthropic.Message["usage"] | undefined): void => {
+      inputTokens += u?.input_tokens ?? 0;
+      outputTokens += u?.output_tokens ?? 0;
+      cacheWriteTokens += u?.cache_creation_input_tokens ?? 0;
+      cacheReadTokens += u?.cache_read_input_tokens ?? 0;
+    };
+    const costUsd = (): number =>
+      (inputTokens * USD_PER_M_INPUT +
+        outputTokens * USD_PER_M_OUTPUT +
+        cacheWriteTokens * USD_PER_M_CACHE_WRITE +
+        cacheReadTokens * USD_PER_M_CACHE_READ) /
+      1e6;
     let searchCount = 0;
     let fetchCount = 0;
     let toolCallCount = 0;
@@ -722,14 +781,13 @@ export async function research(question: string, config: ResearchConfig): Promis
       const response = await client.messages.create({
         model: "claude-sonnet-4-6",
         max_tokens: 4096,
-        system: SYSTEM_PROMPT,
-        tools: TOOLS,
-        messages,
+        system: CACHED_SYSTEM,
+        tools: CACHED_TOOLS,
+        messages: withPrefixCacheBreakpoint(messages),
       });
 
       // Optional-chained: unit-test mocks omit usage; the live API always sends it.
-      inputTokens += response.usage?.input_tokens ?? 0;
-      outputTokens += response.usage?.output_tokens ?? 0;
+      addUsage(response.usage);
 
       const toolUses = response.content.filter(
         (b): b is Anthropic.ToolUseBlock => b.type === "tool_use",
@@ -742,15 +800,11 @@ export async function research(question: string, config: ResearchConfig): Promis
           lastContent: response.content,
           report: responseText(response.content),
           citations,
-          addUsage: (r) => {
-            inputTokens += r.usage?.input_tokens ?? 0;
-            outputTokens += r.usage?.output_tokens ?? 0;
-          },
+          addUsage: (r) => addUsage(r.usage),
         });
         return {
           report,
-          cost_estimate_usd:
-            (inputTokens * USD_PER_M_INPUT + outputTokens * USD_PER_M_OUTPUT) / 1e6,
+          cost_estimate_usd: costUsd(),
           delegation_receipts: delegationReceipts,
           sub_settlements: subSettlements,
           routing_transcripts: routingTranscripts,
@@ -773,28 +827,30 @@ export async function research(question: string, config: ResearchConfig): Promis
     const finalResponse = await client.messages.create({
       model: "claude-sonnet-4-6",
       max_tokens: 4096,
-      system:
-        SYSTEM_PROMPT +
-        "\n\nNote: tool budget exhausted. Synthesize a report from what you've already gathered.",
-      messages,
+      // The cached system block stays byte-identical (prefix hit); the
+      // budget-exhausted note rides as a second, uncached block.
+      system: [
+        ...CACHED_SYSTEM,
+        {
+          type: "text",
+          text: "Note: tool budget exhausted. Synthesize a report from what you've already gathered.",
+        },
+      ],
+      messages: withPrefixCacheBreakpoint(messages),
     });
-    inputTokens += finalResponse.usage?.input_tokens ?? 0;
-    outputTokens += finalResponse.usage?.output_tokens ?? 0;
+    addUsage(finalResponse.usage);
     const report = await ensureReport({
       client,
       messages,
       lastContent: finalResponse.content,
       report: responseText(finalResponse.content),
       citations,
-      addUsage: (r) => {
-        inputTokens += r.usage?.input_tokens ?? 0;
-        outputTokens += r.usage?.output_tokens ?? 0;
-      },
+      addUsage: (r) => addUsage(r.usage),
     });
 
     return {
       report,
-      cost_estimate_usd: (inputTokens * USD_PER_M_INPUT + outputTokens * USD_PER_M_OUTPUT) / 1e6,
+      cost_estimate_usd: costUsd(),
       delegation_receipts: delegationReceipts,
       sub_settlements: subSettlements,
       routing_transcripts: routingTranscripts,


### PR DESCRIPTION
Born from the founder's reprice question ("should research cost $0.25?") — which hit two findings before any number could answer it:

**The tuning signal was blind on the real path.** `report_cost_estimate_usd` logged only on the unused tool-registry handler; `handleAgentTask` — the path every actual hire takes — never logged cost. We were pricing blind. Now the hire path logs it.

**The loop ran uncached.** Every iteration re-sent the ENTIRE growing history — every fetched page — at full input price: the source of the 26–42¢/report worst case, meaning $0.25 was likely *below* cost on heavy runs. Now: system + tools are cache-marked constants, and a moving prefix breakpoint is applied per request to a SHALLOW COPY — the canonical `messages` array stays clean, so markers never accumulate past the API's 4-breakpoint limit. Iterations land seconds apart, far inside the 5-minute TTL, so iterations 2..N read the prefix at 0.1×. The cost estimate now prices cache writes (1.25×) and reads (0.1×) from `usage`.

## Reprice plan (not in this PR)

Expected new floor: ~$0.06–0.12 inference + ~3–6¢ atoms + 5% relay fee ≈ 11–19¢. `MOTEBIT_UNIT_COST` stays 0.25 until 2–3 logged runs confirm; candidate reprice **$0.15** (ops env change + CLI price-table sweep), floor $0.10 — nonzero stays load-bearing for anti-sybil economics and the settlement thesis.

## Tests

Request-shape (cached system/tools + breakpoint on the string-question first call), canonical-array cleanliness (exactly ONE message-level marker on iteration 2), cache-aware cost math, edge shapes. Two existing assertions adapted to the block-array system (budget-note now rides as an uncached second block so the cached prefix stays byte-identical). 69 green, 100% coverage held.

No changeset (service is private); auto-deploys on merge — the next hire is the first metered data point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)