### PR TITLE
fix(ai-core): 'default' tier resolves to the user's model — never the family workhorse

### DIFF
--- a/.changeset/default-tier-users-model.md
+++ b/.changeset/default-tier-users-model.md
@@ -1,0 +1,5 @@
+---
+"motebit": patch
+---
+
+Background tasks no longer borrow a model you didn't choose (#533): the task router's `default` tier now resolves to the current model — the sovereign's choice — in every provider family, instead of the family's workhorse SKU (which silently hopped brain and billing for every routed internal operation, witnessed when the mode row caught the deferred memory-formation pass mid-borrow on sonnet-5 under a sonnet-4-6 session). `strongest` and `fast` keep their family mappings — they express deliberate deviation. Found and diagnosed live by the 1.13.0 observability stack: the mode row surfaced the hop, and the substrate facet's second ask confirmed race-not-leak.

--- a/packages/ai-core/src/__tests__/coverage-uplift.test.ts
+++ b/packages/ai-core/src/__tests__/coverage-uplift.test.ts
@@ -169,20 +169,30 @@ describe("isModelTier", () => {
 });
 
 describe("resolveModelTier", () => {
-  it("resolves Anthropic family tiers", () => {
+  // #533 — 'default' means the USER'S model, in every family. Witnessed
+  // 2026-08-01: the old family-workhorse mapping hopped the deferred
+  // memory-formation pass onto sonnet-5 under a sonnet-4-6 session; the
+  // mode row caught the borrow and the substrate facet's second ask
+  // confirmed the restore. Default-as-current makes the hop structurally
+  // impossible for default-tier tasks.
+  it("'default' resolves to the current model — the sovereign's choice, every family", () => {
+    expect(resolveModelTier("default", "claude-sonnet-4-6")).toBe("claude-sonnet-4-6");
+    expect(resolveModelTier("default", "claude-haiku-3")).toBe("claude-haiku-3");
+    expect(resolveModelTier("default", "o1-preview")).toBe("o1-preview");
+    expect(resolveModelTier("default", "gemini-1.5-flash")).toBe("gemini-1.5-flash");
+    expect(resolveModelTier("default", "qwen3:latest")).toBe("qwen3:latest");
+  });
+  it("resolves Anthropic family deviation tiers", () => {
     expect(resolveModelTier("strongest", "claude-sonnet-4-5-20250929")).toBe("claude-opus-5");
-    expect(resolveModelTier("default", "claude-haiku-3")).toBe("claude-sonnet-5");
     expect(resolveModelTier("fast", "anthropic-x")).toBe("claude-haiku-4-5");
   });
-  it("resolves OpenAI family tiers", () => {
+  it("resolves OpenAI family deviation tiers", () => {
     expect(resolveModelTier("strongest", "gpt-5.4-mini")).toBe("gpt-5.4");
-    expect(resolveModelTier("default", "o1-preview")).toBe("gpt-5.4-mini");
     expect(resolveModelTier("fast", "o3-pro")).toBe("gpt-5.4-nano");
     expect(resolveModelTier("fast", "o4-mini")).toBe("gpt-5.4-nano");
   });
-  it("resolves Google family tiers", () => {
+  it("resolves Google family deviation tiers", () => {
     expect(resolveModelTier("strongest", "gemini-2.0-pro")).toBe("gemini-2.5-pro");
-    expect(resolveModelTier("default", "gemini-1.5-flash")).toBe("gemini-2.5-flash");
     expect(resolveModelTier("fast", "google-gemma")).toBe("gemini-2.5-flash-lite");
   });
   it("falls back to currentModel for unknown providers (Ollama, WebLLM, etc.)", () => {

--- a/packages/ai-core/src/task-router.ts
+++ b/packages/ai-core/src/task-router.ts
@@ -116,23 +116,34 @@ export function isModelTier(model: string): model is ModelTier {
 /**
  * Resolve a model tier to a concrete model ID based on the provider's current model.
  *
- * The current model reveals which provider family is active (Anthropic, OpenAI,
- * Google, Ollama, WebLLM). The tier resolves to the best available model in
- * that family. If the current model doesn't match a known family, the tier
- * resolves to the current model (no-op — use whatever's loaded).
+ * **`default` means the USER'S model** (#533): from the sovereign's seat,
+ * "default" is whatever they chose — never the family's workhorse SKU.
+ * The old mapping (`default` → claude-sonnet-5 / gpt-5.4-mini / …)
+ * silently replaced an explicit model choice for every routed background
+ * task, hopping brain and billing to a SKU the user never picked —
+ * witnessed 2026-08-01 when the mode row caught the deferred
+ * memory-formation pass mid-borrow on sonnet-5 under a sonnet-4-6
+ * session, and the substrate facet's second ask confirmed the restore
+ * (race, not leak). `default` resolving to `currentModel` also makes the
+ * tier a structural no-op — no hop, no race surface, nothing to catch
+ * mid-flight.
+ *
+ * `strongest` and `fast` express DELIBERATE deviation intent and keep
+ * their family mappings (real API aliases, not family names — #474): the
+ * current model reveals which family is active; the tier resolves within
+ * it. If the current model doesn't match a known family, every tier
+ * resolves to the current model (the user loaded a specific model; it's
+ * all we have).
  */
 export function resolveModelTier(tier: ModelTier, currentModel: string): string {
+  // The sovereign's seat: "default" IS the current model, in every family.
+  if (tier === "default") return currentModel;
+
   // Detect provider family from current model
   if (currentModel.includes("claude") || currentModel.includes("anthropic")) {
-    // Real API aliases, not family names: the previous values
-    // ("claude-opus" etc.) are not servable model ids — a tier switch fed
-    // them to provider.setModel() and 404'd the turn (#471's sibling,
-    // found in the same sweep).
     switch (tier) {
       case "strongest":
         return "claude-opus-5";
-      case "default":
-        return "claude-sonnet-5";
       case "fast":
         return "claude-haiku-4-5";
     }
@@ -147,8 +158,6 @@ export function resolveModelTier(tier: ModelTier, currentModel: string): string 
     switch (tier) {
       case "strongest":
         return "gpt-5.4";
-      case "default":
-        return "gpt-5.4-mini";
       case "fast":
         return "gpt-5.4-nano";
     }
@@ -158,8 +167,6 @@ export function resolveModelTier(tier: ModelTier, currentModel: string): string 
     switch (tier) {
       case "strongest":
         return "gemini-2.5-pro";
-      case "default":
-        return "gemini-2.5-flash";
       case "fast":
         return "gemini-2.5-flash-lite";
     }

--- a/packages/runtime/src/runtime-config.ts
+++ b/packages/runtime/src/runtime-config.ts
@@ -23,7 +23,10 @@ import type { PolicyConfig, MemoryGovernanceConfig, GrantSpendStore } from "@mot
 /**
  * Default task router config for planning operations.
  * Uses the strongest model for decomposition + reflection — bad plans cascade.
- * Step execution stays on the user's current model (auto-routed per message).
+ * Step execution stays on the user's current model: since #533, tier
+ * "default" RESOLVES to the current model in every family (the sovereign's
+ * choice), so non-overridden tasks are a structural no-op hop — the old
+ * family-workhorse mapping silently borrowed a SKU the user never picked.
  *
  * Class aliases ("claude-opus") are resolved to current dated versions by the
  * proxy's resolveModelAlias(). When Anthropic ships a new Opus, update the


### PR DESCRIPTION
Closes #533. Witnessed 2026-08-01, minutes after 1.13.0 installed: the mode row read `claude-sonnet-5` under a `claude-sonnet-4-6` session — the deferred memory-formation pass, routed at tier `default`, had borrowed the family workhorse SKU. The founder diagnosed it live with the substrate facet itself: a second "what model are you running?" cited sonnet-4-6 and the mode row snapped back — race confirmed, leak ruled out, `withTaskConfig`'s restore vindicated. The display was honest; the SEMANTICS were wrong.

## Fix

`resolveModelTier`: tier **`default` returns `currentModel` in every family** — from the sovereign's seat, "default" is whatever they chose. This makes the hop *structurally impossible* for default-tier tasks: no switch, no race surface, nothing to catch mid-flight. `strongest` and `fast` keep their family mappings (real API aliases per #474) because they express deliberate deviation intent — the only kind of borrow the mode row should ever witness again.

Bonus honesty: `PLANNING_TASK_ROUTER`'s doc comment always *claimed* "step execution stays on the user's current model" — the mechanism now matches its own words.

## Tests

Tier suite rewritten around the contract: a dedicated default-is-sovereign case sweeping five families (including the witnessed `claude-sonnet-4-6` and `qwen3:latest`), deviation tiers pinned unchanged, unknown-family fallback pinned. ai-core 583 green.

Changeset: `motebit` patch → 1.13.1. Live validation beat reserved for the founder: post-install, the mode row must never leave the chosen model across a memory-forming turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)