### PR TITLE
fix(relay): allocation payouts release the ledger hold, never the row's claim

### DIFF
--- a/.changeset/ledger-derived-allocation-release.md
+++ b/.changeset/ledger-derived-allocation-release.md
@@ -1,0 +1,15 @@
+---
+"@motebit/relay": patch
+---
+
+Allocation payouts release what the ledger holds, never what the row claims.
+
+`amount_locked` is a claim; the `allocation_hold`/`allocation_release` ledger
+rows are the fact. Allocation rows also exist on never-debited paths, so
+crediting `amount_locked` minted balance the relay never received — as
+`allocation_release`, a type carrying neither the dispute-window hold nor the
+promotional-grant hold, and therefore immediately withdrawable. Both the
+stale-allocation sweep and the retry-exhaustion refund now derive the payout
+from `getAllocationHoldRemaining`. The sweep is extracted as
+`releaseStaleAllocations` so tests drive the deployed function rather than a
+re-implementation of it.

--- a/services/relay/src/__tests__/money-loop-failures.test.ts
+++ b/services/relay/src/__tests__/money-loop-failures.test.ts
@@ -174,41 +174,20 @@ describe("Money Loop Failure Injection", () => {
       .prepare("UPDATE relay_allocations SET created_at = ? WHERE task_id = ?")
       .run(Date.now() - 3_700_000, taskId);
 
-    // Run the stale cleanup logic manually (same as the interval callback)
-    const now = Date.now();
-    const staleAllocations = relay.moteDb.db
-      .prepare(
-        "SELECT allocation_id, task_id, motebit_id, amount_locked FROM relay_allocations WHERE status = 'locked' AND created_at < ?",
-      )
-      .all(now - 3_600_000) as Array<{
-      allocation_id: string;
-      task_id: string;
-      motebit_id: string;
-      amount_locked: number;
-    }>;
-
-    expect(staleAllocations.length).toBeGreaterThan(0);
-
-    // Import creditAccount to perform the cleanup
-    const { creditAccount } = await import("../accounts.js");
-
-    relay.moteDb.db.exec("BEGIN");
-    for (const a of staleAllocations) {
-      creditAccount(
-        relay.moteDb.db,
-        worker.motebitId,
-        a.amount_locked,
-        "allocation_release",
-        a.allocation_id,
-        `Stale allocation release for task ${a.task_id}`,
-      );
-    }
-    relay.moteDb.db
-      .prepare(
-        "UPDATE relay_allocations SET status = 'released', released_at = ? WHERE status = 'locked' AND created_at < ?",
-      )
-      .run(now, now - 3_600_000);
-    relay.moteDb.db.exec("COMMIT");
+    // Drive the REAL cleanup function the interval calls — not a copy of it.
+    // This test used to re-implement the loop body inline ("same as the
+    // interval callback"), which is a modeled composition: it stayed green no
+    // matter what the deployed loop actually did, and would not have caught the
+    // release-the-claim-not-the-ledger mint. `releaseStaleAllocations` is
+    // exported for exactly this reason.
+    const { releaseStaleAllocations } = await import("../index.js");
+    const released = releaseStaleAllocations(
+      relay.moteDb.db,
+      Date.now(),
+      3_600_000,
+      () => worker.motebitId,
+    );
+    expect(released).toBeGreaterThan(0);
 
     // Funds returned to delegator
     const afterBalance = await getBalance(relay, worker.motebitId);

--- a/services/relay/src/__tests__/stale-allocation-release-ledger.test.ts
+++ b/services/relay/src/__tests__/stale-allocation-release-ledger.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Payout sites release what the LEDGER holds, never what the allocation row
+ * claims.
+ *
+ * `amount_locked` is a CLAIM; the `allocation_hold` / `allocation_release`
+ * ledger rows are the FACT. Allocation rows also exist on never-debited paths —
+ * free agents, and (before the funding check was corrected) any listing priced
+ * above zero whose `pay_to_address` was absent, which read as free. Crediting
+ * `amount_locked` against such a row mints balance the relay never received.
+ *
+ * This is the larger of the two legs in that family, and the easier to reach:
+ *
+ *   - the settlement credit pays the worker NET and needs a signed receipt;
+ *   - this pays the delegator the full GROSS and needs nothing but patience —
+ *     book the row, never return a receipt, wait out the horizon.
+ *
+ * It is also the more dangerous payout: `allocation_release` carries neither
+ * the dispute-window hold nor the promotional-grant hold, so minted balance is
+ * immediately withdrawable/sweepable as real cash. `reconcileLedger` cannot see
+ * it — the credit is itself a ledger row, so the balance equation stays
+ * self-consistent.
+ *
+ * ## Why these rows are seeded directly
+ *
+ * The submission-time fix means the API will no longer CREATE a priced-but-
+ * unfunded allocation, so the state has to be seeded to be tested at all.
+ *
+ * Measured against production at the time of writing: 1,861 allocations, of
+ * which 1,387 `settled` and 474 `released` — **zero `locked`**, and no
+ * `reference_id` has ever released more than it held. So this guard is
+ * FORWARD-LOOKING, not remediation: nothing in the live ledger is currently
+ * awaiting a payout it could mint from. The invariant still has to hold,
+ * because a submission-time check cannot protect a row that is already booked,
+ * and any future path that books one lands here.
+ *
+ * ## Why this drives the real function
+ *
+ * The prior coverage (`money-loop-failures.test.ts`) re-implemented the cleanup
+ * loop's body inside the test — "same as the interval callback." A modeled
+ * composition proves nothing about the deployed path: it stays green no matter
+ * what the real loop does. `releaseStaleAllocations` was extracted so this
+ * suite drives production code, and the interval now calls the same function.
+ *
+ * Severing: restore either payout to `alloc.amount_locked` and the unfunded
+ * cases below go red with a minted credit.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import type { SyncRelay } from "../index.js";
+import { releaseStaleAllocations } from "../index.js";
+import { createTestRelay, seedBalance } from "./test-helpers.js";
+import { getAccountBalance, toMicro, debitSpendableAccount } from "../accounts.js";
+
+let relay: SyncRelay | undefined;
+
+afterEach(async () => {
+  await relay?.close();
+  relay = undefined;
+});
+
+const HORIZON_MS = 3_600_000;
+
+/** Insert an allocation row, optionally backed by a real ledger debit. */
+function seedAllocation(
+  r: SyncRelay,
+  opts: { taskId: string; motebitId: string; claimMicro: number; funded: boolean; ageMs: number },
+): string {
+  const allocationId = `x402-${opts.taskId}`;
+  if (opts.funded) {
+    // A real hold: credit the delegator, then debit under the allocation
+    // reference exactly as the submission path does.
+    seedBalance(r, opts.motebitId, opts.claimMicro / 1_000_000 + 1);
+    debitSpendableAccount(
+      r.moteDb.db,
+      opts.motebitId,
+      opts.claimMicro,
+      "allocation_hold",
+      allocationId,
+      "test hold",
+    );
+  }
+  r.moteDb.db
+    .prepare(
+      "INSERT INTO relay_allocations (allocation_id, task_id, motebit_id, amount_locked, status, created_at) VALUES (?, ?, ?, ?, 'locked', ?)",
+    )
+    .run(allocationId, opts.taskId, opts.motebitId, opts.claimMicro, Date.now() - opts.ageMs);
+  return allocationId;
+}
+
+function balance(r: SyncRelay, id: string): number {
+  return getAccountBalance(r.moteDb.db, id)?.balance ?? 0;
+}
+
+function releaseCredits(r: SyncRelay, id: string): number {
+  const row = r.moteDb.db
+    .prepare(
+      "SELECT COALESCE(SUM(amount), 0) as t FROM relay_transactions WHERE motebit_id = ? AND type = 'allocation_release'",
+    )
+    .get(id) as { t: number };
+  return row.t;
+}
+
+describe("stale-allocation release pays the ledger, not the claim", () => {
+  it("mints nothing for an allocation that was never debited", async () => {
+    relay = await createTestRelay();
+    // The exploit shape: a locked row claiming $1.00 with no hold behind it.
+    seedAllocation(relay, {
+      taskId: "task-unfunded",
+      motebitId: "attacker",
+      claimMicro: toMicro(1),
+      funded: false,
+      ageMs: HORIZON_MS + 60_000,
+    });
+    expect(balance(relay, "attacker")).toBe(0);
+
+    const released = releaseStaleAllocations(
+      relay.moteDb.db,
+      Date.now(),
+      HORIZON_MS,
+      () => undefined,
+    );
+    expect(released).toBe(1); // considered…
+
+    // …but nothing minted. This is the whole invariant.
+    expect(releaseCredits(relay, "attacker")).toBe(0);
+    expect(balance(relay, "attacker")).toBe(0);
+
+    // The row is still retired, so it stops being reconsidered every tick.
+    const status = relay.moteDb.db
+      .prepare("SELECT status FROM relay_allocations WHERE task_id = ?")
+      .get("task-unfunded") as { status: string };
+    expect(status.status).toBe("released");
+  });
+
+  it("returns exactly the held amount for a genuinely funded allocation", async () => {
+    relay = await createTestRelay();
+    const claim = toMicro(1);
+    seedAllocation(relay, {
+      taskId: "task-funded",
+      motebitId: "honest",
+      claimMicro: claim,
+      funded: true,
+      ageMs: HORIZON_MS + 60_000,
+    });
+    const before = balance(relay, "honest");
+
+    releaseStaleAllocations(relay.moteDb.db, Date.now(), HORIZON_MS, () => undefined);
+
+    // The delegator is made whole — exactly the hold, no more.
+    expect(releaseCredits(relay, "honest")).toBe(claim);
+    expect(balance(relay, "honest")).toBe(before + claim);
+  });
+
+  it("never releases twice — a second sweep is a no-op", async () => {
+    relay = await createTestRelay();
+    const claim = toMicro(1);
+    seedAllocation(relay, {
+      taskId: "task-twice",
+      motebitId: "honest2",
+      claimMicro: claim,
+      funded: true,
+      ageMs: HORIZON_MS + 60_000,
+    });
+
+    releaseStaleAllocations(relay.moteDb.db, Date.now(), HORIZON_MS, () => undefined);
+    const afterFirst = balance(relay, "honest2");
+    releaseStaleAllocations(relay.moteDb.db, Date.now(), HORIZON_MS, () => undefined);
+
+    expect(balance(relay, "honest2")).toBe(afterFirst);
+    expect(releaseCredits(relay, "honest2")).toBe(claim);
+  });
+
+  it("leaves allocations inside the horizon alone", async () => {
+    relay = await createTestRelay();
+    seedAllocation(relay, {
+      taskId: "task-fresh",
+      motebitId: "fresh",
+      claimMicro: toMicro(1),
+      funded: true,
+      ageMs: 60_000, // well inside the horizon
+    });
+
+    expect(releaseStaleAllocations(relay.moteDb.db, Date.now(), HORIZON_MS, () => undefined)).toBe(
+      0,
+    );
+    expect(releaseCredits(relay, "fresh")).toBe(0);
+    const status = relay.moteDb.db
+      .prepare("SELECT status FROM relay_allocations WHERE task_id = ?")
+      .get("task-fresh") as { status: string };
+    expect(status.status).toBe("locked");
+  });
+
+  it("credits the task's submitter when the task is still queued", async () => {
+    relay = await createTestRelay();
+    const claim = toMicro(1);
+    seedAllocation(relay, {
+      taskId: "task-delegated",
+      motebitId: "worker",
+      claimMicro: claim,
+      funded: true,
+      ageMs: HORIZON_MS + 60_000,
+    });
+
+    // Delegator resolution routes the refund away from the allocation's own
+    // motebit_id when the queue knows who submitted it.
+    releaseStaleAllocations(relay.moteDb.db, Date.now(), HORIZON_MS, () => "delegator");
+
+    expect(releaseCredits(relay, "delegator")).toBe(claim);
+    expect(releaseCredits(relay, "worker")).toBe(0);
+  });
+});

--- a/services/relay/src/index.ts
+++ b/services/relay/src/index.ts
@@ -151,6 +151,7 @@ import {
   createProofTable,
   createWalletTable,
   creditAccount,
+  getAllocationHoldRemaining,
   storeSettlementProof,
 } from "./accounts.js";
 import { createPairingTables, registerPairingRoutes } from "./pairing.js";
@@ -201,6 +202,101 @@ export interface X402Config {
 
 /** Callback to query shutdown state. Injected by standalone boot, unused in tests. */
 export type ShutdownStateGetter = () => boolean;
+
+const staleAllocationLogger = createLogger({ service: "stale-allocations" });
+
+/**
+ * Release budget allocations that have sat `'locked'` past the horizon with no
+ * settlement, returning the held funds to the delegator.
+ *
+ * **Releases what the LEDGER holds, never `amount_locked`.** The row's
+ * `amount_locked` is a claim; the ledger is the fact. Allocation rows are also
+ * written on never-debited paths — free agents, and (before the funding check
+ * was corrected) any listing priced above zero whose `pay_to_address` was
+ * absent, which read as free. Crediting `amount_locked` against such a row
+ * mints balance the relay never received, as `allocation_release` — a type
+ * carrying neither the dispute-window hold nor the promotional-grant hold, so
+ * immediately withdrawable. `reconcileLedger` cannot see it either: the credit
+ * is itself a ledger row, so the balance equation stays self-consistent.
+ *
+ * The x402 lane is safe under this rule rather than in spite of it. An x402
+ * payment is credited to the delegator as a `deposit` BEFORE the hold is taken,
+ * so a task that never allocated leaves that deposit sitting in the delegator's
+ * balance — there is nothing to release because they were never debited, and
+ * they are not out of pocket. Releasing `amount_locked` there would pay them
+ * twice.
+ *
+ * Extracted from the cleanup interval so tests drive THIS function rather than
+ * a re-implementation of it. The previous coverage
+ * (`money-loop-failures.test.ts`) copied the loop body into the test — a
+ * modeled composition that stays green no matter what the real loop does.
+ *
+ * @param resolveDelegator maps a task id to its submitter, when the task is
+ *   still in the queue; falls back to the allocation's own `motebit_id`.
+ * @returns the number of allocations released.
+ */
+export function releaseStaleAllocations(
+  db: MotebitDatabase["db"],
+  now: number,
+  horizonMs: number,
+  resolveDelegator: (taskId: string) => string | undefined,
+): number {
+  try {
+    const cutoff = now - horizonMs;
+    const stale = db
+      .prepare(
+        "SELECT allocation_id, task_id, motebit_id, amount_locked FROM relay_allocations WHERE status = 'locked' AND created_at < ?",
+      )
+      .all(cutoff) as Array<{
+      allocation_id: string;
+      task_id: string;
+      motebit_id: string;
+      amount_locked: number;
+    }>;
+    if (stale.length === 0) return 0;
+
+    db.exec("BEGIN");
+    try {
+      for (const alloc of stale) {
+        const held = getAllocationHoldRemaining(db, alloc.allocation_id);
+        if (held <= 0) {
+          // Nothing was ever debited for this row (or it was already
+          // released). Skip the credit; the status flip below still retires
+          // the row so it stops being reconsidered every tick.
+          staleAllocationLogger.warn("stale_allocation.unfunded_skipped", {
+            allocationId: alloc.allocation_id,
+            taskId: alloc.task_id,
+            claimed: alloc.amount_locked,
+            reason:
+              "allocation holds nothing on the ledger — never debited (best-effort path) or already released; release skipped to prevent minting unfunded balance",
+          });
+          continue;
+        }
+        creditAccount(
+          db,
+          resolveDelegator(alloc.task_id) ?? alloc.motebit_id,
+          held,
+          "allocation_release",
+          alloc.allocation_id,
+          `Stale allocation release for task ${alloc.task_id}`,
+        );
+      }
+      db.prepare(
+        "UPDATE relay_allocations SET status = 'released', released_at = ? WHERE status = 'locked' AND created_at < ?",
+      ).run(now, cutoff);
+      db.exec("COMMIT");
+      return stale.length;
+    } catch (err) {
+      db.exec("ROLLBACK");
+      staleAllocationLogger.error("stale_allocation.release_failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return 0;
+    }
+  } catch {
+    return 0; // Best-effort cleanup
+  }
+}
 
 export interface SyncRelayConfig {
   dbPath?: string;
@@ -774,47 +870,12 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
       // Best-effort — no-op if auto_vacuum mode differs
     }
     // Release stale budget allocations locked > 1 hour with no settlement.
-    // Return held funds to the delegator's virtual account.
-    try {
-      const staleAllocations = moteDb.db
-        .prepare(
-          "SELECT allocation_id, task_id, motebit_id, amount_locked FROM relay_allocations WHERE status = 'locked' AND created_at < ?",
-        )
-        .all(now - STALE_ALLOCATION_HORIZON_MS) as Array<{
-        allocation_id: string;
-        task_id: string;
-        motebit_id: string;
-        amount_locked: number;
-      }>;
-
-      if (staleAllocations.length > 0) {
-        moteDb.db.exec("BEGIN");
-        try {
-          for (const alloc of staleAllocations) {
-            const taskEntry = taskQueue.get(alloc.task_id);
-            const delegatorId = taskEntry?.submitted_by ?? alloc.motebit_id;
-            creditAccount(
-              moteDb.db,
-              delegatorId,
-              alloc.amount_locked,
-              "allocation_release",
-              alloc.allocation_id,
-              `Stale allocation release for task ${alloc.task_id}`,
-            );
-          }
-          moteDb.db
-            .prepare(
-              "UPDATE relay_allocations SET status = 'released', released_at = ? WHERE status = 'locked' AND created_at < ?",
-            )
-            .run(now, now - STALE_ALLOCATION_HORIZON_MS);
-          moteDb.db.exec("COMMIT");
-        } catch {
-          moteDb.db.exec("ROLLBACK");
-        }
-      }
-    } catch {
-      // Best-effort cleanup
-    }
+    releaseStaleAllocations(
+      moteDb.db,
+      now,
+      STALE_ALLOCATION_HORIZON_MS,
+      (taskId) => taskQueue.get(taskId)?.submitted_by,
+    );
   });
 
   // --- WebSocket routes ---
@@ -1453,10 +1514,29 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
             return;
           }
           const delegatorId = taskEntry?.submitted_by ?? alloc.motebit_id;
+          // Refund what the LEDGER holds, never `amount_locked` — the row is a
+          // claim, the ledger is the fact. A never-debited allocation (free
+          // agent, or the priced-but-unpayable listing that used to read as
+          // free) would otherwise mint balance here as `allocation_release`,
+          // which carries no dispute-window or grant hold and is therefore
+          // immediately withdrawable. Same rule as `releaseStaleAllocations`.
+          const heldRemaining = getAllocationHoldRemaining(moteDb.db, alloc.allocation_id);
+          if (heldRemaining <= 0) {
+            moteDb.db.exec("ROLLBACK");
+            logger.warn("settlement.retry.refund_skipped_unfunded", {
+              retryId: retry.retry_id,
+              taskId: retry.task_id,
+              allocationId: alloc.allocation_id,
+              claimed: alloc.amount_locked,
+              reason:
+                "allocation holds nothing on the ledger — never debited or already released; refund skipped to prevent minting unfunded balance",
+            });
+            return;
+          }
           creditAccount(
             moteDb.db,
             delegatorId,
-            alloc.amount_locked,
+            heldRemaining,
             "allocation_release",
             alloc.allocation_id,
             `Retry exhaustion refund for task ${retry.task_id}`,
@@ -1472,7 +1552,10 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
               retry.task_id,
               alloc.allocation_id,
               delegatorId,
-              alloc.amount_locked,
+              // The audit row records what was actually refunded (the ledger
+              // hold), not what the allocation row claimed — otherwise the
+              // refund log asserts a payout that never happened.
+              heldRemaining,
               Date.now(),
             );
           moteDb.db.exec("COMMIT");
@@ -1480,7 +1563,8 @@ export async function createSyncRelay(config: SyncRelayConfig): Promise<SyncRela
             refundId,
             taskId: retry.task_id,
             allocationId: alloc.allocation_id,
-            amount: alloc.amount_locked,
+            amount: heldRemaining,
+            claimed: alloc.amount_locked,
             delegator: delegatorId,
           });
         } catch (txnErr) {


### PR DESCRIPTION
Closes the **larger** leg of the unfunded-mint family. Fixes #548.

`amount_locked` is a **claim**; the `allocation_hold` / `allocation_release` ledger rows are the **fact**. Allocation rows also exist on never-debited paths — free agents, and (before the funding check was corrected) any listing priced above zero whose `pay_to_address` was absent, which read as free. Two payout sites credited `amount_locked` with no ledger check:

- the stale-allocation sweep (1h horizon, `index.ts`)
- the retry-exhaustion refund

Both now credit `getAllocationHoldRemaining(...)`, skipping with a warn when the ledger holds nothing.

## Why this leg is worse than the settlement-credit leg

| | settlement credit (#541) | these two sites |
|---|---|---|
| amount | worker **net** (~95%) | full **gross** |
| requires | a signed receipt | **nothing** — book the row, never reply, wait |
| credit type | `settlement_credit` | `allocation_release` |
| dispute-window hold | yes | **none** |
| grant hold | n/a | **none** |
| withdrawable | after the window | **immediately** |

`reconcileLedger` cannot see any of it: the credit is itself a ledger row, so the balance equation stays self-consistent.

## Scope — measured against production, not asserted

```
allocations: 1861   settled: 1387   released: 474   locked: 0
refs where releases exceeded holds: 0
```

So this guard is **forward-looking, not remediation**. It fires on nothing at deploy and can strand no refund, because there is no `locked` row for either payout site to act on, and the vector was never exercised historically.

It matters because a submission-time check cannot protect a row that is *already booked*, and any future path that books one lands here. (An earlier draft of this PR described it as protecting rows already in production — that overstated it, and the wording is corrected here and in the test's docblock.)

## The x402 lane is safe *under* this rule, not in spite of it

The review of the previous money PR raised this as a possible false negative, and it resolves in favour of the ledger-derived rule. An x402 payment is credited to the delegator as a **`deposit`** *before* the hold is taken. So a task that never allocated leaves that deposit sitting in the delegator's balance — nothing to release because they were never debited, and they are not out of pocket. Releasing `amount_locked` there would have paid them **twice**.

## A modeled composition was hiding this

`money-loop-failures.test.ts` re-implemented the cleanup loop's body inside the test — literally commented *"Run the stale cleanup logic manually (same as the interval callback)"*. That is a modeled composition: it stays green no matter what the deployed loop does, and could never have caught this bug.

The sweep is now extracted as the exported `releaseStaleAllocations`; the interval calls it, and both suites drive **that** function. The converted test is proven to discriminate — severing the real function turns it red, which it previously was not. This is the `composition-preserves-enforcement` "reduce the seams" half: the test and the deployed path are now the same code.

## Verification

New suite (`stale-allocation-release-ledger.test.ts`), seeding rows directly because #552 means the API can no longer create them:

1. never-debited row → **nothing minted**, balance stays 0, row still retired so it stops being reconsidered every tick
2. genuinely funded row → returns **exactly** the hold, no more
3. double sweep → second pass is a no-op
4. inside the horizon → untouched, stays `locked`
5. delegator resolution → refund routes to the submitter, not the allocation's own id

**Severing proven:** restoring `alloc.amount_locked` mints on case 1 while 2–5 hold.

Also records the **actual** refunded amount in `relay_refund_log` rather than the row's claim — an audit row asserting a payout that never happened is its own defect.

Relay suite **1534 green**; **139** drift defenses green; typecheck and lint clean.

## Relationship to #552

Siblings, not duplicates. #552 stops priced-but-unpayable listings from being *created*; this stops any booked row from *paying out* more than it holds. Neither subsumes the other, and this one is independent of #552's economics question — it changes no behavior for any correctly-funded allocation.

Unrelated finding surfaced while measuring: #554 (legacy dollar-denominated ledger rows from March 2026 — inert, but historical analysis over that window mixes units).

🤖 Generated with [Claude Code](https://claude.com/claude-code)