### PR TITLE
chore(core-identity): graduate to the identity coverage floor, 2 days early

### DIFF
--- a/coverage-graduation.json
+++ b/coverage-graduation.json
@@ -6,50 +6,110 @@
     {
       "package": "@motebit/core-identity",
       "vitest_config": "packages/core-identity/vitest.config.ts",
-      "current": { "statements": 82, "branches": 86, "functions": 83, "lines": 82 },
-      "target": { "statements": 85, "branches": 80, "functions": 85, "lines": 85 },
+      "current": {
+        "statements": 85,
+        "branches": 86,
+        "functions": 85,
+        "lines": 85
+      },
+      "target": {
+        "statements": 85,
+        "branches": 80,
+        "functions": 85,
+        "lines": 85
+      },
       "target_date": "2026-08-15",
-      "rationale": "Short of the identity floor (85/80/85/85) on statements/functions/lines — the gap is the service-layer error/retry branches in bootstrap + register-with-relay, exercised today only on the happy path. Plan: a dedicated PR adding register-with-relay failure-path tests (relay 4xx/5xx, signature-mismatch) + bootstrap re-entry/partial-state tests, which cover the uncovered branches without touching the pure crypto. Lever: those named error paths, not a coverage knob. Recalibrated 2026-06 to vitest-4 coverage-v8 (commits c0faba1e + bf254dd8): the same tests measure ~7pts lower on branches under v8, so the enforced threshold + this snapshot moved 93→86. The branches target was a no-regress pin on the old inflated current; it is reset to the named 80 floor (already met at 86) so it cannot become an unreachable hard-fail under v8 — the real statements/functions/lines→85 gaps are unchanged."
+      "rationale": "GRADUATED 2026-08-13, two days ahead of the raise-by date. Measured coverage (95.4 statements / 88.4 branches / 89.4 functions / 97.1 lines) was already well clear of the 85/80/85/85 identity floor, so the floor was raised to the commitment without new tests \u2014 the named service-layer error paths (register-with-relay 4xx/5xx, bootstrap re-entry) had been covered by work landing after the 2026-06 snapshot was taken, and nobody re-measured. `branches` is held at 86, above its target of 80: a graduation target is a floor to reach, never a level to fall back to, and lowering a live threshold to match one would violate the never-lower-thresholds policy. Retained as a closed record rather than deleted so the commitment and its outcome stay auditable."
     },
     {
       "package": "@motebit/crypto-appattest",
       "vitest_config": "packages/crypto-appattest/vitest.config.ts",
-      "current": { "statements": 84, "branches": 75, "functions": 100, "lines": 89 },
-      "target": { "statements": 85, "branches": 80, "functions": 100, "lines": 85 },
+      "current": {
+        "statements": 84,
+        "branches": 75,
+        "functions": 100,
+        "lines": 89
+      },
+      "target": {
+        "statements": 85,
+        "branches": 80,
+        "functions": 100,
+        "lines": 85
+      },
       "target_date": "2026-09-30",
-      "rationale": "Branches 75 < 80 floor (plus a statements 84→85 sliver) — the systematic cert-chain rare-error gap shared by all four platform verifiers (malformed/expired/wrong-root attestation paths exercised only by a few hand-built fixtures). Plan: a shared fuzz/property-based malformed-certificate fixture generator across the four verifiers so the rejection branches are exercised systematically. Lever: that fixture generator (one PR, four packages); raise-now would be hand-stubbed branches = the test-theater we ruled out. Recalibrated 2026-06 to vitest-4 coverage-v8 (commits c0faba1e + bf254dd8): the same tests measure statements 90→84, lines 90→89 under v8; this snapshot syncs to that, and the statements/lines no-regress pins (old inflated 90/90) reset to the shared platform-verifier floor 85/80/100/85 so they cannot become unreachable hard-fails — harmonizing all four verifiers on one floor. The real branches→80 gap is unchanged."
+      "rationale": "Branches 75 < 80 floor (plus a statements 84\u219285 sliver) \u2014 the systematic cert-chain rare-error gap shared by all four platform verifiers (malformed/expired/wrong-root attestation paths exercised only by a few hand-built fixtures). Plan: a shared fuzz/property-based malformed-certificate fixture generator across the four verifiers so the rejection branches are exercised systematically. Lever: that fixture generator (one PR, four packages); raise-now would be hand-stubbed branches = the test-theater we ruled out. Recalibrated 2026-06 to vitest-4 coverage-v8 (commits c0faba1e + bf254dd8): the same tests measure statements 90\u219284, lines 90\u219289 under v8; this snapshot syncs to that, and the statements/lines no-regress pins (old inflated 90/90) reset to the shared platform-verifier floor 85/80/100/85 so they cannot become unreachable hard-fails \u2014 harmonizing all four verifiers on one floor. The real branches\u219280 gap is unchanged."
     },
     {
       "package": "@motebit/crypto-android-keystore",
       "vitest_config": "packages/crypto-android-keystore/vitest.config.ts",
-      "current": { "statements": 85, "branches": 70, "functions": 100, "lines": 85 },
-      "target": { "statements": 85, "branches": 80, "functions": 100, "lines": 85 },
+      "current": {
+        "statements": 85,
+        "branches": 70,
+        "functions": 100,
+        "lines": 85
+      },
+      "target": {
+        "statements": 85,
+        "branches": 80,
+        "functions": 100,
+        "lines": 85
+      },
       "target_date": "2026-09-30",
-      "rationale": "Branches 70 < 80 floor — same cert-chain rare-error gap. Plan: the shared fuzz-based malformed-attestation fixture generator (see crypto-appattest entry) covers the Google RSA + ECDSA P-384 root rejection branches. Lever: that shared fixture infra."
+      "rationale": "Branches 70 < 80 floor \u2014 same cert-chain rare-error gap. Plan: the shared fuzz-based malformed-attestation fixture generator (see crypto-appattest entry) covers the Google RSA + ECDSA P-384 root rejection branches. Lever: that shared fixture infra."
     },
     {
       "package": "@motebit/crypto-tpm",
       "vitest_config": "packages/crypto-tpm/vitest.config.ts",
-      "current": { "statements": 85, "branches": 70, "functions": 100, "lines": 85 },
-      "target": { "statements": 85, "branches": 80, "functions": 100, "lines": 85 },
+      "current": {
+        "statements": 85,
+        "branches": 70,
+        "functions": 100,
+        "lines": 85
+      },
+      "target": {
+        "statements": 85,
+        "branches": 80,
+        "functions": 100,
+        "lines": 85
+      },
       "target_date": "2026-09-30",
-      "rationale": "Branches 70 < 80 floor — same cert-chain rare-error gap. Plan: the shared fuzz-based malformed-EK-chain fixture generator (see crypto-appattest entry) covers the vendor-root rejection branches. Lever: that shared fixture infra. (Real-device EK fixtures remain structurally unpublishable — EK certs identify chips — so fuzz fixtures are the only honest lever.)"
+      "rationale": "Branches 70 < 80 floor \u2014 same cert-chain rare-error gap. Plan: the shared fuzz-based malformed-EK-chain fixture generator (see crypto-appattest entry) covers the vendor-root rejection branches. Lever: that shared fixture infra. (Real-device EK fixtures remain structurally unpublishable \u2014 EK certs identify chips \u2014 so fuzz fixtures are the only honest lever.)"
     },
     {
       "package": "@motebit/crypto-webauthn",
       "vitest_config": "packages/crypto-webauthn/vitest.config.ts",
-      "current": { "statements": 85, "branches": 75, "functions": 100, "lines": 85 },
-      "target": { "statements": 85, "branches": 80, "functions": 100, "lines": 85 },
+      "current": {
+        "statements": 85,
+        "branches": 75,
+        "functions": 100,
+        "lines": 85
+      },
+      "target": {
+        "statements": 85,
+        "branches": 80,
+        "functions": 100,
+        "lines": 85
+      },
       "target_date": "2026-09-30",
-      "rationale": "Branches 75 < 80 floor — same cert-chain rare-error gap. Plan: the shared fuzz-based malformed-attestation fixture generator (see crypto-appattest entry) covers the FIDO root (Apple/Yubico/Microsoft) rejection branches. Lever: that shared fixture infra."
+      "rationale": "Branches 75 < 80 floor \u2014 same cert-chain rare-error gap. Plan: the shared fuzz-based malformed-attestation fixture generator (see crypto-appattest entry) covers the FIDO root (Apple/Yubico/Microsoft) rejection branches. Lever: that shared fixture infra."
     },
     {
       "package": "@motebit/verify",
       "vitest_config": "packages/verify/vitest.config.ts",
-      "current": { "statements": 90, "branches": 75, "functions": 100, "lines": 90 },
-      "target": { "statements": 90, "branches": 80, "functions": 100, "lines": 90 },
+      "current": {
+        "statements": 90,
+        "branches": 75,
+        "functions": 100,
+        "lines": 90
+      },
+      "target": {
+        "statements": 90,
+        "branches": 80,
+        "functions": 100,
+        "lines": 90
+      },
       "target_date": "2026-09-30",
-      "rationale": "New registry member (canonical motebit-verify aggregator; verification is the identity path). Branches 75 < 80 — inherits the bundled leaf verifiers' cert-chain gap plus its own CLI error branches. Plan: rides the shared cert-chain fuzz fixtures (see crypto-appattest entry) + a PR covering the CLI's unsupported-suite / post-quantum-pending branches. Lever: shared fixtures + named CLI error paths."
+      "rationale": "New registry member (canonical motebit-verify aggregator; verification is the identity path). Branches 75 < 80 \u2014 inherits the bundled leaf verifiers' cert-chain gap plus its own CLI error branches. Plan: rides the shared cert-chain fuzz fixtures (see crypto-appattest entry) + a PR covering the CLI's unsupported-suite / post-quantum-pending branches. Lever: shared fixtures + named CLI error paths."
     }
   ]
 }

--- a/packages/core-identity/vitest.config.ts
+++ b/packages/core-identity/vitest.config.ts
@@ -1,5 +1,15 @@
 import { defineMotebitTest } from "../../vitest.shared.js";
 
 export default defineMotebitTest({
-  thresholds: { statements: 82, branches: 86, functions: 83, lines: 82 },
+  // Graduated to the identity floor 2026-08-13, ahead of the 08-15 raise-by
+  // date (coverage-graduation.json). Measured coverage is 95.4 / 88.4 / 89.4 /
+  // 97.1, so the floor was raised to the committed 85 without writing new
+  // tests — the named error paths in the rationale were already covered by
+  // work that landed since the snapshot.
+  //
+  // `branches` stays at 86, ABOVE its target of 80: the graduation target is a
+  // floor to reach, never a level to fall back to, and lowering a live
+  // threshold to match a target would violate the never-lower-thresholds
+  // policy in vitest.shared.ts.
+  thresholds: { statements: 85, branches: 86, functions: 85, lines: 85 },
 });


### PR DESCRIPTION
## Why now

`@motebit/core-identity` carries a **hard raise-by date of 2026-08-15** in `coverage-graduation.json`. On or after that date, `scripts/coverage-graduation.ts` exits 1 if the live vitest threshold is still below the 85/80/85/85 identity floor. Nobody had picked it up — CI was two days from going red for the whole repo.

## It needed no new tests

Measured coverage today:

```
statements 95.41   branches 88.42   functions 89.36   lines 97.14
```

against a live threshold of `82/86/83/82` — a snapshot taken in June.

The lever named in the rationale (register-with-relay 4xx/5xx paths, bootstrap re-entry/partial-state) had **already been covered** by work that landed after that snapshot. Nobody re-measured, so the manifest went on tracking a gap that had closed. The deadline was real; the work behind it wasn't.

So this is a ratchet, not a coverage push. 88 tests pass with 4–10 points of margin on every axis.

## Two deliberate choices

**`branches` stays at 86, not its target of 80.** A graduation target is a floor to *reach*, never a level to fall back to — dropping a live threshold to match a target would violate the never-lower-thresholds policy in `vitest.shared.ts`. The gate is satisfied by `live >= target`, so 86 clears 80 fine.

**The manifest entry is kept, not deleted.** It now reads `gap: (targets met)` and records the outcome, so the commitment and how it resolved stay auditable rather than vanishing.

## Verification

```
$ npx tsx scripts/coverage-graduation.ts
▸ @motebit/core-identity
  gap:       (targets met)
  target:    2026-08-15 (2d remaining)
exit=0
```

Because `meetsTarget(live, target)` is now true, the hard-fail branch (`days < 0 && !meetsTarget`) can no longer fire on any future date — this doesn't just push the deadline, it retires it.

Manifest `current` was updated alongside the config, since the gate flags manifest-vs-live drift as a separate check.

All **139** drift defenses green; full pre-push gauntlet green (294 tasks).

## Note for the remaining five entries

The other five graduation commitments are all dated **2026-09-30** (48 days out) and four of them share one lever — the cert-chain fuzz-fixture generator for the attestation verifiers. Worth measuring those the same way before assuming they need work: if this entry was stale, others may be too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)