### PR TITLE
fix(relay): settlement credits only what the ledger holds — claim-order corrected

### DIFF
--- a/.changeset/settlement-funding-claim.md
+++ b/.changeset/settlement-funding-claim.md
@@ -1,0 +1,15 @@
+---
+"@motebit/relay": patch
+---
+
+Settlement credits the worker only when the ledger actually holds the funds.
+
+The funding claim asked whether the allocation ROW was still `'locked'`, never
+whether anything had been debited for it. A priced listing with no
+`pay_to_address` books an allocation with no hold, so a self-delegated task
+against one credited a worker from nothing. The claim is now ledger-derived —
+and, critically, the ledger is read BEFORE the status UPDATE, so an unfunded
+allocation is left `'locked'` rather than marked `'settled'` with no settlement
+row (which would break reconciliation invariant 3). Earmarked x402 funds are
+also excluded from the escrow-hold net at submission, so a delegator who has
+already paid onchain can still take a real hold.

--- a/services/relay/src/__tests__/unfunded-allocation-mint.test.ts
+++ b/services/relay/src/__tests__/unfunded-allocation-mint.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Money-conservation regression: an UNFUNDED allocation row must never credit
+ * a worker at settlement.
+ *
+ * The relay-custody lane holds delegator funds before work and credits the
+ * worker after. Two independent listing reads decide the two halves of that
+ * contract, and they disagree on what "priced" means:
+ *
+ *  - `getListingUnitCost` (drives `price_snapshot`, and therefore the
+ *    allocation's `amount_locked`) reads ONLY the `pricing` column.
+ *  - `getAgentPricing` (drives `requiresPayment`, and therefore the
+ *    insufficient-funds 402) returns `null` when `pay_to_address` is absent.
+ *
+ * `pay_to_address` is optional and self-served on `POST /listing`. A listing
+ * with `pricing > 0` and no `pay_to_address` therefore lands in the gap: it is
+ * priced enough to mint a `price_snapshot`, but not priced enough to demand
+ * payment. With no delegator balance, `allocateBudget` returns null, control
+ * falls to the free-agent/best-effort `else` branch, and an allocation row is
+ * inserted `status='locked'` with `amount_locked = price_snapshot` and NO
+ * debit against any account.
+ *
+ * At settlement, `allocationClaimed` asks only whether that row is still
+ * `'locked'` — never whether the ledger actually holds anything for it — so
+ * `settlementFunded` is true and the worker is credited from nothing. The
+ * refund and partial branches were already hardened against exactly this
+ * ("releasing `amount_locked` there would mint unfunded balance"); the
+ * worker-credit branch was not.
+ *
+ * `reconcileLedger` cannot catch the mint: the credit IS written to
+ * `relay_transactions`, so the balance equation stays self-consistent. Only a
+ * hold-vs-credit test sees it.
+ *
+ * Severing check (discriminating power): restore `settlementFunded` to
+ * `grossAmount === 0 || allocationClaimed` and the accept-half below flips red
+ * — the worker's balance goes from 0 to the settled amount with no
+ * corresponding debit anywhere in the ledger.
+ *
+ * Rung: composition-root in-process. The relay-custody lane is not
+ * HTTP-fundable (the self-declared /deposit route was removed as a
+ * treasury-drain vector), which is why `booted-settlement-activation.test.ts`
+ * records this lane's severing as the honest in-process remainder.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { vi } from "vitest";
+// eslint-disable-next-line no-restricted-imports -- tests need direct crypto
+import { generateKeypair, bytesToHex, signExecutionReceipt } from "@motebit/encryption";
+import type { MotebitId, DeviceId } from "@motebit/sdk";
+import type { SyncRelay } from "../index.js";
+import {
+  AUTH_HEADER,
+  JSON_AUTH,
+  createTestRelay,
+  createAgent,
+  jsonAuthWithIdempotency,
+  seedBalance,
+} from "./test-helpers.js";
+import { getAccountBalance } from "../accounts.js";
+
+let relay: SyncRelay | undefined;
+
+afterEach(async () => {
+  await relay?.close();
+  relay = undefined;
+});
+
+/** Total of every ledger row for an account, by type — the funding truth. */
+function ledgerByType(r: SyncRelay, motebitId: string): Record<string, number> {
+  const rows = r.moteDb.db
+    .prepare(
+      "SELECT type, SUM(amount) as total FROM relay_transactions WHERE motebit_id = ? GROUP BY type",
+    )
+    .all(motebitId) as Array<{ type: string; total: number }>;
+  return Object.fromEntries(rows.map((row) => [row.type, row.total]));
+}
+
+async function priceListing(
+  r: SyncRelay,
+  motebitId: string,
+  opts: { unitCost: number; payTo?: string },
+): Promise<void> {
+  await r.app.request(`/api/v1/agents/${motebitId}/listing`, {
+    method: "POST",
+    headers: JSON_AUTH,
+    body: JSON.stringify({
+      capabilities: ["web_search"],
+      pricing: [
+        { capability: "web_search", unit_cost: opts.unitCost, currency: "USD", per: "task" },
+      ],
+      ...(opts.payTo != null ? { pay_to_address: opts.payTo } : {}),
+    }),
+  });
+}
+
+/**
+ * Drive one relay-custody delegation to settlement: worker registers, is
+ * priced, connects, receives a self-delegated task, returns a signed receipt.
+ * Self-delegation is an explicit Arc-3.5 submission carve-out
+ * (`requiresP2pProof` needs `submittedBy !== workerId`), so this reaches the
+ * relay-custody settlement path without a P2P proof.
+ */
+async function settleSelfDelegatedTask(
+  r: SyncRelay,
+  args: { unitCost: number; payTo?: string; fundDelegator?: number },
+): Promise<{ motebitId: string; taskId: string }> {
+  const keypair = await generateKeypair();
+  const pubHex = bytesToHex(keypair.publicKey);
+  const { motebitId, deviceId } = await createAgent(r, pubHex);
+
+  await priceListing(r, motebitId, { unitCost: args.unitCost, payTo: args.payTo });
+
+  const ws = { send: vi.fn(), close: vi.fn(), readyState: 1 };
+  r.connections.set(motebitId, [{ ws: ws as never, deviceId, capabilities: ["web_search"] }]);
+
+  if (args.fundDelegator != null) seedBalance(r, motebitId, args.fundDelegator);
+
+  const submitRes = await r.app.request(`/agent/${motebitId}/task`, {
+    method: "POST",
+    headers: jsonAuthWithIdempotency(),
+    body: JSON.stringify({ prompt: "search", required_capabilities: ["web_search"] }),
+  });
+  expect(submitRes.status).toBe(201);
+  const { task_id } = (await submitRes.json()) as { task_id: string };
+
+  const receipt = await signExecutionReceipt(
+    {
+      task_id,
+      relay_task_id: task_id,
+      motebit_id: motebitId as unknown as MotebitId,
+      device_id: deviceId as unknown as DeviceId,
+      submitted_at: Date.now(),
+      completed_at: Date.now(),
+      status: "completed" as const,
+      result: "found it",
+      tools_used: ["web_search"],
+      memories_formed: 0,
+      prompt_hash: "abc",
+      result_hash: "def",
+    },
+    keypair.privateKey,
+  );
+
+  const resultRes = await r.app.request(`/agent/${motebitId}/task/${task_id}/result`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...AUTH_HEADER },
+    body: JSON.stringify(receipt),
+  });
+  expect(resultRes.status).toBe(200);
+
+  return { motebitId, taskId: task_id };
+}
+
+describe("unfunded allocation must not mint balance at settlement", () => {
+  it("credits nothing when a priced listing has no pay_to_address and no funds were held", async () => {
+    relay = await createTestRelay();
+
+    // Priced at $1.00, no pay_to_address, delegator never funded.
+    const { motebitId } = await settleSelfDelegatedTask(relay, { unitCost: 1.0 });
+
+    const ledger = ledgerByType(relay, motebitId);
+
+    // The premise: this really is the unfunded path — no hold was ever taken.
+    expect(ledger["allocation_hold"] ?? 0).toBe(0);
+
+    // The invariant: no hold ⇒ no settlement credit. A credit here is minted
+    // from nothing — the relay would owe a balance it never received.
+    expect(ledger["settlement_credit"] ?? 0).toBe(0);
+
+    const balance = getAccountBalance(relay.moteDb.db, motebitId)?.balance ?? 0;
+    expect(balance).toBe(0);
+  });
+
+  it("still credits normally when the allocation WAS funded (no regression)", async () => {
+    relay = await createTestRelay();
+
+    // Same shape, but the delegator holds real balance, so `allocateBudget`
+    // succeeds and a genuine `allocation_hold` debit backs the settlement.
+    const { motebitId } = await settleSelfDelegatedTask(relay, {
+      unitCost: 1.0,
+      fundDelegator: 5.0,
+    });
+
+    const ledger = ledgerByType(relay, motebitId);
+
+    expect(ledger["allocation_hold"] ?? 0).toBeLessThan(0); // debit taken
+    expect(ledger["settlement_credit"] ?? 0).toBeGreaterThan(0); // worker paid
+
+    // Conservation: the worker's credit never exceeds what was actually held.
+    const held = Math.abs(ledger["allocation_hold"] ?? 0);
+    const credited = ledger["settlement_credit"] ?? 0;
+    expect(credited).toBeLessThanOrEqual(held);
+  });
+
+  it("leaves the allocation LOCKED, never 'settled' without a settlement row", async () => {
+    relay = await createTestRelay();
+    const { taskId } = await settleSelfDelegatedTask(relay, { unitCost: 1.0 });
+
+    // Reconciliation invariant 3: a 'settled' allocation must have a matching
+    // settlement record. `allocationClaimed` EXECUTES the status UPDATE, so an
+    // earlier attempt at this fix — claim first, check the ledger second, skip
+    // the INSERT when unfunded — left the row 'settled' with no settlement row
+    // and put `reconcileLedger` into permanent error. Claiming only when funded
+    // is what keeps the claim and the INSERT atomic.
+    const alloc = relay.moteDb.db
+      .prepare("SELECT status FROM relay_allocations WHERE task_id = ?")
+      .get(taskId) as { status: string } | undefined;
+    expect(alloc?.status).toBe("locked");
+
+    const settlements = relay.moteDb.db
+      .prepare("SELECT COUNT(*) as n FROM relay_settlements WHERE task_id = ?")
+      .get(taskId) as { n: number };
+    expect(settlements.n).toBe(0);
+
+    // The ledger reconciler must be clean — this is the assertion the earlier
+    // attempt would have failed.
+    const orphans = relay.moteDb.db
+      .prepare(
+        `SELECT COUNT(*) as n FROM relay_allocations a
+         LEFT JOIN relay_settlements s ON s.allocation_id = a.allocation_id
+         WHERE a.status = 'settled' AND s.settlement_id IS NULL`,
+      )
+      .get() as { n: number };
+    expect(orphans.n).toBe(0);
+  });
+
+  // NOT TESTED HERE, deliberately and with the reason stated: the x402 branch
+  // of the spendable-balance computation (earmarked funds excluded from the
+  // escrow net). `x402TxHash` is set only by the facilitator's real
+  // `onAfterSettle` hook — a module closure, not a spyable relay method — so
+  // the submission path that reads it is not integration-drivable, the same
+  // unreachability `requiresP2pProof` already documents for its x402 carve-out.
+  // Writing a test that re-derives the arithmetic on local variables would
+  // assert nothing about the deployed code; an honest gap beats a modeled one.
+});

--- a/services/relay/src/tasks.ts
+++ b/services/relay/src/tasks.ts
@@ -1359,30 +1359,50 @@ export async function handleReceiptIngestion(
         // keeps reconciliation invariant 3 (allocation 'settled' ⇔ settlement
         // record exists) true: the claim and the INSERT below commit together
         // or not at all.
+        // What the delegator actually has at stake: allocation_hold debits
+        // minus allocation_release credits for this allocation, from the
+        // transaction ledger. NEVER `amount_locked` — allocation rows also
+        // exist for never-debited paths (free-agent best-effort holds), and
+        // crediting against one mints balance the relay never received.
+        //
+        // READ BEFORE CLAIMING, and this ordering is load-bearing.
+        // `allocationClaimed` is not a predicate — it EXECUTES the UPDATE. An
+        // earlier attempt at this fix claimed first, consulted the ledger
+        // second, then skipped the settlement INSERT when unfunded, which left
+        // an allocation permanently `'settled'` with no settlement row: a hard
+        // error in `reconcileLedger` invariant 3 (settled allocation ⇔
+        // settlement record). Deriving funding first and claiming only when
+        // funded keeps the claim and the INSERT atomic, exactly as the previous
+        // comment here promised.
+        const heldOnLedger = getAllocationHoldRemaining(moteDb.db, allocationId);
+        const settlementApplies = !isP2pTask && signedSettlement != null;
+        const fundedOnLedger = grossAmount === 0 || heldOnLedger > 0;
+
+        // Claim only what we intend to settle. An unfunded row stays `'locked'`
+        // and is retired later by the stale-allocation sweep, which (since the
+        // ledger-derived release) correctly pays out nothing for it.
         const allocationClaimed =
-          !isP2pTask &&
-          signedSettlement != null &&
+          settlementApplies &&
+          fundedOnLedger &&
           moteDb.db
             .prepare(
               "UPDATE relay_allocations SET status = 'settled', settled_at = ? WHERE task_id = ? AND status = 'locked'",
             )
             .run(Date.now(), taskId).changes > 0;
-        // What the delegator actually has at stake: allocation_hold debits
-        // minus allocation_release credits for this allocation, from the
-        // transaction ledger. NEVER `amount_locked` — allocation rows also
-        // exist for never-debited paths (free-agent best-effort holds), and
-        // releasing `amount_locked` there would mint unfunded balance.
-        const heldRemaining = allocationClaimed
-          ? getAllocationHoldRemaining(moteDb.db, allocationId)
-          : 0;
-        const settlementFunded = grossAmount === 0 || allocationClaimed;
-        if (!isP2pTask && signedSettlement != null && !settlementFunded) {
+
+        const heldRemaining = allocationClaimed ? heldOnLedger : 0;
+        const settlementFunded = grossAmount === 0 || (allocationClaimed && heldRemaining > 0);
+        if (settlementApplies && !settlementFunded) {
           logger.error("settlement.unfunded_skipped", {
             correlationId: taskId,
             settlementId: settlement.settlement_id,
             gross: settlement.amount_settled + settlement.platform_fee,
+            heldOnLedger,
+            allocationClaimed,
             reason:
-              "allocation no longer locked — funds already released to the delegator; settlement skipped to prevent double-credit",
+              heldOnLedger > 0
+                ? "allocation no longer locked — funds already released to the delegator; settlement skipped to prevent double-credit"
+                : "allocation holds nothing on the ledger — never debited (best-effort path, or a priced listing with no payout address), so crediting the worker would mint balance the relay never received",
           });
         }
         // Relay settlement: INSERT record + credit/refund virtual accounts.
@@ -2462,7 +2482,20 @@ export async function registerTaskRoutes(deps: TasksDeps): Promise<void> {
         const account = getAccountBalance(moteDb.db, delegatorId);
         const rawBalance = account?.balance ?? 0;
         const escrowHold = computeDisputeWindowHold(moteDb.db, delegatorId);
-        const virtualBalance = Math.max(0, rawBalance - escrowHold);
+        // The escrow hold exists to stop a delegator spending its own recent
+        // EARNINGS while those are still disputable. An x402 payment is not
+        // that: it arrived seconds ago, from outside, earmarked for THIS task,
+        // and was deposit-credited just above. Netting the escrow hold against
+        // it would refuse a task the delegator has already paid for onchain.
+        //
+        // That refusal used to fail quietly in the worst way: `allocateBudget`
+        // returned null, control fell to the best-effort branch, and the task
+        // booked an allocation with NO hold behind it — so the relay took the
+        // money, the worker did the work, and the settlement path had nothing
+        // to pay from. Once settlement became ledger-derived that turns into a
+        // worker who is simply never paid. Excluding earmarked x402 funds from
+        // the escrow net keeps the hold real and the invariant honest.
+        const virtualBalance = x402TxHash ? rawBalance : Math.max(0, rawBalance - escrowHold);
 
         // Use allocateBudget to compute lock amount with risk buffer
         const allocation = allocateBudget(


### PR DESCRIPTION
The **last live leg** of the unfunded-mint family. The two payout-side legs shipped in #553; this is the settlement-credit side, and it is still reachable on `main` today.

## The bug

```ts
const settlementFunded = grossAmount === 0 || allocationClaimed;
```

`allocationClaimed` asks only whether the allocation **row** is still `'locked'` — never whether the ledger holds anything for it. A listing priced above zero with no `pay_to_address` books an allocation with no debit behind it, so a self-delegated task against one credits a worker from nothing.

**Production currently carries six such listings.**

## Why my first attempt was wrong

`allocationClaimed` is not a predicate — it **executes** the status UPDATE. The earlier version claimed first, consulted the ledger second, then skipped the settlement INSERT when unfunded. That left an allocation permanently `'settled'` with no settlement row: a hard error in `reconcileLedger` invariant 3.

The comment directly above that code already promised the claim and the INSERT "commit together or not at all." The fix had quietly broken its own stated invariant, which is why the hostile review killed it.

Now the ledger is read **before** anything mutates, and the claim fires only when funded. An unfunded allocation stays `'locked'` and is retired later by the stale-allocation sweep — which, since #553, correctly pays out nothing for it.

## The x402 false negative, closed at its real cause

The review raised this and it needed a real answer, not a guard.

An x402 payment is deposit-credited to the delegator **before** the hold is taken. Netting the dispute-window escrow hold against that earmarked money can zero the spendable balance, so `allocateBudget` returns null and the task books an allocation with no hold — the relay took the money and the settlement path has nothing to pay from. Under a ledger-derived rule that turns an over-credit bug into a **worker who is never paid**.

The escrow hold exists to stop a delegator spending its own recent *disputable earnings*. Funds that arrived seconds ago from outside, earmarked for this task, are not that. They're now excluded from the net, so the hold is real and the invariant stays honest.

## Severings — both directions

| severing | mint test | invariant test |
|---|---|---|
| restore the original rule | **red** | **red** |
| break ONLY the claim-ordering | green | **red** |

The second row is the one that matters: the new coverage specifically catches the reconciliation bug my earlier attempt introduced, not merely the mint.

## An honest gap, stated rather than papered over

The x402 branch is **not** covered by a test. `x402TxHash` is set only by the facilitator's real `onAfterSettle` hook — a module closure, not a spyable relay method — so the submission path that reads it isn't integration-drivable. This is the same unreachability `requiresP2pProof` already documents for its own x402 carve-out.

I wrote a test for it, realised it only re-derived the arithmetic on local variables, and deleted it. That's the modeled-composition pattern I flagged as worthless in #553, and shipping one here would have been hypocritical. The gap is recorded in the suite with its reason.

## Verification

- Relay suite **1539 green** (137 files)
- **139** drift defenses green; typecheck clean

## Closes the family

| leg | amount | requires | status |
|---|---|---|---|
| stale-allocation release | full gross | nothing | ✅ #553 |
| retry-exhaustion refund | full gross | nothing | ✅ #553 |
| settlement credit | worker net | a signed receipt | **this PR** |

Sibling #552 (priced-but-unpayable listings can no longer be *created*) remains open pending the economics call — but it is no longer load-bearing for this vulnerability, since the payout side now refuses regardless of what the listing claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)