### PR TITLE
chore(attestation-verifiers): graduate four coverage commitments, 48 days early

### DIFF
--- a/coverage-graduation.json
+++ b/coverage-graduation.json
@@ -25,8 +25,8 @@
       "package": "@motebit/crypto-appattest",
       "vitest_config": "packages/crypto-appattest/vitest.config.ts",
       "current": {
-        "statements": 84,
-        "branches": 75,
+        "statements": 85,
+        "branches": 80,
         "functions": 100,
         "lines": 89
       },
@@ -37,14 +37,14 @@
         "lines": 85
       },
       "target_date": "2026-09-30",
-      "rationale": "Branches 75 < 80 floor (plus a statements 84\u219285 sliver) \u2014 the systematic cert-chain rare-error gap shared by all four platform verifiers (malformed/expired/wrong-root attestation paths exercised only by a few hand-built fixtures). Plan: a shared fuzz/property-based malformed-certificate fixture generator across the four verifiers so the rejection branches are exercised systematically. Lever: that fixture generator (one PR, four packages); raise-now would be hand-stubbed branches = the test-theater we ruled out. Recalibrated 2026-06 to vitest-4 coverage-v8 (commits c0faba1e + bf254dd8): the same tests measure statements 90\u219284, lines 90\u219289 under v8; this snapshot syncs to that, and the statements/lines no-regress pins (old inflated 90/90) reset to the shared platform-verifier floor 85/80/100/85 so they cannot become unreachable hard-fails \u2014 harmonizing all four verifiers on one floor. The real branches\u219280 gap is unchanged."
+      "rationale": "GRADUATED 2026-08-13, 48 days ahead of the raise-by date. Measured coverage (87.3/81.8/100/93.3 statements/branches/functions/lines) already cleared the 80-branch identity floor, so the threshold was raised to the commitment without new tests. The cert-chain fuzz-fixture generator named as the lever was never built \u2014 the branches were covered incidentally by work landing after the 2026-06 snapshot, and nobody re-measured. Existing live values ABOVE target are held, never lowered to match one. Retained as a closed record so the commitment and its outcome stay auditable."
     },
     {
       "package": "@motebit/crypto-android-keystore",
       "vitest_config": "packages/crypto-android-keystore/vitest.config.ts",
       "current": {
         "statements": 85,
-        "branches": 70,
+        "branches": 80,
         "functions": 100,
         "lines": 85
       },
@@ -55,14 +55,14 @@
         "lines": 85
       },
       "target_date": "2026-09-30",
-      "rationale": "Branches 70 < 80 floor \u2014 same cert-chain rare-error gap. Plan: the shared fuzz-based malformed-attestation fixture generator (see crypto-appattest entry) covers the Google RSA + ECDSA P-384 root rejection branches. Lever: that shared fixture infra."
+      "rationale": "GRADUATED 2026-08-13, 48 days ahead of the raise-by date. Measured coverage (88.8/80.9/100/91.0 statements/branches/functions/lines) already cleared the 80-branch identity floor, so the threshold was raised to the commitment without new tests. The cert-chain fuzz-fixture generator named as the lever was never built \u2014 the branches were covered incidentally by work landing after the 2026-06 snapshot, and nobody re-measured. Existing live values ABOVE target are held, never lowered to match one. Retained as a closed record so the commitment and its outcome stay auditable."
     },
     {
       "package": "@motebit/crypto-tpm",
       "vitest_config": "packages/crypto-tpm/vitest.config.ts",
       "current": {
         "statements": 85,
-        "branches": 70,
+        "branches": 80,
         "functions": 100,
         "lines": 85
       },
@@ -73,14 +73,14 @@
         "lines": 85
       },
       "target_date": "2026-09-30",
-      "rationale": "Branches 70 < 80 floor \u2014 same cert-chain rare-error gap. Plan: the shared fuzz-based malformed-EK-chain fixture generator (see crypto-appattest entry) covers the vendor-root rejection branches. Lever: that shared fixture infra. (Real-device EK fixtures remain structurally unpublishable \u2014 EK certs identify chips \u2014 so fuzz fixtures are the only honest lever.)"
+      "rationale": "GRADUATED 2026-08-13, 48 days ahead of the raise-by date. Measured coverage (93.5/85.8/100/96.7 statements/branches/functions/lines) already cleared the 80-branch identity floor, so the threshold was raised to the commitment without new tests. The cert-chain fuzz-fixture generator named as the lever was never built \u2014 the branches were covered incidentally by work landing after the 2026-06 snapshot, and nobody re-measured. Existing live values ABOVE target are held, never lowered to match one. Retained as a closed record so the commitment and its outcome stay auditable."
     },
     {
       "package": "@motebit/crypto-webauthn",
       "vitest_config": "packages/crypto-webauthn/vitest.config.ts",
       "current": {
         "statements": 85,
-        "branches": 75,
+        "branches": 80,
         "functions": 100,
         "lines": 85
       },
@@ -91,7 +91,7 @@
         "lines": 85
       },
       "target_date": "2026-09-30",
-      "rationale": "Branches 75 < 80 floor \u2014 same cert-chain rare-error gap. Plan: the shared fuzz-based malformed-attestation fixture generator (see crypto-appattest entry) covers the FIDO root (Apple/Yubico/Microsoft) rejection branches. Lever: that shared fixture infra."
+      "rationale": "GRADUATED 2026-08-13, 48 days ahead of the raise-by date. Measured coverage (89.0/82.1/100/94.2 statements/branches/functions/lines) already cleared the 80-branch identity floor, so the threshold was raised to the commitment without new tests. The cert-chain fuzz-fixture generator named as the lever was never built \u2014 the branches were covered incidentally by work landing after the 2026-06 snapshot, and nobody re-measured. Existing live values ABOVE target are held, never lowered to match one. Retained as a closed record so the commitment and its outcome stay auditable."
     },
     {
       "package": "@motebit/verify",

--- a/packages/crypto-android-keystore/vitest.config.ts
+++ b/packages/crypto-android-keystore/vitest.config.ts
@@ -1,5 +1,5 @@
 import { defineMotebitTest } from "../../vitest.shared.js";
 
 export default defineMotebitTest({
-  thresholds: { statements: 85, branches: 70, functions: 100, lines: 85 },
+  thresholds: { statements: 85, branches: 80, functions: 100, lines: 85 },
 });

--- a/packages/crypto-appattest/vitest.config.ts
+++ b/packages/crypto-appattest/vitest.config.ts
@@ -1,5 +1,5 @@
 import { defineMotebitTest } from "../../vitest.shared.js";
 
 export default defineMotebitTest({
-  thresholds: { statements: 84, branches: 75, functions: 100, lines: 89 },
+  thresholds: { statements: 85, branches: 80, functions: 100, lines: 89 },
 });

--- a/packages/crypto-tpm/vitest.config.ts
+++ b/packages/crypto-tpm/vitest.config.ts
@@ -1,5 +1,5 @@
 import { defineMotebitTest } from "../../vitest.shared.js";
 
 export default defineMotebitTest({
-  thresholds: { statements: 85, branches: 70, functions: 100, lines: 85 },
+  thresholds: { statements: 85, branches: 80, functions: 100, lines: 85 },
 });

--- a/packages/crypto-webauthn/vitest.config.ts
+++ b/packages/crypto-webauthn/vitest.config.ts
@@ -1,5 +1,5 @@
 import { defineMotebitTest } from "../../vitest.shared.js";
 
 export default defineMotebitTest({
-  thresholds: { statements: 85, branches: 75, functions: 100, lines: 85 },
+  thresholds: { statements: 85, branches: 80, functions: 100, lines: 85 },
 });


### PR DESCRIPTION
Prompted by #563 — core-identity's raise-by commitment turned out to be tracking a gap that had already closed. So I measured the other five. **Four were stale the same way.**

| package | target (branches) | measured | margin |
|---|---|---|---|
| `crypto-tpm` | 80 | **85.8** | 5.8 |
| `crypto-webauthn` | 80 | **82.1** | 2.1 |
| `crypto-appattest` | 80 | **81.8** | 1.8 |
| `crypto-android-keystore` | 80 | **80.9** | 0.9 |

All four also clear their statements/lines targets. The cert-chain fuzz-fixture generator named as the lever for every one of them **was never built** — the branches got covered incidentally by work landing after the 2026-06 snapshot, and nobody re-measured.

So this is a ratchet, not a coverage push: thresholds raised to the commitments, manifest snapshots updated to match live (the gate flags manifest-vs-live drift as a separate check).

## Deliberate choices

**Live values above target are held, never lowered.** `crypto-appattest` keeps `lines` at 89 rather than dropping to its target of 85. A graduation target is a floor to *reach*, not a level to fall back to.

**The 0.9 margin on `crypto-android-keystore` is accepted, not overlooked.** coverage-v8 is deterministic for unchanged code, so a thin margin isn't a flake risk — it means the next uncovered branch added there reds the gate. That is what a floor is for.

## `@motebit/verify` is NOT graduated — and shouldn't be

It's the one remaining entry with a gap, and raising its threshold would be actively wrong: **its coverage currently measures zero files.**

```
File         | % Stmts | % Branch | % Funcs | % Lines |
-------------|---------|----------|---------|---------|
-------------|---------|----------|---------|---------|
```

The package has three sources. `src/cli.ts` and `src/index.ts` are both in `coverageExclude`, and `src/adapters.ts` — which *does* have a test importing it — never appears in the report. So the `90/75/100/90` thresholds are enforced against nothing and pass vacuously.

This also explains the contradiction flagged in #546: verify's graduation plan names CLI branches that its own config excludes. Raising a vacuous threshold would have "closed" the commitment while measuring exactly as much as before — zero. Filing separately.

## Verification

- All four packages pass with the raised thresholds (0 threshold errors)
- `coverage-graduation` now reports **5 of 6 "(targets met)"**, exit 0
- **152 of 152** gates proven effective — including the graduation probe, which I re-pointed in #565 at the still-gapped cohort precisely so it wouldn't go vacuous as packages graduate. `verify` keeps it honest for now; when that one is fixed the probe will need another look.
- **139** drift defenses green

🤖 Generated with [Claude Code](https://claude.com/claude-code)